### PR TITLE
docs(cockpit): adicionar skills solaris-orquestracao e solaris-contexto na biblioteca

### DIFF
--- a/docs/painel-po/index.html
+++ b/docs/painel-po/index.html
@@ -471,6 +471,23 @@
             <span class="doc-updated" contenteditable="plaintext-only" data-key="doc-matriz-rastr">Atualizado: 2026-03-26</span>
           </div>
         </div>
+        <div class="docs-category-title" style="margin-top:12px">🤖 Skills dos agentes</div>
+        <div class="doc-item">
+          <div class="doc-icon">🤖</div>
+          <div>
+            <a class="doc-name" href="https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/.manus/skills/solaris-orquestracao/SKILL.md" target="_blank">SKILL — solaris-orquestracao (Manus)</a>
+            <div class="doc-when">Skill operacional do Manus — checklist, commits, bloqueios, pós-sprint</div>
+            <span class="doc-updated" contenteditable="plaintext-only" data-key="doc-skill-manus">Atualizado: 2026-03-26</span>
+          </div>
+        </div>
+        <div class="doc-item">
+          <div class="doc-icon">🧠</div>
+          <div>
+            <a class="doc-name" href="https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/.claude/skills/solaris-contexto/SKILL.md" target="_blank">SKILL — solaris-contexto (Claude)</a>
+            <div class="doc-when">Skill de contexto do Orquestrador — Gate 0, estado do produto, governança</div>
+            <span class="doc-updated" contenteditable="plaintext-only" data-key="doc-skill-claude">Atualizado: 2026-03-26</span>
+          </div>
+        </div>
       </div>
 
     </div>


### PR DESCRIPTION
## Objetivo
Adicionar links para as skills solaris-orquestracao (Manus) e solaris-contexto
(Claude) na biblioteca do Cockpit P.O. Fechamento de documentação pós-PR #113.

## Tipo de mudança
- [x] Governança / Docs

## Componentes afetados
- [x] Apenas documentação

## Classificação de risco
- [x] Baixo — sem impacto em dados ou fluxo principal

## Declaração de escopo
- [x] NÃO altera comportamento visível ao usuário final
- [x] NÃO toca no adaptador getDiagnosticSource()
- [x] NÃO impacta o domínio RAG
- [x] NÃO ativa DIAGNOSTIC_READ_MODE=new
- [x] NÃO executa DROP COLUMN em colunas legadas

## Validação executada
- [x] Links verificados no browser
- [x] Nenhum teste automatizado necessário
```json
{
  "data_integrity": true,
  "regression": false,
  "rag_impact": false,
  "unexpected_behavior": false,
  "tests_passed": true,
  "typescript_errors": 0,
  "risk_level": "low"
}
```

## Classificação da task
- [x] Nível 1 — Seguro (autônomo)