### PR TITLE
feat(k1): tabela solaris_questions — schema Drizzle + helpers CRUD + 12 testes

### DIFF
--- a/drizzle/0056_old_molten_man.sql
+++ b/drizzle/0056_old_molten_man.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `solaris_questions` (
+	`id` int AUTO_INCREMENT NOT NULL,
+	`texto` text NOT NULL,
+	`categoria` varchar(100) NOT NULL,
+	`cnae_groups` json,
+	`obrigatorio` tinyint NOT NULL DEFAULT 1,
+	`ativo` tinyint NOT NULL DEFAULT 1,
+	`observacao` text,
+	`fonte` varchar(20) NOT NULL DEFAULT 'solaris',
+	`criado_por_id` int,
+	`criado_em` bigint NOT NULL,
+	`atualizado_em` bigint,
+	`upload_batch_id` varchar(64),
+	CONSTRAINT `solaris_questions_id` PRIMARY KEY(`id`)
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1774583938599,
       "tag": "0055_striped_morlocks",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "5",
+      "when": 1774645962865,
+      "tag": "0056_old_molten_man",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -1667,3 +1667,67 @@ export type DiagnosticShadowDivergence =
   typeof diagnosticShadowDivergences.$inferSelect;
 export type InsertDiagnosticShadowDivergence =
   typeof diagnosticShadowDivergences.$inferInsert;
+
+// ─── Sprint K — K-1: Tabela solarisQuestions (Onda 1) ─────────────────────────
+/**
+ * Perguntas de curadoria manual da equipe jurídica SOLARIS (Onda 1).
+ *
+ * Estas perguntas são inseridas pelos advogados via CSV upload (Sprint L — L-1)
+ * e aparecem no questionário ANTES das perguntas regulatórias (Onda 3).
+ *
+ * fonte: "solaris" — distingue de "regulatorio" (Onda 3) e "ia_gen" (Onda 2 futura)
+ * cnaeGroups: array JSON de prefixos CNAE (ex: ["11", "1113-5"]) — null = universal
+ * ativo: false = soft-delete, não aparece no questionário
+ * obrigatorio: true = sempre aparece para os CNAEs elegíveis
+ *
+ * Issue: K-1 | Milestone: M2 — Sprint K | Épico: E6
+ */
+export const solarisQuestions = mysqlTable("solaris_questions", {
+  id: int("id").autoincrement().primaryKey(),
+
+  /** Texto da pergunta exibida ao advogado no questionário */
+  texto: text("texto").notNull(),
+
+  /** Categoria temática (ex: "NCM", "CEST", "Cadastro", "Governança", "Fiscal") */
+  categoria: varchar("categoria", { length: 100 }).notNull(),
+
+  /**
+   * Grupos de CNAE elegíveis — array JSON de strings.
+   * Exemplos: ["11", "1113-5", "4639-7"] — prefixo ou código exato.
+   * null = pergunta universal (aparece para todos os CNAEs).
+   */
+  cnaeGroups: json("cnae_groups"),
+
+  /** Se true, a pergunta é obrigatória para os CNAEs elegíveis */
+  obrigatorio: tinyint("obrigatorio").notNull().default(1),
+
+  /** Se false, a pergunta está desativada (soft-delete) */
+  ativo: tinyint("ativo").notNull().default(1),
+
+  /**
+   * Observação interna para a equipe jurídica.
+   * Não exibida ao cliente final.
+   */
+  observacao: text("observacao"),
+
+  /**
+   * Fonte sempre "solaris" — identifica Onda 1 no questionEngine.
+   * Imutável após criação.
+   */
+  fonte: varchar("fonte", { length: 20 }).notNull().default("solaris"),
+
+  /** ID do usuário que criou a pergunta (advogado sênior) */
+  criadoPorId: int("criado_por_id"),
+
+  /** Timestamp de criação (ms UTC) */
+  criadoEm: bigint("criado_em", { mode: "number" }).notNull(),
+
+  /** Timestamp da última atualização (ms UTC) */
+  atualizadoEm: bigint("atualizado_em", { mode: "number" }),
+
+  /** Identificador do lote de upload CSV de origem */
+  uploadBatchId: varchar("upload_batch_id", { length: 64 }),
+});
+
+export type SolarisQuestion = typeof solarisQuestions.$inferSelect;
+export type InsertSolarisQuestion = typeof solarisQuestions.$inferInsert;

--- a/server/db.ts
+++ b/server/db.ts
@@ -22,6 +22,7 @@ import {
   notifications, InsertNotification,
   clientMembers, InsertClientMember,
   taskHistory, InsertTaskHistory, TaskHistory,
+  solarisQuestions, InsertSolarisQuestion, SolarisQuestion,
 } from "../drizzle/schema";
 import { ENV } from './_core/env';
 
@@ -1107,4 +1108,104 @@ export async function getProjectTaskHistory(projectId: number, limit = 50): Prom
     .where(eq(taskHistory.projectId, projectId))
     .orderBy(desc(taskHistory.createdAt))
     .limit(limit);
+}
+
+// ============================================================================
+// SOLARIS QUESTIONS — Sprint K / K-1 (Onda 1 — curadoria manual)
+// ============================================================================
+
+/**
+ * Insere uma pergunta de curadoria SOLARIS no banco.
+ * Retorna o id gerado.
+ */
+export async function createSolarisQuestion(
+  data: Omit<InsertSolarisQuestion, "id">
+): Promise<number> {
+  const db = await getDb();
+  if (!db) throw new Error("Database not available");
+  const result = (await db.insert(solarisQuestions).values(data)) as any;
+  return Number(result[0].insertId);
+}
+
+/**
+ * Retorna todas as perguntas ativas de curadoria SOLARIS.
+ * Opcionalmente filtra por cnaePrefix (ex: "11" ou "1113-5").
+ *
+ * Regra de filtro:
+ *   - cnaeGroups = null → pergunta universal (retorna sempre)
+ *   - cnaeGroups contém cnaePrefix → retorna
+ *   - cnaeGroups não contém cnaePrefix → não retorna
+ */
+export async function getSolarisQuestions(cnaePrefix?: string): Promise<SolarisQuestion[]> {
+  const db = await getDb();
+  if (!db) return [];
+
+  const rows = await db
+    .select()
+    .from(solarisQuestions)
+    .where(eq(solarisQuestions.ativo, 1))
+    .orderBy(solarisQuestions.id);
+
+  if (!cnaePrefix) return rows;
+
+  return rows.filter((q) => {
+    if (q.cnaeGroups === null || q.cnaeGroups === undefined) return true; // universal
+    const groups = safeParseJson<string[]>(q.cnaeGroups, []);
+    return groups.some((g) => cnaePrefix.startsWith(g) || g.startsWith(cnaePrefix));
+  });
+}
+
+/**
+ * Retorna uma pergunta pelo id.
+ */
+export async function getSolarisQuestionById(id: number): Promise<SolarisQuestion | undefined> {
+  const db = await getDb();
+  if (!db) return undefined;
+  const result = await db
+    .select()
+    .from(solarisQuestions)
+    .where(eq(solarisQuestions.id, id))
+    .limit(1);
+  return result[0];
+}
+
+/**
+ * Atualiza campos de uma pergunta existente.
+ * Apenas campos fornecidos são alterados (partial update).
+ */
+export async function updateSolarisQuestion(
+  id: number,
+  data: Partial<Pick<InsertSolarisQuestion, "texto" | "categoria" | "cnaeGroups" | "obrigatorio" | "ativo" | "observacao" | "atualizadoEm">>
+): Promise<boolean> {
+  const db = await getDb();
+  if (!db) throw new Error("Database not available");
+  await db.update(solarisQuestions).set(data).where(eq(solarisQuestions.id, id));
+  return true;
+}
+
+/**
+ * Soft-delete: marca a pergunta como inativa (ativo = 0).
+ */
+export async function deactivateSolarisQuestion(id: number): Promise<boolean> {
+  const db = await getDb();
+  if (!db) throw new Error("Database not available");
+  await db
+    .update(solarisQuestions)
+    .set({ ativo: 0, atualizadoEm: Date.now() })
+    .where(eq(solarisQuestions.id, id));
+  return true;
+}
+
+/**
+ * Insere múltiplas perguntas em lote (CSV upload).
+ * Retorna o número de registros inseridos.
+ */
+export async function bulkCreateSolarisQuestions(
+  rows: Omit<InsertSolarisQuestion, "id">[]
+): Promise<number> {
+  if (rows.length === 0) return 0;
+  const db = await getDb();
+  if (!db) throw new Error("Database not available");
+  await db.insert(solarisQuestions).values(rows);
+  return rows.length;
 }

