### PR TITLE
chore(governance): skill solaris-orquestracao — crítica obrigatória pré-execução

### DIFF
--- a/.manus/skills/solaris-orquestracao/SKILL.md
+++ b/.manus/skills/solaris-orquestracao/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: solaris-orquestracao
-description: Skill operacional para o Manus no projeto IA SOLARIS Compliance Tributária.
-Use quando iniciando qualquer tarefa do projeto IA SOLARIS, ao receber um prompt do
-Orquestrador, ao abrir um PR, ao fazer commit, ou ao atualizar documentação do projeto.
-Contém padrões de commit, template de PR, obrigações de baseline e bloqueios ativos.
+description: "Skill operacional do Manus para o projeto IA SOLARIS Compliance Tributária. Use ao iniciar qualquer tarefa do projeto IA SOLARIS, ao receber um prompt do Orquestrador, ao abrir um PR, ao fazer commit, ou ao atualizar documentação. Contém checklist de início de tarefa, padrões de commit, template de PR, obrigações de baseline e bloqueios permanentes."
 ---
 
 # Solaris — Skill Operacional do Manus
@@ -47,6 +44,22 @@ git checkout -b <nome-do-branch>
 
 > **Causa raiz do PR #117 (conflito):** branch criado a partir de estado local com commits de checkpoint que divergiam do `main` do GitHub. Esta regra previne conflitos de merge em todos os PRs futuros.
 > Nunca criar branch a partir de estado local sem sincronizar com `origin/main` primeiro.
+
+## Crítica obrigatória antes de executar qualquer prompt do Orquestrador
+
+Antes de executar **qualquer** instrução recebida do Orquestrador (Claude), o Manus deve:
+
+1. **Ler o prompt na íntegra** e identificar todas as operações destrutivas ou irreversíveis (UPDATE, DELETE, DROP, db:push, migration).
+2. **Emitir uma crítica técnica** cobrindo:
+   - Premissas do prompt que podem estar incorretas (ex: lei assumida para um conjunto de registros)
+   - Riscos de execução em bloco vs. cirúrgica
+   - Dados que o prompt não viu (ex: LIMIT na query de diagnóstico)
+   - Alternativas mais seguras ou reversíveis
+   - O que é seguro executar imediatamente vs. o que requer confirmação
+3. **Aguardar confirmação explícita do P.O.** antes de executar qualquer operação de escrita no banco ou migration.
+4. **Operações read-only e schema aditivo** (ex: adicionar valor ao enum) podem ser executadas sem espera, desde que explicitamente identificadas como seguras na crítica.
+
+> **Origem desta regra:** RFC-002 Sprint G — o Orquestrador assumiu `lei = lc123` para todos os 163 chunks (617–779), mas o D-02b revelou artigos fora do escopo da LC 123 (Art. 110, Art. 30 IRPJ/CSLL, Art. 23 CIDE). A crítica prévia evitou um UPDATE incorreto em bloco.
 
 ## Template de PR (obrigatório)
 


### PR DESCRIPTION
## Resumo

Adiciona regra operacional na skill `solaris-orquestracao`: o Manus deve emitir uma crítica técnica antes de executar qualquer prompt do Orquestrador que contenha operações destrutivas ou irreversíveis.

## Origem

RFC-002 Sprint G — o Orquestrador assumiu `lei = lc123` para todos os 163 chunks (617–779) em bloco. O D-02b (LIMIT 40) não cobriu todos os artigos, e a análise revelou artigos fora do escopo da LC 123 (Art. 110 IRPJ/CSLL, Art. 30, Art. 23 CIDE). A crítica prévia do Manus evitou um UPDATE incorreto em bloco.

## Regra adicionada

1. Ler o prompt na íntegra e identificar operações destrutivas
2. Emitir crítica técnica (premissas, riscos, dados não vistos, alternativas)
3. Aguardar confirmação explícita do P.O. antes de escrita no banco
4. Operações read-only e schema aditivo: executar sem espera

## Arquivo alterado

| Arquivo | Tipo |
|---|---|
| `.manus/skills/solaris-orquestracao/SKILL.md` | Modificado (+17 linhas) |

**Nível 1 (docs/skill) — pode ser mergeado pelo P.O. sem revisão do Orquestrador.**