### PR TITLE
fix(risks-v4): pool.promise().execute() — corrige (intermediate value) is not iterable

### DIFF
--- a/server/lib/db-queries-risks-v4.ts
+++ b/server/lib/db-queries-risks-v4.ts
@@ -204,7 +204,9 @@ async function query<T = unknown>(
   params: unknown[] = []
 ): Promise<T[]> {
   const db = await getDb();
-  const [rows] = await (db.$client as any).execute(sql, params);
+  // TiDB/MySQL2: $client é um Pool — precisa de .promise() para API baseada em Promise.
+  // Sem .promise(), .execute() usa callbacks e não é iterável (fix/pool-execute-risks-v4).
+  const [rows] = await (db.$client as any).promise().execute(sql, params);
   return rows as T[];
 }
 


### PR DESCRIPTION
## Causa Raiz

O erro `(intermediate value) is not iterable` ocorria em `db-queries-risks-v4.ts` na funcao `query()`.

O `db.$client` do drizzle-orm/mysql2 e um Pool do MySQL2. O metodo `.execute()` direto usa callbacks (nao retorna Promise iteravel). E necessario chamar `.promise()` primeiro.

## Fix

```ts
// Antes
const [rows] = await (db.$client as any).execute(sql, params);

// Depois
const [rows] = await (db.$client as any).promise().execute(sql, params);
```

## Gate

- pnpm tsc --noEmit: 0 erros
- Tabelas confirmadas: risks_v4, action_plans, audit_log
- ADR-0022 respeitado: apenas 1 arquivo alterado

## Evidencia JSON

```json
{"pr": "fix/pool-execute-risks-v4", "fix": "pool.promise().execute()", "tsc": "0 erros", "tabelas": ["risks_v4", "action_plans", "audit_log"]}
```