### PR TITLE
feat(k4-d): wiring etapas 7-8 no stepper + fix T06.1 [clean]

### DIFF
--- a/client/src/components/DiagnosticoStepper.tsx
+++ b/client/src/components/DiagnosticoStepper.tsx
@@ -70,6 +70,10 @@ interface DiagnosticoStepperProps {
   onStartOnda2?: () => void;
   /** Callback ao clicar em "Gerar Briefing" */
   onGenerateBriefing?: () => void;
+  /** Callback ao clicar em "Iniciar" Etapa 7 — Matrizes de Risco (K-4-D) */
+  onStartMatrizes?: () => void;
+  /** Callback ao clicar em "Iniciar" Etapa 8 — Plano de Ação (K-4-D) */
+  onStartPlano?: () => void;
   /** Status do projeto (para derivar estado das ondas) */
   projectStatus?: string;
   /** Se true, desabilita todos os botões (loading state) */
@@ -375,6 +379,8 @@ export function DiagnosticoStepper({
   onStartOnda1,
   onStartOnda2,
   onGenerateBriefing,
+  onStartMatrizes,
+  onStartPlano,
   projectStatus,
   isLoading = false,
   className,
@@ -410,10 +416,10 @@ export function DiagnosticoStepper({
         onGenerateBriefing?.();
         break;
       case "matrizes":
-        // K-4-D — placeholder
+        onStartMatrizes?.(); // K-4-D
         break;
       case "plano":
-        // K-4-D — placeholder
+        onStartPlano?.(); // K-4-D
         break;
     }
   }

--- a/client/src/pages/ProjetoDetalhesV2.tsx
+++ b/client/src/pages/ProjetoDetalhesV2.tsx
@@ -476,6 +476,8 @@ export default function ProjetoDetalhesV2() {
                 onGenerateBriefing={() => {
                   setLocation(`/projetos/${projectId}/briefing-v3`);
                 }}
+                onStartMatrizes={() => setLocation(`/projetos/${projectId}/matrizes-v3`)}
+                onStartPlano={() => setLocation(`/projetos/${projectId}/plano-v3`)}
               />
             </CardContent>
           </Card>

--- a/server/onda1-t06-t10.test.ts
+++ b/server/onda1-t06-t10.test.ts
@@ -106,12 +106,14 @@ async function saveQuestionnaireAnswer(projectId: number, cnaeCode: string, ques
 describe("T06 — Regressão de rotas legadas (regression suite)", () => {
 
   it("T06.1 — rota /questionario-v3 não deve ser o destino após confirmação de CNAEs", () => {
+    // K-4-B alterou o fluxo: após confirmar CNAEs, navega para /questionario-solaris (Onda 1)
+    // antes de /questionario-corporativo-v2. Assertion atualizada em K-4-D.
     const fs = require("fs");
     const novoProjeto = fs.readFileSync(
       "/home/ubuntu/compliance-tributaria-v2/client/src/pages/NovoProjeto.tsx",
       "utf-8"
     );
-    expect(novoProjeto).toContain("questionario-corporativo-v2");
+    expect(novoProjeto).toContain("questionario-solaris"); // K-4-B: Onda 1 é o destino após CNAEs
     const legacyRouteInOnSuccess = /onSuccess[^}]*questionario-v3/.test(novoProjeto);
     expect(legacyRouteInOnSuccess).toBe(false);
   });


### PR DESCRIPTION
## Objetivo
Conectar as etapas 7 (Matrizes de Risco) e 8 (Plano de Ação) do DiagnosticoStepper ao fluxo real de navegação. Corrigir teste T06.1 que estava falhando desde K-4-B.

> **Substitui PR #183** — fechado por conflito em `client/public/__manus__/version.json` (artefato interno do Manus, mesmo padrão dos PRs #173, #177 e #179). Branch limpo via cherry-pick de `ff3438d` a partir do `main` atual do GitHub.

## Escopo (3 arquivos — zero alterações fora do escopo)
- `client/src/components/DiagnosticoStepper.tsx` — interface + handleStepStart
- `client/src/pages/ProjetoDetalhesV2.tsx` — wiring dos callbacks
- `server/onda1-t06-t10.test.ts` — correção T06.1

## Classificação de risco
**LOW** — alterações puramente de wiring (callbacks opcionais). Nenhuma lógica de negócio, nenhuma migration, nenhum endpoint novo.

## Validação executada

```json
{
  "typescript": "0 erros (npx tsc --noEmit)",
  "testes_t06": "36/36 passando (T06.1 corrigido)",
  "risk_level": "low",
  "branch": "feat/k4-d-clean",
  "cherry_pick_de": "ff3438d",
  "arquivos_alterados": 3,
  "linhas_adicionadas": 13,
  "linhas_removidas": 3,
  "conflitos": 0
}
```

## Critério de aceite do P.O.
> "Clicar em Iniciar na Etapa 7 navega para /matrizes-v3. Clicar em Iniciar na Etapa 8 navega para /plano-v3."

## Rastreabilidade
- Substitui: PR #183 (fechado — conflito em version.json)
- Cherry-pick de: `ff3438d` (branch `feat/k4-d`)
- Classificação: K-4-D — Sprint K — Milestone M2