### PR TITLE
docs: BASELINE-PRODUTO v1.9 — DT-01 concluído

### DIFF
--- a/docs/BASELINE-PRODUTO.md
+++ b/docs/BASELINE-PRODUTO.md
@@ -25,7 +25,7 @@ Este é o **único baseline do produto**. Não existe versão em `.docx` — o G
 | Indicador | Valor atual | Status |
 |---|---|---|
 | TypeScript | 0 erros (`npx tsc --noEmit`) | ✅ |
-| Testes automatizados — total | **489 testes passando** | ✅ |
+| Testes automatizados — total | **492 testes passando** | ✅ |
 | Cobertura de suítes | PCT v1 (117) · PCT v2 (81) · E2E Fase 2 (132) · BUG-001 (33) · INV-606/607/608 (47) · Sprint B (9) · Sprint C (15) · Sprint D (55) · Sprint E (20) | ✅ |
 | Git working tree | Limpo — sem arquivos pendentes | ✅ |
 | Servidor de desenvolvimento | Rodando na porta 3000 | ✅ |
@@ -39,6 +39,7 @@ Este é o **único baseline do produto**. Não existe versão em `.docx` — o G
 | RAG Cockpit | Endpoint `ragInventory.getSnapshot` ao vivo · 9 gold set queries (GS-01..GS-08 + GS-07b) · confidence calculado sobre 8 queries canônicas | ✅ |
 | Sprint 98% Confidence | **B0 ✅ · B1 ✅ · B2 ✅** — Sprint 98% CONCLUÍDA | ✅ |
 | Agent Skills | Manus `/solaris-orquestracao` ✅ · Claude `solaris-contexto` ✅ | ✅ |
+| db:push guard | Bloqueado em production — `scripts/db-push-guard.mjs` | ✅ |
 
 ---
 
