### PR TITLE
feat(g15): fonte + requirement_id + source_reference no QuestionSchema + prompt LLM

### DIFF
--- a/server/ai-schemas.ts
+++ b/server/ai-schemas.ts
@@ -139,6 +139,12 @@ export const QuestionSchema = z.object({
   options: z.union([z.array(z.string()), z.null()]).optional().transform(v => v ?? []),
   scale_labels: z.object({ min: z.string(), max: z.string() }).optional().nullable().transform(v => v ?? undefined),
   placeholder: z.string().optional().nullable().transform(v => v ?? undefined),
+  // G15 / Sprint J: rastreabilidade de origem da pergunta
+  // Migração progressiva — defaults garantem compatibilidade com outputs LLM existentes
+  // INV-005: pergunta nunca deve ter fonte undefined — default "ia_gen" garante isso
+  fonte: z.enum(["regulatorio", "solaris", "ia_gen"]).optional().default("ia_gen"),
+  requirement_id: z.string().optional().default(""),
+  source_reference: z.string().optional().default(""),
 });
 
 export const QuestionsResponseSchema = z.object({

--- a/server/routers-fluxo-v3.ts
+++ b/server/routers-fluxo-v3.ts
@@ -560,6 +560,13 @@ REGRAS OBRIGATÓRIAS:
 4. Perguntas de nível 1: diagnóstico essencial (máximo 10 perguntas)
 5. Perguntas de nível 2: aprofundamento baseado nas respostas anteriores (máximo 10 perguntas)
 6. Nunca seja genérico — cada pergunta deve ser específica para o CNAE informado
+7. Cada pergunta deve ter rastreabilidade de origem (G15):
+   - "fonte": "regulatorio" se baseada em legislação (LC 214, EC 132, LC 227, LC 224, LC 116, LC 87),
+              "solaris" se baseada em orientação jurídica SOLARIS interna,
+              "ia_gen" se inferida sem base documental explícita no contexto RAG
+   - "requirement_id": identificador do requisito (ex: "RF-045") ou "" se não aplicável
+   - "source_reference": referência normativa (ex: "LC 214/2025 Art. 9°") ou "" se ia_gen
+   Se não houver base documental no contexto RAG, usar fonte: "ia_gen" e campos vazios.
 
 ${regulatoryContext}
 
@@ -573,7 +580,7 @@ NÍVEL: ${input.level === "nivel1" ? "1 (perguntas essenciais)" : `2 (aprofundam
 ${nivel2Context}
 
 Gere as perguntas no formato:
-{"questions": [{"id": "q1", "text": "...", "objetivo_diagnostico": "...", "impacto_reforma": "...", "type": "sim_nao", "peso_risco": "alto", "required": true, "options": [], "scale_labels": {"min": "Nunca", "max": "Sempre"}, "placeholder": "..."}]}`,
+{"questions": [{"id": "q1", "text": "...", "objetivo_diagnostico": "...", "impacto_reforma": "...", "type": "sim_nao", "peso_risco": "alto", "required": true, "options": [], "scale_labels": {"min": "Nunca", "max": "Sempre"}, "placeholder": "...", "fonte": "regulatorio", "requirement_id": "RF-045", "source_reference": "LC 214/2025 Art. 9°"}]}`,
           },
         ],
           QuestionsResponseSchema,

--- a/server/schema-g15-question.test.ts
+++ b/server/schema-g15-question.test.ts
@@ -1,0 +1,106 @@
+/**
+ * schema-g15-question.test.ts
+ * Sprint J — G15: rastreabilidade de origem das perguntas do questionário
+ *
+ * Cobre os 3 campos adicionados ao QuestionSchema em ai-schemas.ts:
+ *   - fonte: enum("regulatorio" | "solaris" | "ia_gen") — default "ia_gen"
+ *   - requirement_id: string opcional — default ""
+ *   - source_reference: string opcional — default ""
+ *
+ * INV-005: pergunta nunca deve ter fonte undefined — default "ia_gen" garante isso.
+ */
+
+import { describe, it, expect } from "vitest";
+import { QuestionSchema } from "./ai-schemas";
+
+// Base mínima válida para um QuestionSchema (campos obrigatórios)
+const baseQuestion = {
+  id: "q1",
+  text: "A empresa já realizou o mapeamento de suas operações sob a LC 214/2025?",
+};
+
+describe("G15 — QuestionSchema: rastreabilidade de origem (fonte/requirement_id/source_reference)", () => {
+
+  // T-G15-01: pergunta regulatória com todos os campos preenchidos — schema aceita
+  it("T-G15-01: pergunta regulatória com todos os campos — schema aceita", () => {
+    const result = QuestionSchema.safeParse({
+      ...baseQuestion,
+      fonte: "regulatorio",
+      requirement_id: "RF-045",
+      source_reference: "LC 214/2025 Art. 9°",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.fonte).toBe("regulatorio");
+      expect(result.data.requirement_id).toBe("RF-045");
+      expect(result.data.source_reference).toBe("LC 214/2025 Art. 9°");
+    }
+  });
+
+  // T-G15-02: pergunta ia_gen com campos vazios — schema aceita
+  it("T-G15-02: pergunta ia_gen com campos vazios — schema aceita", () => {
+    const result = QuestionSchema.safeParse({
+      ...baseQuestion,
+      fonte: "ia_gen",
+      requirement_id: "",
+      source_reference: "",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.fonte).toBe("ia_gen");
+      expect(result.data.requirement_id).toBe("");
+      expect(result.data.source_reference).toBe("");
+    }
+  });
+
+  // T-G15-03: sem campo fonte — default "ia_gen" aplicado automaticamente
+  it("T-G15-03: sem campo fonte — default ia_gen aplicado automaticamente", () => {
+    const result = QuestionSchema.safeParse({
+      ...baseQuestion,
+      // fonte ausente intencionalmente
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // INV-005: fonte nunca deve ser undefined
+      expect(result.data.fonte).toBeDefined();
+      expect(result.data.fonte).toBe("ia_gen");
+      // requirement_id e source_reference também têm defaults
+      expect(result.data.requirement_id).toBe("");
+      expect(result.data.source_reference).toBe("");
+    }
+  });
+
+  // T-G15-04: fonte inválida — ZodError
+  it("T-G15-04: fonte inválida — ZodError", () => {
+    const result = QuestionSchema.safeParse({
+      ...baseQuestion,
+      fonte: "desconhecido", // valor fora do enum
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const fonteError = result.error.issues.find(i => i.path.includes("fonte"));
+      expect(fonteError).toBeDefined();
+    }
+  });
+
+  // T-G15-05: INV-005 — output nunca tem fonte undefined (migração progressiva)
+  it("T-G15-05: INV-005 — output nunca tem fonte undefined mesmo sem o campo", () => {
+    // Simula outputs antigos do LLM que não retornavam o campo fonte
+    const legacyOutputs = [
+      { ...baseQuestion },                                    // sem fonte
+      { ...baseQuestion, fonte: undefined },                  // fonte explicitamente undefined
+      { ...baseQuestion, fonte: null as any },                // fonte null
+    ];
+
+    for (const output of legacyOutputs) {
+      const result = QuestionSchema.safeParse(output);
+      // Outputs sem fonte válida devem ou receber default "ia_gen" ou falhar — nunca retornar undefined
+      if (result.success) {
+        expect(result.data.fonte).not.toBeUndefined();
+        expect(result.data.fonte).toBe("ia_gen");
+      }
+      // Se falhar (ex: null não é aceito), o schema está protegendo corretamente
+    }
+  });
+
+});


### PR DESCRIPTION
## Resumo
Implementa G15 (Sprint J): adiciona campos de rastreabilidade de origem ao `QuestionSchema` do pipeline de diagnóstico.

## Arquivos alterados (escopo declarado)
- `server/ai-schemas.ts` — J-1: 3 campos adicionados ao QuestionSchema
- `server/routers-fluxo-v3.ts` — J-2: regra 7 + JSON de exemplo no prompt generateQuestions
- `server/schema-g15-question.test.ts` — J-3: 5 testes novos (T-G15-01 a T-G15-05)

## Evidências de execução

```
pnpm vitest run server/schema-g15-question.test.ts
✓ T-G15-01: pergunta regulatória com todos os campos — schema aceita
✓ T-G15-02: pergunta ia_gen com campos vazios — schema aceita
✓ T-G15-03: sem campo fonte — default ia_gen aplicado automaticamente
✓ T-G15-04: fonte inválida — ZodError
✓ T-G15-05: INV-005 — output nunca tem fonte undefined
Test Files  1 passed (1) | Tests  5 passed (5) | Duration 328ms

pnpm vitest run server/onda1-t01-t05.test.ts ... (5 arquivos)
Test Files  5 passed (5) | Tests  107 passed (107) | Duration 6.72s

npx tsc --noEmit → EXIT:0 (zero erros TypeScript)
```

## Critérios de conclusão
- [x] 5/5 testes G15 passando
- [x] 107/107 testes de onda (zero regressão)
- [x] TypeScript zero erros
- [x] Migração progressiva — defaults garantem compatibilidade com outputs LLM existentes
- [x] INV-005 enforced: fonte nunca undefined

## NÃO foi alterado
- `server/routers-questions-crud.ts` — fora do escopo desta sprint (débito técnico registrado)
- `server/routers/questionEngine.ts` — campos B2 com semântica diferente, não tocados
- `OUTPUT_CONTRACT` em `server/ai-helpers.ts` — constante compartilhada por 6 endpoints, não alterada

## Classificação
Nível 2 · Zero banco · Zero DROP COLUMN · DIAGNOSTIC_READ_MODE inalterado

```json
{
  "pr": "feat/g15-question-schema-rastreabilidade",
  "testes_novos": 5,
  "testes_regressao": 107,
  "typescript": "EXIT:0",
  "arquivos": ["server/ai-schemas.ts", "server/routers-fluxo-v3.ts", "server/schema-g15-question.test.ts"],
  "inv_005": "enforced via .default('ia_gen')"
}
```
