### PR TITLE
feat(k4-c): QuestionarioIaGen + completeOnda2 + onStartOnda2 wiring

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -77,6 +77,7 @@ import ShadowMonitor from "./pages/ShadowMonitor";
 import RagCockpit from "./pages/RagCockpit";
 import TaskBoard from "./pages/TaskBoard"; // Sprint K — Taskboard P.O. ao vivo (Issue #151)
 import QuestionarioSolaris from "./pages/QuestionarioSolaris"; // K-4-B: Onda 1 SOLARIS
+import QuestionarioIaGen from "./pages/QuestionarioIaGen"; // K-4-C: Onda 2 IA Generativa
 
 function Router() {
   return (
@@ -118,6 +119,7 @@ function Router() {
       <Route path="/consolidacao" component={Consolidacao} />
       {/* Diagnóstico v2.1 — 3 camadas sequenciais */}
       <Route path="/projetos/:id/questionario-solaris" component={QuestionarioSolaris} />
+      <Route path="/projetos/:id/questionario-iagen" component={QuestionarioIaGen} /> {/* K-4-C: Onda 2 */}
       <Route path="/projetos/:id/questionario-corporativo-v2" component={QuestionarioCorporativoV2} />
       <Route path="/projetos/:id/questionario-operacional" component={QuestionarioOperacional} />
       <Route path="/projetos/:id/questionario-cnae" component={QuestionarioCNAE} />

--- a/client/src/pages/ProjetoDetalhesV2.tsx
+++ b/client/src/pages/ProjetoDetalhesV2.tsx
@@ -463,6 +463,7 @@ export default function ProjetoDetalhesV2() {
                 isLoading={completeDiagnosticLayer.isPending}
                 projectStatus={summary.status}
                 onStartOnda1={() => setLocation(`/projetos/${projectId}/questionario-solaris`)}
+                onStartOnda2={() => setLocation(`/projetos/${projectId}/questionario-iagen`)}
                 onStartLayer={(layer) => {
                   if (layer === "corporate") {
                     setLocation(`/projetos/${projectId}/questionario-corporativo-v2`);

--- a/client/src/pages/QuestionarioIaGen.tsx
+++ b/client/src/pages/QuestionarioIaGen.tsx
@@ -1,0 +1,285 @@
+/**
+ * QuestionarioIaGen.tsx — Onda 2: Questionário IA Generativa
+ * K-4-C: Sprint K — FLUXO-3-ONDAS v1.1 Seção 9
+ *
+ * Gera 5–10 perguntas combinatórias via LLM com base no perfil da empresa.
+ * Badge laranja "Perfil da empresa". Salva em iagen_answers via completeOnda2.
+ * Ao concluir: navega para /questionario-corporativo-v2.
+ */
+import { useState, useEffect } from "react";
+import { useLocation, useParams } from "wouter";
+import { trpc } from "@/lib/trpc";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { toast } from "sonner";
+import { Brain, ChevronLeft, ChevronRight, Loader2, AlertTriangle, CheckCircle2 } from "lucide-react";
+
+interface Pergunta {
+  id: string;
+  texto: string;
+  objetivo_diagnostico: string;
+  combinacao_gatilho: string;
+  fonte: "ia_gen";
+  confidence_score: number;
+}
+
+export default function QuestionarioIaGen() {
+  const params = useParams<{ id: string }>();
+  const projectId = Number(params.id);
+  const [, setLocation] = useLocation();
+
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [respostas, setRespostas] = useState<Record<string, string>>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Buscar perguntas geradas pela IA
+  const { data, isLoading, error } = trpc.fluxoV3.generateOnda2Questions.useQuery(
+    { projectId },
+    { enabled: !!projectId && !isNaN(projectId) }
+  );
+
+  const perguntas: Pergunta[] = data?.questions ?? [];
+  const source = data?.source ?? "llm";
+  const totalPerguntas = perguntas.length;
+  const perguntaAtual = perguntas[currentIndex];
+  const respondidas = Object.values(respostas).filter((r) => r.trim().length > 0).length;
+  const todasRespondidas = respondidas === totalPerguntas && totalPerguntas > 0;
+  const progresso = totalPerguntas > 0 ? Math.round((respondidas / totalPerguntas) * 100) : 0;
+
+  // Mutation para salvar respostas e avançar status
+  const completeOnda2 = trpc.fluxoV3.completeOnda2.useMutation({
+    onSuccess: () => {
+      toast.success("Onda 2 concluída! Iniciando Questionário Corporativo...");
+      setLocation(`/projetos/${projectId}/questionario-corporativo-v2`);
+    },
+    onError: (err) => {
+      toast.error(err.message ?? "Erro ao concluir Onda 2. Tente novamente.");
+      setIsSubmitting(false);
+    },
+  });
+
+  const handleResposta = (texto: string) => {
+    if (!perguntaAtual) return;
+    setRespostas((prev) => ({ ...prev, [perguntaAtual.id]: texto }));
+  };
+
+  const handleAnterior = () => {
+    if (currentIndex > 0) setCurrentIndex((i) => i - 1);
+  };
+
+  const handleProxima = () => {
+    if (currentIndex < totalPerguntas - 1) setCurrentIndex((i) => i + 1);
+  };
+
+  const handleConcluir = async () => {
+    if (!todasRespondidas) {
+      toast.warning(`Faltam ${totalPerguntas - respondidas} resposta(s) para concluir.`);
+      return;
+    }
+    setIsSubmitting(true);
+    const answers = perguntas.map((p) => ({
+      questionText: p.texto,
+      resposta: respostas[p.id] ?? "",
+      confidenceScore: p.confidence_score,
+    }));
+    completeOnda2.mutate({ projectId, answers });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-background flex flex-col items-center justify-center gap-4">
+        <Loader2 className="h-10 w-10 animate-spin text-orange-500" />
+        <p className="text-muted-foreground text-sm">
+          Gerando perguntas personalizadas com base no perfil da empresa...
+        </p>
+        <p className="text-xs text-muted-foreground">(pode levar até 30 segundos)</p>
+      </div>
+    );
+  }
+
+  if (error || totalPerguntas === 0) {
+    return (
+      <div className="min-h-screen bg-background flex flex-col items-center justify-center gap-4 p-8">
+        <AlertTriangle className="h-10 w-10 text-destructive" />
+        <p className="text-foreground font-medium">Erro ao gerar perguntas</p>
+        <p className="text-muted-foreground text-sm text-center">
+          {error?.message ?? "Nenhuma pergunta foi gerada. Tente novamente."}
+        </p>
+        <Button variant="outline" onClick={() => setLocation(`/projetos/${projectId}`)}>
+          Voltar ao Projeto
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Header */}
+      <div className="border-b bg-card sticky top-0 z-10">
+        <div className="max-w-3xl mx-auto px-4 py-4 flex items-center justify-between">
+          <button
+            onClick={() => setLocation(`/projetos/${projectId}`)}
+            className="flex items-center gap-1 text-muted-foreground hover:text-foreground text-sm transition-colors"
+          >
+            <ChevronLeft className="h-4 w-4" />
+            Voltar ao Projeto
+          </button>
+          <div className="flex flex-col items-center">
+            <div className="flex items-center gap-2">
+              <Brain className="h-5 w-5 text-orange-500" />
+              <span className="font-semibold text-foreground">Questionário IA Generativa</span>
+              <Badge className="bg-orange-100 text-orange-700 border-orange-200 text-xs font-medium">
+                Perfil da empresa
+              </Badge>
+            </div>
+            <span className="text-xs text-muted-foreground mt-0.5">
+              Etapa 2 de 8 — Onda 2
+            </span>
+          </div>
+          <div className="text-sm text-muted-foreground">
+            {respondidas}/{totalPerguntas} respondidas
+          </div>
+        </div>
+
+        {/* Barra de progresso */}
+        <div className="max-w-3xl mx-auto px-4 pb-3">
+          <Progress value={progresso} className="h-1.5" />
+        </div>
+
+        {/* Pills de navegação */}
+        <div className="max-w-3xl mx-auto px-4 pb-3 flex gap-1.5 flex-wrap">
+          {perguntas.map((p, i) => {
+            const respondida = (respostas[p.id] ?? "").trim().length > 0;
+            return (
+              <button
+                key={p.id}
+                onClick={() => setCurrentIndex(i)}
+                className={`w-8 h-8 rounded-full text-xs font-medium transition-colors border ${
+                  i === currentIndex
+                    ? "bg-orange-500 text-white border-orange-500"
+                    : respondida
+                    ? "bg-orange-100 text-orange-700 border-orange-300"
+                    : "bg-background text-muted-foreground border-border hover:border-orange-300"
+                }`}
+              >
+                {i + 1}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Conteúdo */}
+      <div className="max-w-3xl mx-auto px-4 py-8">
+        {/* Aviso de fallback */}
+        {source === "fallback" && (
+          <div className="mb-6 p-3 rounded-lg border border-amber-200 bg-amber-50 flex items-start gap-2">
+            <AlertTriangle className="h-4 w-4 text-amber-600 mt-0.5 shrink-0" />
+            <p className="text-sm text-amber-700">
+              As perguntas foram geradas com base em um modelo padrão (IA indisponível temporariamente).
+            </p>
+          </div>
+        )}
+
+        {/* Card da pergunta atual */}
+        {perguntaAtual && (
+          <div className="border rounded-xl bg-card p-6 shadow-sm">
+            {/* Header da pergunta */}
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center gap-2">
+                <span className="text-xs font-mono font-semibold text-orange-600 bg-orange-50 border border-orange-200 px-2 py-0.5 rounded">
+                  {perguntaAtual.id.toUpperCase()}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {currentIndex + 1}/{totalPerguntas}
+                </span>
+              </div>
+              <span className="text-xs text-muted-foreground">
+                Confiança: {Math.round(perguntaAtual.confidence_score * 100)}%
+              </span>
+            </div>
+
+            {/* Texto da pergunta */}
+            <p className="text-base font-medium text-foreground leading-relaxed mb-6">
+              {perguntaAtual.texto}
+            </p>
+
+            {/* Objetivo diagnóstico */}
+            <p className="text-xs text-muted-foreground mb-4 italic">
+              Objetivo: {perguntaAtual.objetivo_diagnostico}
+            </p>
+
+            {/* Campo de resposta */}
+            <Textarea
+              placeholder="Digite sua resposta aqui..."
+              value={respostas[perguntaAtual.id] ?? ""}
+              onChange={(e) => handleResposta(e.target.value)}
+              className="min-h-[120px] resize-none"
+              autoFocus
+            />
+
+            {(respostas[perguntaAtual.id] ?? "").trim().length > 0 && (
+              <div className="flex items-center gap-1.5 mt-2">
+                <CheckCircle2 className="h-3.5 w-3.5 text-green-500" />
+                <span className="text-xs text-green-600">Resposta registrada</span>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Navegação */}
+        <div className="flex items-center justify-between mt-6">
+          <Button
+            variant="outline"
+            onClick={handleAnterior}
+            disabled={currentIndex === 0}
+            className="flex items-center gap-1"
+          >
+            <ChevronLeft className="h-4 w-4" />
+            Anterior
+          </Button>
+
+          {currentIndex < totalPerguntas - 1 ? (
+            <Button
+              onClick={handleProxima}
+              className="flex items-center gap-1 bg-orange-500 hover:bg-orange-600 text-white"
+            >
+              Próxima
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          ) : (
+            <Button
+              onClick={handleConcluir}
+              disabled={!todasRespondidas || isSubmitting}
+              className="flex items-center gap-2 bg-orange-500 hover:bg-orange-600 text-white"
+            >
+              {isSubmitting ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Salvando...
+                </>
+              ) : (
+                <>
+                  <CheckCircle2 className="h-4 w-4" />
+                  Concluir Onda 2
+                </>
+              )}
+            </Button>
+          )}
+        </div>
+
+        {/* Resumo final */}
+        {todasRespondidas && (
+          <div className="mt-4 p-3 rounded-lg border border-green-200 bg-green-50 flex items-center gap-2">
+            <CheckCircle2 className="h-4 w-4 text-green-600 shrink-0" />
+            <p className="text-sm text-green-700">
+              Todas as {totalPerguntas} perguntas respondidas. Clique em "Concluir Onda 2" para salvar e avançar.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/server/db.ts
+++ b/server/db.ts
@@ -1297,3 +1297,55 @@ export async function countOnda1Answers(projectId: number): Promise<number> {
 
   return Number(result[0]?.count ?? 0);
 }
+
+// ─── Sprint K — K-4-C: Funções de iagen_answers (Onda 2) ─────────────────────
+
+/**
+ * Salva as respostas da Onda 2 (IA Generativa) para um projeto.
+ * Cada item = uma resposta a uma pergunta gerada dinamicamente pela IA.
+ */
+export async function saveOnda2Answers(
+  projectId: number,
+  answers: Array<{ questionText: string; resposta: string; confidenceScore: number }>
+): Promise<void> {
+  const db = await getDb();
+  if (!db) return;
+  const now = Date.now();
+  const rows: InsertIagenAnswer[] = answers.map((a) => ({
+    projectId,
+    questionText: a.questionText,
+    resposta: a.resposta,
+    confidenceScore: String(a.confidenceScore),
+    fonte: "ia_gen",
+    createdAt: now,
+    updatedAt: now,
+  }));
+  if (rows.length > 0) {
+    await db.insert(iagenAnswers).values(rows);
+  }
+}
+
+/**
+ * Busca as respostas da Onda 2 já salvas para um projeto.
+ */
+export async function getOnda2Answers(projectId: number): Promise<IagenAnswer[]> {
+  const db = await getDb();
+  if (!db) return [];
+  return db
+    .select()
+    .from(iagenAnswers)
+    .where(eq(iagenAnswers.projectId, projectId));
+}
+
+/**
+ * Conta quantas respostas da Onda 2 existem para um projeto.
+ */
+export async function countOnda2Answers(projectId: number): Promise<number> {
+  const db = await getDb();
+  if (!db) return 0;
+  const result = await db
+    .select({ count: sql<number>`COUNT(*)` })
+    .from(iagenAnswers)
+    .where(eq(iagenAnswers.projectId, projectId));
+  return Number(result[0]?.count ?? 0);
+}

--- a/server/flowStateMachine.ts
+++ b/server/flowStateMachine.ts
@@ -416,7 +416,7 @@ export function createHistoryEntry(
 export const VALID_TRANSITIONS: Record<string, string[]> = {
   'rascunho':                  ['consistencia_pendente'],  // rascunho → consistência (não pula para Onda 1)
   'onda1_solaris':             ['onda2_iagen', 'rascunho'],
-  'onda2_iagen':               ['diagnostico_corporativo', 'onda1_solaris'],
+  'onda2_iagen':               ['diagnostico_corporativo'],  // K-4-C: sem retrocesso para Onda 1
   'diagnostico_corporativo':   ['diagnostico_operacional', 'onda2_iagen'],
   'diagnostico_operacional':   ['diagnostico_cnae', 'diagnostico_corporativo'],
   'diagnostico_cnae':          ['briefing', 'diagnostico_operacional'],

--- a/server/k4a-schema-statemachine.test.ts
+++ b/server/k4a-schema-statemachine.test.ts
@@ -147,8 +147,8 @@ describe("T-K4A-05: VALID_TRANSITIONS exportado do flowStateMachine", () => {
 
 // ─── T-K4A-06: assertValidTransition aceita transição válida ─────────────────
 describe("T-K4A-06: assertValidTransition aceita transições válidas", () => {
-  it("rascunho → onda1_solaris deve ser válido", () => {
-    expect(() => assertValidTransition("rascunho", "onda1_solaris")).not.toThrow();
+  it("cnaes_confirmados → onda1_solaris deve ser válido (K-4-B fix: rascunho não vai direto para Onda 1)", () => {
+    expect(() => assertValidTransition("cnaes_confirmados", "onda1_solaris")).not.toThrow();
   });
 
   it("onda1_solaris → onda2_iagen deve ser válido", () => {

--- a/server/k4b-onda1-stepper.test.ts
+++ b/server/k4b-onda1-stepper.test.ts
@@ -118,8 +118,8 @@ describe("T-K4B-04: DiagnosticoStepper — Cadeia completa de bloqueio", () => {
 
 // ─── T-K4B-05: VALID_TRANSITIONS — Onda 1 → onda1_solaris ───────────────────
 describe("T-K4B-05: VALID_TRANSITIONS — Onda 1 → onda1_solaris", () => {
-  it("rascunho → onda1_solaris é válido", () => {
-    expect(VALID_TRANSITIONS["rascunho"]).toContain("onda1_solaris");
+  it("cnaes_confirmados → onda1_solaris é válido (K-4-B fix)", () => {
+    expect(VALID_TRANSITIONS["cnaes_confirmados"]).toContain("onda1_solaris");
   });
 
   it("onda1_solaris → onda2_iagen é válido", () => {
@@ -137,8 +137,8 @@ describe("T-K4B-05: VALID_TRANSITIONS — Onda 1 → onda1_solaris", () => {
 
 // ─── T-K4B-06: assertValidTransition — Enforcement Onda 1 ───────────────────
 describe("T-K4B-06: assertValidTransition — Enforcement Onda 1", () => {
-  it("assertValidTransition('rascunho', 'onda1_solaris') não lança erro", () => {
-    expect(() => assertValidTransition("rascunho", "onda1_solaris")).not.toThrow();
+  it("assertValidTransition('cnaes_confirmados', 'onda1_solaris') não lança erro (K-4-B fix)", () => {
+    expect(() => assertValidTransition("cnaes_confirmados", "onda1_solaris")).not.toThrow();
   });
 
   it("assertValidTransition('onda1_solaris', 'onda2_iagen') não lança erro", () => {

--- a/server/k4c-onda2-iagen.test.ts
+++ b/server/k4c-onda2-iagen.test.ts
@@ -1,0 +1,138 @@
+/**
+ * k4c-onda2-iagen.test.ts — Testes K-4-C: Questionário IA Generativa (Onda 2)
+ * Sprint K — FLUXO-3-ONDAS v1.1 Seção 9
+ *
+ * Testa:
+ * T-K4C-01: Schema iagenAnswers tem as colunas obrigatórias
+ * T-K4C-02: Schema iagenAnswers tem confidence_score
+ * T-K4C-03: VALID_TRANSITIONS inclui onda1_solaris → onda2_iagen
+ * T-K4C-04: VALID_TRANSITIONS inclui onda2_iagen → diagnostico_corporativo
+ * T-K4C-05: assertValidTransition bloqueia onda2_iagen → onda1_solaris (retrocesso)
+ * T-K4C-06: assertValidTransition permite onda1_solaris → onda2_iagen
+ * T-K4C-07: assertValidTransition permite onda2_iagen → diagnostico_corporativo
+ * T-K4C-08: Funções de iagen_answers existem no db.ts
+ * T-K4C-09: QuestionarioIaGen.tsx existe no frontend
+ * T-K4C-10: Rota /questionario-iagen está registrada no App.tsx
+ * T-K4C-11: onStartOnda2 está presente no ProjetoDetalhesV2.tsx
+ * T-K4C-12: Regressão K-4-A: cnaes_confirmados → onda1_solaris ainda válido
+ */
+
+import { describe, it, expect } from "vitest";
+import { existsSync } from "fs";
+import { readFileSync } from "fs";
+import path from "path";
+
+// ─── Imports do schema e state machine ───────────────────────────────────────
+import { iagenAnswers } from "../drizzle/schema";
+import { VALID_TRANSITIONS, assertValidTransition } from "./flowStateMachine";
+
+// ─── T-K4C-01: Schema iagenAnswers tem as colunas obrigatórias ───────────────
+describe("T-K4C-01: Schema iagenAnswers — colunas obrigatórias", () => {
+  it("deve ter as colunas id, projectId, questionText, resposta, createdAt", () => {
+    const cols = Object.keys(iagenAnswers);
+    expect(cols).toContain("id");
+    expect(cols).toContain("projectId");
+    expect(cols).toContain("questionText");
+    expect(cols).toContain("resposta");
+    expect(cols).toContain("createdAt");
+  });
+});
+
+// ─── T-K4C-02: Schema iagenAnswers tem confidence_score ──────────────────────
+describe("T-K4C-02: Schema iagenAnswers — confidence_score obrigatório", () => {
+  it("deve ter a coluna confidenceScore (Seção 9 do contrato)", () => {
+    const cols = Object.keys(iagenAnswers);
+    expect(cols).toContain("confidenceScore");
+  });
+});
+
+// ─── T-K4C-03: VALID_TRANSITIONS onda1_solaris → onda2_iagen ─────────────────
+describe("T-K4C-03: VALID_TRANSITIONS — onda1_solaris → onda2_iagen", () => {
+  it("deve permitir transição de onda1_solaris para onda2_iagen", () => {
+    const targets = VALID_TRANSITIONS["onda1_solaris"] ?? [];
+    expect(targets).toContain("onda2_iagen");
+  });
+});
+
+// ─── T-K4C-04: VALID_TRANSITIONS onda2_iagen → diagnostico_corporativo ───────
+describe("T-K4C-04: VALID_TRANSITIONS — onda2_iagen → diagnostico_corporativo", () => {
+  it("deve permitir transição de onda2_iagen para diagnostico_corporativo", () => {
+    const targets = VALID_TRANSITIONS["onda2_iagen"] ?? [];
+    expect(targets).toContain("diagnostico_corporativo");
+  });
+});
+
+// ─── T-K4C-05: assertValidTransition bloqueia retrocesso ─────────────────────
+describe("T-K4C-05: assertValidTransition — bloqueia retrocesso onda2_iagen → onda1_solaris", () => {
+  it("deve lançar erro ao tentar voltar de onda2_iagen para onda1_solaris", () => {
+    expect(() => assertValidTransition("onda2_iagen", "onda1_solaris")).toThrow();
+  });
+});
+
+// ─── T-K4C-06: assertValidTransition permite onda1_solaris → onda2_iagen ─────
+describe("T-K4C-06: assertValidTransition — permite onda1_solaris → onda2_iagen", () => {
+  it("não deve lançar erro para transição válida onda1_solaris → onda2_iagen", () => {
+    expect(() => assertValidTransition("onda1_solaris", "onda2_iagen")).not.toThrow();
+  });
+});
+
+// ─── T-K4C-07: assertValidTransition permite onda2_iagen → diagnostico_corporativo
+describe("T-K4C-07: assertValidTransition — permite onda2_iagen → diagnostico_corporativo", () => {
+  it("não deve lançar erro para transição válida onda2_iagen → diagnostico_corporativo", () => {
+    expect(() => assertValidTransition("onda2_iagen", "diagnostico_corporativo")).not.toThrow();
+  });
+});
+
+// ─── T-K4C-08: Funções de iagen_answers existem no db.ts ─────────────────────
+describe("T-K4C-08: db.ts — funções de iagen_answers", () => {
+  it("deve ter saveOnda2Answers, getOnda2Answers e countOnda2Answers no db.ts", () => {
+    const dbPath = path.resolve(__dirname, "db.ts");
+    const content = readFileSync(dbPath, "utf-8");
+    expect(content).toContain("saveOnda2Answers");
+    expect(content).toContain("getOnda2Answers");
+    expect(content).toContain("countOnda2Answers");
+  });
+});
+
+// ─── T-K4C-09: QuestionarioIaGen.tsx existe no frontend ──────────────────────
+describe("T-K4C-09: QuestionarioIaGen.tsx — arquivo existe", () => {
+  it("deve existir o componente QuestionarioIaGen.tsx", () => {
+    const filePath = path.resolve(
+      __dirname,
+      "../client/src/pages/QuestionarioIaGen.tsx"
+    );
+    expect(existsSync(filePath)).toBe(true);
+  });
+});
+
+// ─── T-K4C-10: Rota /questionario-iagen registrada no App.tsx ────────────────
+describe("T-K4C-10: App.tsx — rota /questionario-iagen registrada", () => {
+  it("deve ter a rota /questionario-iagen no App.tsx", () => {
+    const appPath = path.resolve(__dirname, "../client/src/App.tsx");
+    const content = readFileSync(appPath, "utf-8");
+    expect(content).toContain("questionario-iagen");
+    expect(content).toContain("QuestionarioIaGen");
+  });
+});
+
+// ─── T-K4C-11: onStartOnda2 presente no ProjetoDetalhesV2.tsx ────────────────
+describe("T-K4C-11: ProjetoDetalhesV2.tsx — onStartOnda2 wiring", () => {
+  it("deve ter onStartOnda2 passado ao DiagnosticoStepper", () => {
+    const filePath = path.resolve(
+      __dirname,
+      "../client/src/pages/ProjetoDetalhesV2.tsx"
+    );
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("onStartOnda2");
+    expect(content).toContain("questionario-iagen");
+  });
+});
+
+// ─── T-K4C-12: Regressão K-4-A — cnaes_confirmados → onda1_solaris ───────────
+describe("T-K4C-12: Regressão K-4-A — cnaes_confirmados → onda1_solaris", () => {
+  it("deve manter a transição cnaes_confirmados → onda1_solaris (regressão K-4-A)", () => {
+    const targets = VALID_TRANSITIONS["cnaes_confirmados"] ?? [];
+    expect(targets).toContain("onda1_solaris");
+    expect(targets).not.toContain("diagnostico_corporativo");
+  });
+});

--- a/server/routers-fluxo-v3.ts
+++ b/server/routers-fluxo-v3.ts
@@ -2228,6 +2228,169 @@ Gere o Briefing estruturado em JSON:
         answersCount: input.answers.length,
       };
     }),
+
+  // ─── K-4-C: Onda 2 IA Generativa ──────────────────────────────────────────
+
+  /**
+   * Gera 5–10 perguntas combinatórias via LLM com base no perfil da empresa.
+   * Timeout 30s com fallback obrigatório (5 perguntas hardcoded).
+   * Seção 9 do contrato FLUXO-3-ONDAS v1.1.
+   */
+  generateOnda2Questions: protectedProcedure
+    .input(z.object({ projectId: z.number().int().positive() }))
+    .query(async ({ input, ctx }) => {
+      const project = await db.getProjectById(input.projectId);
+      if (!project) throw new TRPCError({ code: 'NOT_FOUND', message: 'Projeto não encontrado' });
+      const hasAccess = await db.isUserInProject(ctx.user.id, input.projectId);
+      if (!hasAccess && ctx.user.role !== 'equipe_solaris' && ctx.user.role !== 'advogado_senior') {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Sem acesso a este projeto' });
+      }
+
+      // Parâmetros combinatórios (Seção 9)
+      const profile = project.companyProfile as any;
+      const opProfile = project.operationProfile as any;
+      const regime = profile?.taxRegime ?? 'lucro_presumido';
+      const porte = profile?.companySize ?? 'media';
+      const cnaes: string[] = Array.isArray(project.confirmedCnaes) ? project.confirmedCnaes : [];
+      const exportacao = opProfile?.faz_exportacao ?? false;
+      const contrata_simples = opProfile?.contrata_simples_nacional ?? false;
+      const operacao_interestadual = opProfile?.multiState ?? false;
+      const tem_ativo_imobilizado = opProfile?.tem_ativo_imobilizado ?? false;
+
+      // Fallback hardcoded (Seção 9 — 5 perguntas genéricas, confidence_score = 0.5)
+      const FALLBACK_QUESTIONS = [
+        { id: 'ia-gen-001', texto: 'A empresa possui operações com substituição tributária no contexto da Reforma Tributária?', objetivo_diagnostico: 'Identificar impacto da ST no novo regime', combinacao_gatilho: 'Qualquer regime', fonte: 'ia_gen' as const, confidence_score: 0.5 },
+        { id: 'ia-gen-002', texto: 'Qual o percentual estimado de receita sujeita ao IBS/CBS após a transição?', objetivo_diagnostico: 'Dimensionar exposição ao novo tributo', combinacao_gatilho: 'Qualquer regime', fonte: 'ia_gen' as const, confidence_score: 0.5 },
+        { id: 'ia-gen-003', texto: 'A empresa tem créditos acumulados de PIS/COFINS que precisam ser aproveitados antes da transição?', objetivo_diagnostico: 'Gestão de créditos no período de transição', combinacao_gatilho: 'Lucro Real ou Presumido', fonte: 'ia_gen' as const, confidence_score: 0.5 },
+        { id: 'ia-gen-004', texto: 'Existem contratos de longo prazo que precisam de cláusulas de reequilíbrio tributário?', objetivo_diagnostico: 'Risco contratual na transição', combinacao_gatilho: 'Qualquer porte', fonte: 'ia_gen' as const, confidence_score: 0.5 },
+        { id: 'ia-gen-005', texto: 'A empresa possui benefícios fiscais estaduais que podem ser impactados pela unificação do ICMS no IBS?', objetivo_diagnostico: 'Impacto de benefícios fiscais', combinacao_gatilho: 'Operação interestadual', fonte: 'ia_gen' as const, confidence_score: 0.5 },
+      ];
+
+      try {
+        const prompt = `Você é um especialista em Reforma Tributária brasileira (LC 214/2025 e LC 224/2026).
+Gere entre 5 e 10 perguntas diagnósticas combinatórias para uma empresa com o seguinte perfil:
+- Regime tributário: ${regime}
+- Porte: ${porte}
+- CNAEs: ${cnaes.join(', ') || 'não informado'}
+- Operação interestadual: ${operacao_interestadual ? 'Sim' : 'Não'}
+- Faz exportação: ${exportacao ? 'Sim' : 'Não'}
+- Contrata Simples Nacional: ${contrata_simples ? 'Sim' : 'Não'}
+- Tem ativo imobilizado: ${tem_ativo_imobilizado ? 'Sim' : 'Não'}
+
+Regras obrigatórias:
+- Mínimo 5, máximo 10 perguntas
+- NÃO gere perguntas genéricas que se aplicam a qualquer empresa
+- NÃO gere perguntas sobre o que a lei diz
+- CADA pergunta deve ser específica para a combinação de perfil acima
+- confidence_score entre 0.7 e 1.0 para perguntas de alta qualidade`;
+
+        const llmPromise = invokeLLM({
+          messages: [
+            { role: 'system', content: 'Você é um especialista em compliance tributário da Reforma Tributária brasileira. Responda sempre em JSON válido.' },
+            { role: 'user', content: prompt },
+          ],
+          response_format: {
+            type: 'json_schema',
+            json_schema: {
+              name: 'onda2_questions',
+              strict: true,
+              schema: {
+                type: 'object',
+                properties: {
+                  perguntas: {
+                    type: 'array',
+                    items: {
+                      type: 'object',
+                      properties: {
+                        id: { type: 'string' },
+                        texto: { type: 'string' },
+                        objetivo_diagnostico: { type: 'string' },
+                        combinacao_gatilho: { type: 'string' },
+                        fonte: { type: 'string' },
+                        confidence_score: { type: 'number' },
+                      },
+                      required: ['id', 'texto', 'objetivo_diagnostico', 'combinacao_gatilho', 'fonte', 'confidence_score'],
+                      additionalProperties: false,
+                    },
+                  },
+                },
+                required: ['perguntas'],
+                additionalProperties: false,
+              },
+            },
+          },
+        });
+
+        // Timeout 30s (Seção 9)
+        const timeoutPromise = new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error('LLM timeout 30s')), 30_000)
+        );
+
+        const response = await Promise.race([llmPromise, timeoutPromise]);
+        const content = (response as any).choices?.[0]?.message?.content;
+        if (!content) throw new Error('LLM retornou resposta vazia');
+
+        const parsed = JSON.parse(content);
+        const perguntas = parsed.perguntas;
+        if (!Array.isArray(perguntas) || perguntas.length < 5) throw new Error('LLM retornou menos de 5 perguntas');
+
+        const filtered = perguntas
+          .slice(0, 10)
+          .map((p: any, i: number) => ({
+            id: p.id ?? `ia-gen-${String(i + 1).padStart(3, '0')}`,
+            texto: p.texto,
+            objetivo_diagnostico: p.objetivo_diagnostico,
+            combinacao_gatilho: p.combinacao_gatilho,
+            fonte: 'ia_gen' as const,
+            confidence_score: Number(p.confidence_score ?? 0.5),
+          }));
+
+        return { questions: filtered, source: 'llm' as const };
+      } catch (err: any) {
+        // Fallback obrigatório (Seção 9 — logar, não silenciar)
+        console.error('[K-4-C] generateOnda2Questions fallback ativado:', err?.message ?? err);
+        return { questions: FALLBACK_QUESTIONS, source: 'fallback' as const };
+      }
+    }),
+
+  /**
+   * Salva as respostas da Onda 2 e avança o status para onda2_iagen.
+   * Enforcement: assertValidTransition (Seção 8 + Seção 10).
+   */
+  completeOnda2: protectedProcedure
+    .input(z.object({
+      projectId: z.number().int().positive(),
+      answers: z.array(z.object({
+        questionText: z.string().min(1),
+        resposta: z.string().min(1),
+        confidenceScore: z.number().min(0).max(1),
+      })).min(1, 'É necessário responder ao menos uma pergunta'),
+    }))
+    .mutation(async ({ input, ctx }) => {
+      const project = await db.getProjectById(input.projectId);
+      if (!project) throw new TRPCError({ code: 'NOT_FOUND', message: 'Projeto não encontrado' });
+      const hasAccess = await db.isUserInProject(ctx.user.id, input.projectId);
+      if (!hasAccess && ctx.user.role !== 'equipe_solaris' && ctx.user.role !== 'advogado_senior') {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Sem acesso a este projeto' });
+      }
+      const { assertValidTransition } = await import('./flowStateMachine');
+      try {
+        assertValidTransition(project.status, 'onda2_iagen');
+      } catch (err: any) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: `Transição inválida: ${err.message}. Conclua a Onda 1 antes de avançar.`,
+        });
+      }
+      await db.saveOnda2Answers(input.projectId, input.answers);
+      await db.updateProject(input.projectId, { status: 'onda2_iagen' as any });
+      return {
+        success: true,
+        projectId: input.projectId,
+        newStatus: 'onda2_iagen',
+        answersCount: input.answers.length,
+      };
+    }),
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## K-4-C — Onda 2 (IA Generativa)

### Entregáveis
- `QuestionarioIaGen.tsx`: badge laranja, 5-10 perguntas LLM, fallback 30s, salva em `iagen_answers`
- `generateOnda2Questions` + `completeOnda2` com `assertValidTransition`
- Rota `/projetos/:id/questionario-iagen` em `App.tsx`
- `onStartOnda2` wiring em `ProjetoDetalhesV2.tsx`
- `flowStateMachine.ts`: `onda2_iagen` sem retrocesso para `onda1_solaris`
- 12 testes T-K4C-01..12 + correção T-K4A-06, T-K4B-05/06

### Evidência
```json
{"testes": "82/82", "typescript": "0 erros", "migrations": "nenhuma (schema K-4-A)", "label": "p.o.-valida"}
```

### Critério de aceite do P.O.
"Após concluir a Onda 1, clico em Iniciar na Etapa 2, sou levado ao Questionário IA Generativa com badge laranja, vejo 5-10 perguntas geradas com base no perfil da minha empresa, consigo responder e avançar para o Questionário Corporativo."

Closes #[issue K-4-C]