@@ -242,6 +243,7 @@ Os erros abaixo estão catalogados em [`docs/ERROS-CONHECIDOS.md`](https://githu
 | **Sprint G (Corpus)** | RFC-001 (fusão id 810+811 lc227) · RFC-002 (25 chunks lc214→lc123) · 5 leis ativas · gold set 8/8 · confiabilidade 100% | ✅ Concluída | PR #129 — `f71bf85` |
 | **Sprint H · M1 (RAG)** | `ragInventory.getSnapshot` tRPC endpoint · 9 gold set queries · GS-07 threshold `< 10 bytes` · GS-07b SUPERSEDED informativo · `lc123` ao enum `lei` | ✅ Concluída | PR #131 — `49520a0` |
 | **Sprint H · M2 (Cockpit)** | RAG Cockpit ao vivo: dados estáticos → tRPC · loading state · timestamp · botão Atualizar · 8 abas com dados reais · refetchInterval 60s | ✅ Concluída | PR #132 — `ebfa1cb` |
+| **Sprint I — DT-01** | Guard db:push (.mjs) + 3 testes automatizados + OPENAI_API_KEY no CI | ✅ Concluída | PR #139 — `fc54e13f` |
 
 ---
 
@@ -324,6 +326,7 @@ Os seguintes bloqueios estão em vigor por decisão formal e **não devem ser re
 | 1.6 | 2026-03-26 | `0647511` | Sprint 98% B2 concluída · GATE-CHECKLIST · Skills Manus+Claude · Cockpit v2 · G12 fonte_acao · Rollout documentado (HANDOFF-SESSAO + SNAPSHOT-B2 + GUIA-PO) |
 | 1.7 | 2026-03-26 | `a96cf25` | Sprint G concluída · RFC-001 (fusão id 810+811 lc227) · RFC-002 (25 chunks lc214→lc123) · 5 leis ativas · gold set 8/8 · confiabilidade 100% · RAG Cockpit ao vivo |
 | 1.8 | 2026-03-27 | `ebfa1cb` | Sprint H concluída · PR #131 ragInventory tRPC (9 gold set queries, GS-07 threshold < 10 bytes, lc123 ao enum) · PR #132 RAG Cockpit ao vivo (dados estáticos → tRPC, 8 abas, refetchInterval 60s) · Sprint I iniciada (G13+G14 UAT) |
+| 1.9 | 2026-03-27 | `fc54e13f` | DT-01 — guard db:push + 3 testes + secret CI configurado |
 
 > **Instrução para próxima atualização:** ao concluir uma sprint ou tomar uma decisão relevante, adicione uma linha nesta tabela e atualize as seções 1, 2, 5 e 10 com os novos valores. Faça commit com mensagem `docs: BASELINE-PRODUTO v1.x — <descrição>`.
 

--- a/docs/HANDOFF-MANUS.md
+++ b/docs/HANDOFF-MANUS.md
@@ -30,10 +30,10 @@ Drizzle ORM / Vitest / pnpm
 | Implementador | Você (Manus) — executa código, commits, deploy |
 | Consultor | ChatGPT — segunda opinião estratégica |
 
-## Estado atual do projeto (2026-03-26)
+## Estado atual do projeto (2026-03-27)
 
-- BASELINE **v1.6** — Sprint 98% Confidence B0/B1/B2 **CONCLUÍDA**
-- **489+ testes passando**
+- BASELINE **v1.9** — Sprint I/DT-01 **CONCLUÍDA**
+- **492+ testes passando**
 - DIAGNOSTIC_READ_MODE: `shadow` (ativo — NÃO alterar)
 - 56 migrations aplicadas
 - Branch protection: ativa (ruleset `main-protection`, ID 14328406)
@@ -52,6 +52,10 @@ Drizzle ORM / Vitest / pnpm
 | #112 | docs: BASELINE v1.5 + HANDOFF-MANUS | `d18dadb` |
 | #113 | feat(b2): GATE-CHECKLIST + Skills + Cockpit v2 + fonte_acao G12 | `805afd1` |
 | #115 | docs(cockpit): skills na biblioteca | `0647511` |
+| ... | PRs #116–#136 — Sprints F/G/H/I — ver docs/product/cpie-v2/produto/RASTREABILIDADE-RF-PR-SPRINT.md | — |
+| #137 | docs: RASTREABILIDADE-RF-PR-SPRINT.md | — |
+| #138 | chore(skills): solaris-contexto + solaris-orquestracao | — |
+| #139 | test(dt01): guard db:push + 3 testes de integridade de schema | `fc54e13f` |
 
 ## Gaps RAG — estado atual
 


### PR DESCRIPTION
## Resumo
Atualização documental do BASELINE-PRODUTO para v1.9 e HANDOFF-MANUS, registrando a conclusão do DT-01 (guard db:push + testes + OPENAI_API_KEY no CI).

## Arquivos alterados
- `docs/BASELINE-PRODUTO.md` — 4 alterações cirúrgicas
- `docs/HANDOFF-MANUS.md` — PRs recentes + estado atualizado

## Alterações detalhadas

### BASELINE-PRODUTO.md
- **Seção 1, linha 28:** 489 → 492 testes passando
- **Seção 1, fim da tabela:** nova linha `db:push guard | Bloqueado em production — scripts/db-push-guard.mjs | ✅`
- **Seção 8, após Sprint H · M2:** nova linha `Sprint I — DT-01 | Guard db:push (.mjs) + 3 testes automatizados + OPENAI_API_KEY no CI | ✅ Concluída | PR #139 — fc54e13f`
- **Seção 13:** nova linha `1.9 | 2026-03-27 | fc54e13f | DT-01 — guard db:push + 3 testes + secret CI configurado`

### HANDOFF-MANUS.md
- Estado: v1.6 → v1.9 | 489+ → 492+
- PRs #137, #138, #139 adicionados com linha separadora para #116–#136

## Evidência de verificação
```
grep -n "489" docs/BASELINE-PRODUTO.md
→ linha 325 apenas (histórico v1.5 — imutável) ✅

grep -n "492" docs/BASELINE-PRODUTO.md
→ linha 28 (Seção 1) ✅

Sprint I posição: linha 246, imediatamente após Sprint H · M2 (linha 245) ✅

git diff --stat: 2 files changed, 11 insertions(+), 4 deletions(-)
```

## Classificação
- Nível 1 — documentação pura
- Zero banco
- Zero código
- SEM Closes