### PR TITLE
fix(k4-b): VALID_TRANSITIONS — cnaes_confirmados → onda1_solaris

### DIFF
--- a/server/flowStateMachine.ts
+++ b/server/flowStateMachine.ts
@@ -414,7 +414,7 @@ export function createHistoryEntry(
  * Inclui os novos status onda1_solaris e onda2_iagen (K-4-A).
  */
 export const VALID_TRANSITIONS: Record<string, string[]> = {
-  'rascunho':                  ['onda1_solaris'],
+  'rascunho':                  ['consistencia_pendente'],  // rascunho → consistência (não pula para Onda 1)
   'onda1_solaris':             ['onda2_iagen', 'rascunho'],
   'onda2_iagen':               ['diagnostico_corporativo', 'onda1_solaris'],
   'diagnostico_corporativo':   ['diagnostico_operacional', 'onda2_iagen'],
@@ -425,9 +425,9 @@ export const VALID_TRANSITIONS: Record<string, string[]> = {
   'aprovado':                  ['matriz_riscos'],
   // Status legados — mantidos para compatibilidade com projetos existentes
   'consistencia_pendente':     ['cnaes_confirmados', 'rascunho'],
-  'cnaes_confirmados':         ['diagnostico_corporativo', 'consistencia_pendente'],
+  'cnaes_confirmados':         ['onda1_solaris', 'consistencia_pendente'],  // K-4-B fix: Onda 1 antes do Corporativo
   'assessment_fase1':          ['assessment_fase2', 'cnaes_confirmados'],
-  'assessment_fase2':          ['diagnostico_corporativo', 'assessment_fase1'],
+  'assessment_fase2':          ['onda1_solaris', 'assessment_fase1'],  // legado: também passa por Onda 1
   'riscos':                    ['plano', 'briefing'],
   'plano':                     ['dashboard', 'riscos'],
   'dashboard':                 ['plano'],


### PR DESCRIPTION
## fix(k4-b): VALID_TRANSITIONS — cnaes_confirmados → onda1_solaris

> Branch limpo sobre `main` (`ae517f0`). Zero conflitos. 1 arquivo alterado.

### Evidência JSON
```json
{
  "sprint": "K",
  "entrega": "K-4-B fix #2 — VALID_TRANSITIONS",
  "commit": "48c41ec",
  "branch": "feat/k4-b-transitions-fix",
  "base": "ae517f0 (main, PR #180)",
  "arquivo": "server/flowStateMachine.ts",
  "linhas_alteradas": 3,
  "conflitos": 0,
  "typescript": "0 erros reais",
  "causa_raiz": "VALID_TRANSITIONS['cnaes_confirmados'] apontava para diagnostico_corporativo",
  "gate": "p.o.-valida"
}
```

### Causa raiz

`assertValidTransition` bloqueava a transição `cnaes_confirmados → onda1_solaris` porque `VALID_TRANSITIONS` mapeava `cnaes_confirmados → ['diagnostico_corporativo', ...]`. Isso causava um erro FORBIDDEN no backend ao tentar salvar o status `onda1_solaris`.

### Correções (3 linhas)

```diff
- 'rascunho':        ['onda1_solaris'],
+ 'rascunho':        ['consistencia_pendente'],  // correto: rascunho → consistência

- 'cnaes_confirmados': ['diagnostico_corporativo', 'consistencia_pendente'],
+ 'cnaes_confirmados': ['onda1_solaris', 'consistencia_pendente'],  // K-4-B fix

- 'assessment_fase2': ['diagnostico_corporativo', 'assessment_fase1'],
+ 'assessment_fase2': ['onda1_solaris', 'assessment_fase1'],  // legado também passa por Onda 1
```

### Critério de Aceite do P.O.
> "Ao criar projeto com CNAE 4639-7/01, clicar 'Confirmar e Avançar' navega para o Questionário SOLARIS com badge azul e 12 questões."

⚠️ **Label: p.o.-valida — não mergear sem aprovação do P.O.**

Closes #156