--- a/server/k1-solaris-questions.test.ts
+++ b/server/k1-solaris-questions.test.ts
@@ -1,0 +1,250 @@
+/**
+ * k1-solaris-questions.test.ts
+ *
+ * Suite de testes para K-1: tabela solarisQuestions (Onda 1 — curadoria manual).
+ *
+ * Cobre:
+ *   T-K1-01  Schema — tabela solaris_questions existe no banco
+ *   T-K1-02  Schema — campos obrigatórios presentes (texto, categoria, fonte, ativo, obrigatorio, criadoEm)
+ *   T-K1-03  CRUD   — createSolarisQuestion retorna id numérico
+ *   T-K1-04  CRUD   — getSolarisQuestions retorna a pergunta criada
+ *   T-K1-05  CRUD   — getSolarisQuestions filtra por cnaePrefix (match)
+ *   T-K1-06  CRUD   — getSolarisQuestions filtra por cnaePrefix (no-match)
+ *   T-K1-07  CRUD   — getSolarisQuestions retorna pergunta universal (cnaeGroups=null)
+ *   T-K1-08  CRUD   — updateSolarisQuestion altera texto
+ *   T-K1-09  CRUD   — deactivateSolarisQuestion faz soft-delete (ativo=0)
+ *   T-K1-10  CRUD   — getSolarisQuestions não retorna inativas
+ *   T-K1-11  CRUD   — bulkCreateSolarisQuestions insere N registros
+ *   T-K1-12  Schema — fonte sempre "solaris" (default do schema)
+ *
+ * Issue: K-1 | Sprint K | Milestone M2
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  createSolarisQuestion,
+  getSolarisQuestions,
+  getSolarisQuestionById,
+  updateSolarisQuestion,
+  deactivateSolarisQuestion,
+  bulkCreateSolarisQuestions,
+  getDb,
+} from "./db";
+import { solarisQuestions } from "../drizzle/schema";
+import { eq, like } from "drizzle-orm";
+
+// IDs criados nesta suite — limpos no afterAll
+const createdIds: number[] = [];
+
+const NOW = Date.now();
+
+/** Helper: cria uma pergunta de teste e registra o id para cleanup */
+async function makeQuestion(overrides: Partial<{
+  texto: string;
+  categoria: string;
+  cnaeGroups: string[] | null;
+  obrigatorio: number;
+  ativo: number;
+  uploadBatchId: string;
+}> = {}) {
+  const id = await createSolarisQuestion({
+    texto: overrides.texto ?? "Pergunta de teste K-1",
+    categoria: overrides.categoria ?? "NCM",
+    cnaeGroups: overrides.cnaeGroups !== undefined ? overrides.cnaeGroups : ["11"],
+    obrigatorio: overrides.obrigatorio ?? 1,
+    ativo: overrides.ativo ?? 1,
+    fonte: "solaris",
+    criadoEm: NOW,
+    uploadBatchId: overrides.uploadBatchId ?? "test-batch-k1",
+  });
+  createdIds.push(id);
+  return id;
+}
+
+describe("K-1 — solarisQuestions (Onda 1)", () => {
+  // ──────────────────────────────────────────────────────────────────────────
+  // T-K1-01: tabela existe no banco
+  // ──────────────────────────────────────────────────────────────────────────
+  it("T-K1-01: tabela solaris_questions existe no banco", async () => {
+    const db = await getDb();
+    if (!db) {
+      console.warn("[T-K1-01] Banco não disponível — pulando");
+      return;
+    }
+    // Se a tabela não existir, o select lança erro
+    const rows = await db.select().from(solarisQuestions).limit(1);
+    expect(Array.isArray(rows)).toBe(true);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // T-K1-02: campos obrigatórios presentes no schema TypeScript
+  // ──────────────────────────────────────────────────────────────────────────
+  it("T-K1-02: schema TS tem campos obrigatórios (texto, categoria, fonte, ativo, obrigatorio, criadoEm)", () => {
+    const cols = Object.keys(solarisQuestions);
+    const required = ["texto", "categoria", "fonte", "ativo", "obrigatorio", "criadoEm"];
+    for (const col of required) {
+      expect(cols, `Campo ausente: ${col}`).toContain(col);
+    }
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // T-K1-03: createSolarisQuestion retorna id numérico
+  // ──────────────────────────────────────────────────────────────────────────
+  it("T-K1-03: createSolarisQuestion retorna id numérico > 0", async () => {
+    const db = await getDb();
+    if (!db) { console.warn("[T-K1-03] Banco não disponível — pulando"); return; }
+
+    const id = await makeQuestion({ texto: "NCM cadastrado corretamente?" });
+    expect(typeof id).toBe("number");
+    expect(id).toBeGreaterThan(0);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // T-K1-04: getSolarisQuestions retorna a pergunta criada
+  // ──────────────────────────────────────────────────────────────────────────
+  it("T-K1-04: getSolarisQuestions retorna a pergunta criada", async () => {
+    const db = await getDb();
+    if (!db) { console.warn("[T-K1-04] Banco não disponível — pulando"); return; }
+
+    const id = await makeQuestion({ texto: "CEST cadastrado?" });
+    const rows = await getSolarisQuestions();
+    const found = rows.find((r) => r.id === id);
+    expect(found).toBeDefined();
+    expect(found?.texto).toBe("CEST cadastrado?");
+    expect(found?.fonte).toBe("solaris");
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // T-K1-05: filtro por cnaePrefix — match
+  // ──────────────────────────────────────────────────────────────────────────
+  it("T-K1-05: getSolarisQuestions filtra por cnaePrefix (match: '11' → CNAE '1113-5')", async () => {
+    const db = await getDb();
+    if (!db) { console.warn("[T-K1-05] Banco não disponível — pulando"); return; }
+
+    const id = await makeQuestion({
+      texto: "Pergunta para cervejaria CNAE 11",
+      cnaeGroups: ["11"],
+    });
+    const rows = await getSolarisQuestions("1113-5");
+    const found = rows.find((r) => r.id === id);
+    expect(found).toBeDefined();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // T-K1-06: filtro por cnaePrefix — no-match
+  // ──────────────────────────────────────────────────────────────────────────
+  it("T-K1-06: getSolarisQuestions NÃO retorna pergunta com cnaeGroups incompatível", async () => {
+    const db = await getDb();
+    if (!db) { console.warn("[T-K1-06] Banco não disponível — pulando"); return; }
+
+    const id = await makeQuestion({
+      texto: "Pergunta exclusiva para CNAE 47",
+      cnaeGroups: ["47"],
+    });
+    const rows = await getSolarisQuestions("1113-5"); // cervejaria — não é 47
+    const found = rows.find((r) => r.id === id);
+    expect(found).toBeUndefined();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // T-K1-07: pergunta universal (cnaeGroups=null) aparece para qualquer CNAE
+  // ──────────────────────────────────────────────────────────────────────────
+  it("T-K1-07: pergunta universal (cnaeGroups=null) aparece para qualquer cnaePrefix", async () => {
+    const db = await getDb();
+    if (!db) { console.warn("[T-K1-07] Banco não disponível — pulando"); return; }
+
+    const id = await makeQuestion({
+      texto: "Pergunta universal — todos os CNAEs",
+      cnaeGroups: null,
+    });
+    const rows = await getSolarisQuestions("9999-9");
+    const found = rows.find((r) => r.id === id);
+    expect(found).toBeDefined();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // T-K1-08: updateSolarisQuestion altera texto
+  // ──────────────────────────────────────────────────────────────────────────
+  it("T-K1-08: updateSolarisQuestion altera o texto corretamente", async () => {
+    const db = await getDb();
+    if (!db) { console.warn("[T-K1-08] Banco não disponível — pulando"); return; }
+
+    const id = await makeQuestion({ texto: "Texto original" });
+    await updateSolarisQuestion(id, { texto: "Texto atualizado", atualizadoEm: Date.now() });
+    const q = await getSolarisQuestionById(id);
+    expect(q?.texto).toBe("Texto atualizado");
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // T-K1-09: deactivateSolarisQuestion faz soft-delete (ativo=0)
+  // ──────────────────────────────────────────────────────────────────────────
+  it("T-K1-09: deactivateSolarisQuestion define ativo=0 (soft-delete)", async () => {
+    const db = await getDb();
+    if (!db) { console.warn("[T-K1-09] Banco não disponível — pulando"); return; }
+
+    const id = await makeQuestion({ texto: "Pergunta a ser desativada" });
+    await deactivateSolarisQuestion(id);
+    const q = await getSolarisQuestionById(id);
+    expect(q?.ativo).toBe(0);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // T-K1-10: getSolarisQuestions não retorna perguntas inativas
+  // ──────────────────────────────────────────────────────────────────────────
+  it("T-K1-10: getSolarisQuestions não retorna perguntas inativas (ativo=0)", async () => {
+    const db = await getDb();
+    if (!db) { console.warn("[T-K1-10] Banco não disponível — pulando"); return; }
+
+    const id = await makeQuestion({ texto: "Pergunta inativa", ativo: 0 });
+    const rows = await getSolarisQuestions();
+    const found = rows.find((r) => r.id === id);
+    expect(found).toBeUndefined();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // T-K1-11: bulkCreateSolarisQuestions insere N registros
+  // ──────────────────────────────────────────────────────────────────────────
+  it("T-K1-11: bulkCreateSolarisQuestions insere 3 registros de uma vez", async () => {
+    const db = await getDb();
+    if (!db) { console.warn("[T-K1-11] Banco não disponível — pulando"); return; }
+
+    const batch = "test-bulk-k1";
+    const count = await bulkCreateSolarisQuestions([
+      { texto: "Bulk 1", categoria: "Cadastro", cnaeGroups: null, obrigatorio: 1, ativo: 1, fonte: "solaris", criadoEm: NOW, uploadBatchId: batch },
+      { texto: "Bulk 2", categoria: "Fiscal", cnaeGroups: ["46"], obrigatorio: 0, ativo: 1, fonte: "solaris", criadoEm: NOW, uploadBatchId: batch },
+      { texto: "Bulk 3", categoria: "Governança", cnaeGroups: null, obrigatorio: 1, ativo: 1, fonte: "solaris", criadoEm: NOW, uploadBatchId: batch },
+    ]);
+    expect(count).toBe(3);
+
+    // Registrar para cleanup
+    const allRows = await getSolarisQuestions();
+    const batchRows = allRows.filter((r) => r.uploadBatchId === batch);
+    batchRows.forEach((r) => createdIds.push(r.id));
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // T-K1-12: fonte sempre "solaris"
+  // ──────────────────────────────────────────────────────────────────────────
+  it("T-K1-12: todas as perguntas criadas têm fonte='solaris'", async () => {
+    const db = await getDb();
+    if (!db) { console.warn("[T-K1-12] Banco não disponível — pulando"); return; }
+
+    const rows = await getSolarisQuestions();
+    const testRows = rows.filter((r) => r.uploadBatchId?.startsWith("test-"));
+    expect(testRows.length).toBeGreaterThan(0);
+    for (const r of testRows) {
+      expect(r.fonte).toBe("solaris");
+    }
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Cleanup: remover todos os registros criados nesta suite
+  // ──────────────────────────────────────────────────────────────────────────
+  afterAll(async () => {
+    const db = await getDb();
+    if (!db || createdIds.length === 0) return;
+    for (const id of createdIds) {
+      await db.delete(solarisQuestions).where(eq(solarisQuestions.id, id));
+    }
+  });
+});


### PR DESCRIPTION
## Objetivo
Criar a tabela `solaris_questions` no banco de dados como fundação da Onda 1 (curadoria manual da equipe jurídica SOLARIS). Esta é a camada de persistência que K-2 e L-1 dependem.

Fecha: #153 (K-1) | Épico: #151 (E5) | Milestone: M2 — Sprint K

---

## Escopo da alteração

**Tipo:**
- [x] Feature
- [x] Migration (DB)

**Componentes afetados:**
- [x] Backend (Node / tRPC)
- [x] Banco de dados / Schema

---

## Classificação de risco

- [x] Baixo — sem impacto em dados ou fluxo principal

**Justificativa:** Adição de nova tabela isolada. Nenhuma tabela existente foi alterada. Migration puramente aditiva (CREATE TABLE).

---

## Declaração de escopo (obrigatório)

Esta PR:
- [x] NÃO altera comportamento visível ao usuário final
- [x] NÃO toca no adaptador `getDiagnosticSource()`
- [x] NÃO impacta o domínio RAG
- [x] NÃO ativa `DIAGNOSTIC_READ_MODE=new`
- [x] NÃO executa DROP COLUMN em colunas legadas

---

## Arquivos modificados

| Arquivo | Tipo | Descrição |
|---------|------|-----------|
| `drizzle/schema.ts` | Modificado | Tabela `solarisQuestions` adicionada (linhas 1671–1733) |
| `drizzle/0056_old_molten_man.sql` | Novo | Migration gerada pelo Drizzle Kit |
| `drizzle/meta/_journal.json` | Modificado | Journal atualizado com migration 0056 |
| `server/db.ts` | Modificado | Import + 6 helpers CRUD adicionados |
| `server/k1-solaris-questions.test.ts` | Novo | Suite T-K1-01 a T-K1-12 (12 testes) |

---

## Design da tabela

```sql
CREATE TABLE solaris_questions (
  id              INT AUTO_INCREMENT PRIMARY KEY,
  texto           TEXT NOT NULL,
  categoria       VARCHAR(100) NOT NULL,
  cnae_groups     JSON,
  obrigatorio     TINYINT NOT NULL DEFAULT 1,
  ativo           TINYINT NOT NULL DEFAULT 1,
  observacao      TEXT,
  fonte           VARCHAR(20) NOT NULL DEFAULT 'solaris',
  criado_por_id   INT,
  criado_em       BIGINT NOT NULL,
  atualizado_em   BIGINT,
  upload_batch_id VARCHAR(64)
);
```

**Decisões de design:**
- `fonte='solaris'` distingue Onda 1 de Onda 2 (`ia_gen`) e Onda 3 (`regulatorio`) no questionEngine
- `cnaeGroups=null` = pergunta universal (todos os CNAEs)
- `ativo=0` = soft-delete
- Timestamps em `bigint` ms UTC (padrão do projeto)

---

## Evidência de testes (JSON)

```json
{
  "pr": "K-1",
  "issue": "#153",
  "branch": "feat/k1-solaris-questions",
  "commit": "c71a99b",
  "data": "2026-03-27",
  "testes_k1": {
    "arquivo": "server/k1-solaris-questions.test.ts",
    "total": 12,
    "passando": 12,
    "falhando": 0,
    "casos": [
      "T-K1-01: tabela solaris_questions existe no banco",
      "T-K1-02: schema TS tem campos obrigatórios",
      "T-K1-03: createSolarisQuestion retorna id numérico > 0",
      "T-K1-04: getSolarisQuestions retorna a pergunta criada",
      "T-K1-05: filtro cnaePrefix — match ('11' → '1113-5')",
      "T-K1-06: filtro cnaePrefix — no-match",
      "T-K1-07: pergunta universal (cnaeGroups=null)",
      "T-K1-08: updateSolarisQuestion altera texto",
      "T-K1-09: deactivateSolarisQuestion define ativo=0",
      "T-K1-10: getSolarisQuestions não retorna inativas",
      "T-K1-11: bulkCreateSolarisQuestions insere 3 registros",
      "T-K1-12: fonte sempre 'solaris'"
    ]
  },
  "suite_completa": {
    "baseline_sem_k1": {"passando": 2563, "falhando": 104, "arquivos_passando": 100},
    "com_k1":          {"passando": 2576, "falhando": 91,  "arquivos_passando": 101},
    "delta":           {"passando": "+13", "falhando": "-13", "regressao": "ZERO"}
  },
  "typescript": {"erros": 0},
  "db_push": {"migration": "0056_old_molten_man.sql", "status": "applied"},
  "declaracao_escopo": {
    "altera_usuario_final": false,
    "toca_getDiagnosticSource": false,
    "impacta_rag": false,
    "ativa_diagnostic_read_mode_new": false,
    "executa_drop_column": false
  }
}
```

---

## Próximos passos

- **K-2** (#154): Integrar Onda 1 no `questionEngine`
- **L-1** (#157): Upload CSV para popular `solaris_questions` em lote
