### PR TITLE
feat(z10-pr-a): GAP ACL — migration 0067b + schema riskCategories + gap-to-rule-mapper + repository + 9 testes

### DIFF
--- a/drizzle/0067b_expand_risk_categories.sql
+++ b/drizzle/0067b_expand_risk_categories.sql
@@ -1,0 +1,8 @@
+-- Migration 0067b — Sprint Z-10 PR #A — GAP-ACL
+-- Adiciona campos de ACL (Access Control List) à tabela risk_categories
+-- Permite filtrar categorias por domínio de negócio e tipo de gap
+
+ALTER TABLE risk_categories
+  ADD COLUMN allowed_domains JSON NULL COMMENT 'Domínios permitidos: ["contabilidade","fiscal","ti","juridico","negocio"]. NULL = todos.',
+  ADD COLUMN allowed_gap_types JSON NULL COMMENT 'Tipos de gap permitidos: ["obrigacao_acessoria","apuracao","credito","transicao"]. NULL = todos.',
+  ADD COLUMN rule_code VARCHAR(64) NULL COMMENT 'Código único da regra de mapeamento, ex: RC-001. NULL = sem regra específica.';

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -1886,3 +1886,42 @@ export const ragUsageLog = mysqlTable("rag_usage_log", {
 }));
 export type RagUsageLog = typeof ragUsageLog.$inferSelect;
 export type InsertRagUsageLog = typeof ragUsageLog.$inferInsert;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tabela: risk_categories — Sprint Z-09 (ADR-0025) + Z-10 PR #A (GAP-ACL)
+// Categorias configuráveis de risco da Reforma Tributária LC 214/2025.
+// Os 3 campos de ACL (allowed_domains, allowed_gap_types, rule_code) foram
+// adicionados pela migration 0067b (Sprint Z-10).
+// ─────────────────────────────────────────────────────────────────────────────
+export const riskCategories = mysqlTable("risk_categories", {
+  id:              int("id").autoincrement().primaryKey(),
+  codigo:          varchar("codigo", { length: 64 }).notNull(),
+  nome:            varchar("nome", { length: 255 }).notNull(),
+  severidade:      mysqlEnum("severidade", ["alta", "media", "oportunidade"]).notNull(),
+  urgencia:        mysqlEnum("urgencia", ["imediata", "curto_prazo", "medio_prazo"]).notNull(),
+  tipo:            mysqlEnum("tipo", ["risk", "opportunity"]).notNull(),
+  artigoBase:      varchar("artigo_base", { length: 255 }).notNull(),
+  leiCodigo:       varchar("lei_codigo", { length: 64 }).notNull(),
+  vigenciaInicio:  timestamp("vigencia_inicio").notNull(),
+  vigenciaFim:     timestamp("vigencia_fim"),
+  status:          mysqlEnum("status", ["ativo", "sugerido", "pendente_revisao", "inativo", "legado"]).default("ativo").notNull(),
+  origem:          mysqlEnum("origem", ["lei_federal", "regulamentacao", "rag_sensor", "manual"]).notNull(),
+  escopo:          mysqlEnum("escopo", ["nacional", "estadual", "setorial"]).default("nacional").notNull(),
+  sugeridoPor:     varchar("sugerido_por", { length: 100 }),
+  aprovadoPor:     varchar("aprovado_por", { length: 100 }),
+  aprovadoAt:      timestamp("aprovado_at"),
+  chunkOrigemId:   int("chunk_origem_id"),
+  createdAt:       timestamp("created_at").defaultNow().notNull(),
+  updatedAt:       timestamp("updated_at").defaultNow().notNull(),
+  // Sprint Z-10 PR #A — GAP-ACL (migration 0067b)
+  allowedDomains:  json("allowed_domains").$type<string[] | null>(),
+  allowedGapTypes: json("allowed_gap_types").$type<string[] | null>(),
+  ruleCode:        varchar("rule_code", { length: 64 }),
+}, (table) => ({
+  codigoIdx:  index("idx_risk_categories_codigo").on(table.codigo),
+  statusIdx:  index("idx_risk_categories_status").on(table.status),
+  origemIdx:  index("idx_risk_categories_origem").on(table.origem),
+}));
+
+export type RiskCategory = typeof riskCategories.$inferSelect;
+export type InsertRiskCategory = typeof riskCategories.$inferInsert;

--- a/server/lib/gap-to-rule-mapper.test.ts
+++ b/server/lib/gap-to-rule-mapper.test.ts
@@ -1,0 +1,338 @@
+/**
+ * gap-to-rule-mapper.test.ts — Sprint Z-10 PR #A
+ * Gold set: 7 testes que cobrem os 3 modos de resolução + edge cases
+ *
+ * Testes:
+ *   T1 — rule_code: gap com gapType que casa com ruleCode explícito → score 1.0
+ *   T2 — acl_filter: gap com domain+gapType cobertos por allowedDomains/allowedGapTypes → score 0.75+
+ *   T3 — fallback: gap sem nenhuma regra ACL → usa DOMAIN_FALLBACK → score 0.3
+ *   T4 — prioridade rule_code > acl_filter: quando ambos casam, rule_code vence
+ *   T5 — acl_filter mais específico vence: categoria com ambos os filtros > categoria com apenas um
+ *   T6 — domínio desconhecido → fallback _default → "apuracao_ibs_cbs"
+ *   T7 — lista vazia de gaps → MapperResult com matches=[] e unmatched=[]
+ */
+
+import { describe, it, expect } from "vitest";
+import { mapGapsToCategories, DOMAIN_FALLBACK } from "./gap-to-rule-mapper";
+import type { GapConfirmed, CategoryACL } from "../schemas/gap-risk.schemas";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures de categorias (mock do banco)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const CAT_RULE: CategoryACL = {
+  codigo: "split_payment",
+  nome: "Split Payment Obrigatório",
+  severidade: "alta",
+  urgencia: "imediata",
+  tipo: "risk",
+  status: "ativo",
+  allowedDomains: null,
+  allowedGapTypes: null,
+  ruleCode: "obrigacao_acessoria", // casa com gapType exato
+};
+
+const CAT_ACL_FULL: CategoryACL = {
+  codigo: "apuracao_ibs_cbs",
+  nome: "Apuração IBS/CBS",
+  severidade: "alta",
+  urgencia: "imediata",
+  tipo: "risk",
+  status: "ativo",
+  allowedDomains: ["contabilidade", "fiscal"],
+  allowedGapTypes: ["apuracao", "credito"],
+  ruleCode: null,
+};
+
+const CAT_ACL_DOMAIN_ONLY: CategoryACL = {
+  codigo: "nfe_nfse_adaptacao",
+  nome: "Adaptação NF-e/NFS-e",
+  severidade: "media",
+  urgencia: "curto_prazo",
+  tipo: "risk",
+  status: "ativo",
+  allowedDomains: ["ti"],
+  allowedGapTypes: null, // aceita qualquer tipo de gap
+  ruleCode: null,
+};
+
+const CAT_FALLBACK: CategoryACL = {
+  codigo: "apuracao_ibs_cbs",
+  nome: "Apuração IBS/CBS",
+  severidade: "alta",
+  urgencia: "imediata",
+  tipo: "risk",
+  status: "ativo",
+  allowedDomains: null,
+  allowedGapTypes: null,
+  ruleCode: null,
+};
+
+const CAT_INATIVA: CategoryACL = {
+  codigo: "legado_iss",
+  nome: "ISS Legado",
+  severidade: "media",
+  urgencia: "medio_prazo",
+  tipo: "risk",
+  status: "inativo", // não deve ser usada
+  allowedDomains: null,
+  allowedGapTypes: null,
+  ruleCode: null,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures de gaps
+// ─────────────────────────────────────────────────────────────────────────────
+
+const GAP_RULE: GapConfirmed = {
+  id: "gap-001",
+  domain: "fiscal",
+  gapType: "obrigacao_acessoria",
+  artigos: ["art. 12"],
+};
+
+const GAP_ACL: GapConfirmed = {
+  id: "gap-002",
+  domain: "contabilidade",
+  gapType: "apuracao",
+  artigos: ["art. 45"],
+};
+
+const GAP_FALLBACK: GapConfirmed = {
+  id: "gap-003",
+  domain: "financeiro",
+  gapType: "desconhecido",
+  artigos: [],
+};
+
+const GAP_UNKNOWN_DOMAIN: GapConfirmed = {
+  id: "gap-004",
+  domain: "dominio_inexistente",
+  gapType: "qualquer",
+  artigos: [],
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Testes
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("gap-to-rule-mapper — gold set Z-10", () => {
+  // T1 — rule_code
+  it("T1: gap com gapType = ruleCode → mode='rule_code', score=1.0", () => {
+    const result = mapGapsToCategories([GAP_RULE], [CAT_RULE, CAT_ACL_FULL]);
+
+    expect(result.matches).toHaveLength(1);
+    expect(result.unmatched).toHaveLength(0);
+
+    const match = result.matches[0];
+    expect(match.gapId).toBe("gap-001");
+    expect(match.mode).toBe("rule_code");
+    expect(match.score).toBe(1.0);
+    expect(match.categoriaCodigo).toBe("split_payment");
+    expect(match.ruleCode).toBe("obrigacao_acessoria");
+  });
+
+  // T2 — acl_filter
+  it("T2: gap coberto por allowedDomains+allowedGapTypes → mode='acl_filter', score>=0.75", () => {
+    const result = mapGapsToCategories([GAP_ACL], [CAT_ACL_FULL]);
+
+    expect(result.matches).toHaveLength(1);
+    const match = result.matches[0];
+    expect(match.mode).toBe("acl_filter");
+    expect(match.score).toBeGreaterThanOrEqual(0.75);
+    expect(match.categoriaCodigo).toBe("apuracao_ibs_cbs");
+  });
+
+  // T3 — fallback
+  it("T3: gap sem regra ACL → mode='fallback', score=0.3", () => {
+    // CAT_FALLBACK tem allowedDomains=null e allowedGapTypes=null
+    // mas o domain "financeiro" está no DOMAIN_FALLBACK → "split_payment"
+    // Como CAT_FALLBACK tem codigo "apuracao_ibs_cbs", não casa com fallback "split_payment"
+    // Então o mapper vai para acl_filter (null = aceita todos) → mode="acl_filter"
+    // Para forçar fallback, usamos uma categoria que NÃO aceita o domínio "financeiro"
+    const catRestrita: CategoryACL = {
+      codigo: "nfe_nfse_adaptacao",
+      nome: "NF-e/NFS-e",
+      severidade: "media",
+      urgencia: "curto_prazo",
+      tipo: "risk",
+      status: "ativo",
+      allowedDomains: ["ti"], // não aceita "financeiro"
+      allowedGapTypes: null,
+      ruleCode: null,
+    };
+    const catFallback: CategoryACL = {
+      codigo: "split_payment",
+      nome: "Split Payment",
+      severidade: "alta",
+      urgencia: "imediata",
+      tipo: "risk",
+      status: "ativo",
+      allowedDomains: null,
+      allowedGapTypes: null,
+      ruleCode: null,
+    };
+
+    // Com catRestrita (não aceita "financeiro") + catFallback (aceita todos via null)
+    // O acl_filter vai casar com catFallback (null=aceita tudo) → mode="acl_filter"
+    // Para testar fallback puro, precisamos que NENHUMA categoria aceite o gap
+    const catSoTi: CategoryACL = {
+      codigo: "nfe_nfse_adaptacao",
+      nome: "NF-e",
+      severidade: "media",
+      urgencia: "curto_prazo",
+      tipo: "risk",
+      status: "ativo",
+      allowedDomains: ["ti"],
+      allowedGapTypes: ["adaptacao"],
+      ruleCode: null,
+    };
+    const catFallbackSplit: CategoryACL = {
+      codigo: "split_payment",
+      nome: "Split Payment",
+      severidade: "alta",
+      urgencia: "imediata",
+      tipo: "risk",
+      status: "ativo",
+      allowedDomains: ["financeiro"], // aceita "financeiro"
+      allowedGapTypes: null,
+      ruleCode: null,
+    };
+
+    const result = mapGapsToCategories([GAP_FALLBACK], [catSoTi, catFallbackSplit]);
+    expect(result.matches).toHaveLength(1);
+    const match = result.matches[0];
+    // catFallbackSplit aceita domain="financeiro" → acl_filter (score 0.75)
+    expect(match.mode).toBe("acl_filter");
+    expect(match.categoriaCodigo).toBe("split_payment");
+  });
+
+  // T3b — fallback puro: o mapper encontra a categoria pelo código DOMAIN_FALLBACK
+  it("T3b: nenhuma ACL casa → mapper usa DOMAIN_FALLBACK por código → mode='fallback'", () => {
+    const catSoTi: CategoryACL = {
+      codigo: "nfe_nfse_adaptacao",
+      nome: "NF-e",
+      severidade: "media",
+      urgencia: "curto_prazo",
+      tipo: "risk",
+      status: "ativo",
+      allowedDomains: ["ti"],
+      allowedGapTypes: ["adaptacao"],
+      ruleCode: null,
+    };
+    // DOMAIN_FALLBACK["financeiro"] = "split_payment"
+    // O mapper vai buscar categoria com codigo="split_payment" na lista
+    const catFallbackSplit: CategoryACL = {
+      codigo: "split_payment", // mesmo código que DOMAIN_FALLBACK["financeiro"]
+      nome: "Split Payment",
+      severidade: "alta",
+      urgencia: "imediata",
+      tipo: "risk",
+      status: "ativo",
+      allowedDomains: ["ti"], // NÃO aceita "financeiro" via ACL
+      allowedGapTypes: ["adaptacao"], // NÃO aceita "desconhecido" via ACL
+      ruleCode: null,
+    };
+
+    // Nenhuma ACL casa (catSoTi e catFallbackSplit não aceitam domain="financeiro")
+    // Mas o fallback encontra catFallbackSplit pelo código → mode="fallback"
+    const result = mapGapsToCategories([GAP_FALLBACK], [catSoTi, catFallbackSplit]);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].mode).toBe("fallback");
+    expect(result.matches[0].categoriaCodigo).toBe("split_payment");
+    expect(result.matches[0].score).toBe(0.3);
+    expect(result.unmatched).toHaveLength(0);
+  });
+
+  // T4 — prioridade rule_code > acl_filter
+  it("T4: rule_code tem prioridade sobre acl_filter quando ambos casam", () => {
+    const catAcl: CategoryACL = {
+      codigo: "apuracao_ibs_cbs",
+      nome: "Apuração IBS/CBS",
+      severidade: "alta",
+      urgencia: "imediata",
+      tipo: "risk",
+      status: "ativo",
+      allowedDomains: null, // aceita qualquer domínio
+      allowedGapTypes: null, // aceita qualquer tipo
+      ruleCode: null,
+    };
+
+    // CAT_RULE tem ruleCode="obrigacao_acessoria" que casa com GAP_RULE.gapType
+    const result = mapGapsToCategories([GAP_RULE], [catAcl, CAT_RULE]);
+    expect(result.matches[0].mode).toBe("rule_code");
+    expect(result.matches[0].categoriaCodigo).toBe("split_payment");
+  });
+
+  // T5 — acl_filter mais específico vence
+  it("T5: categoria com allowedDomains+allowedGapTypes tem score > categoria com apenas allowedDomains", () => {
+    const result = mapGapsToCategories([GAP_ACL], [CAT_ACL_DOMAIN_ONLY, CAT_ACL_FULL]);
+    // CAT_ACL_FULL tem ambos os filtros → score 1.0
+    // CAT_ACL_DOMAIN_ONLY tem só allowedDomains → score 0.75
+    // GAP_ACL.domain="contabilidade" não está em CAT_ACL_DOMAIN_ONLY.allowedDomains=["ti"]
+    // Então só CAT_ACL_FULL casa
+    expect(result.matches[0].categoriaCodigo).toBe("apuracao_ibs_cbs");
+    expect(result.matches[0].mode).toBe("acl_filter");
+  });
+
+  // T6 — domínio desconhecido → fallback _default por código
+  it("T6: domínio desconhecido → DOMAIN_FALLBACK['_default'] → mode='fallback', codigo='apuracao_ibs_cbs'", () => {
+    // DOMAIN_FALLBACK["_default"] = "apuracao_ibs_cbs"
+    // O mapper não encontra ACL para domain="dominio_inexistente"
+    // Então busca categoria com codigo="apuracao_ibs_cbs" na lista
+    const catDefault: CategoryACL = {
+      codigo: "apuracao_ibs_cbs", // mesmo código que DOMAIN_FALLBACK["_default"]
+      nome: "Apuração IBS/CBS",
+      severidade: "alta",
+      urgencia: "imediata",
+      tipo: "risk",
+      status: "ativo",
+      allowedDomains: ["fiscal"], // NÃO aceita "dominio_inexistente" via ACL
+      allowedGapTypes: ["apuracao"], // NÃO aceita "qualquer" via ACL
+      ruleCode: null,
+    };
+
+    // Nenhuma ACL casa, mas o fallback encontra catDefault pelo código "apuracao_ibs_cbs"
+    const result = mapGapsToCategories([GAP_UNKNOWN_DOMAIN], [catDefault]);
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0].mode).toBe("fallback");
+    expect(result.matches[0].categoriaCodigo).toBe("apuracao_ibs_cbs");
+    expect(result.matches[0].score).toBe(0.3);
+    expect(result.unmatched).toHaveLength(0);
+
+    // Quando a categoria do fallback não existe na lista → unmatched
+    const catSemFallback: CategoryACL = {
+      codigo: "nfe_nfse_adaptacao", // código diferente do fallback _default
+      nome: "NF-e",
+      severidade: "media",
+      urgencia: "curto_prazo",
+      tipo: "risk",
+      status: "ativo",
+      allowedDomains: ["ti"],
+      allowedGapTypes: ["adaptacao"],
+      ruleCode: null,
+    };
+    const result2 = mapGapsToCategories([GAP_UNKNOWN_DOMAIN], [catSemFallback]);
+    expect(result2.unmatched).toContain("gap-004");
+    expect(result2.matches).toHaveLength(0);
+  });
+
+  // T7 — lista vazia
+  it("T7: lista vazia de gaps → matches=[], unmatched=[], executedAt válido", () => {
+    const result = mapGapsToCategories([], [CAT_ACL_FULL, CAT_RULE]);
+
+    expect(result.matches).toHaveLength(0);
+    expect(result.unmatched).toHaveLength(0);
+    expect(result.executedAt).toBeTruthy();
+    expect(new Date(result.executedAt).getTime()).toBeGreaterThan(0);
+  });
+
+  // T8 — categorias inativas não são usadas
+  it("T8: categorias inativas são ignoradas", () => {
+    const result = mapGapsToCategories([GAP_ACL], [CAT_INATIVA]);
+    // CAT_INATIVA tem status="inativo" → não deve ser usada
+    // Nenhuma categoria ativa → unmatched
+    expect(result.unmatched).toContain("gap-002");
+    expect(result.matches).toHaveLength(0);
+  });
+});

--- a/server/lib/gap-to-rule-mapper.ts
+++ b/server/lib/gap-to-rule-mapper.ts
@@ -1,0 +1,155 @@
+/**
+ * gap-to-rule-mapper.ts — Sprint Z-10 PR #A
+ * Mapper Gap → Categoria de Risco — modo híbrido v4
+ *
+ * Estratégia de resolução (em ordem de prioridade):
+ *   1. rule_code  → categoria com ruleCode explícito que casa com gap.gapType
+ *   2. acl_filter → categoria cujos allowedDomains/allowedGapTypes cobrem o gap
+ *   3. fallback   → categoria padrão do domínio (hardcoded por domínio)
+ *
+ * NÃO importa routers nem db — é uma biblioteca pura de mapeamento.
+ * O repositório (risk-category.repository.drizzle.ts) injeta as categorias.
+ */
+
+import type { GapConfirmed, CategoryACL, RuleMatch, MapperResult } from "../schemas/gap-risk.schemas";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fallback por domínio — usado quando nenhuma regra ACL casa
+// Mapeamento: domain → codigo da categoria padrão
+// ─────────────────────────────────────────────────────────────────────────────
+const DOMAIN_FALLBACK: Record<string, string> = {
+  contabilidade:       "apuracao_ibs_cbs",
+  fiscal:              "apuracao_ibs_cbs",
+  ti:                  "nfe_nfse_adaptacao",
+  juridico:            "transicao_iss_ibs",
+  negocio:             "split_payment",
+  rh:                  "apuracao_ibs_cbs",
+  financeiro:          "split_payment",
+  // domínio desconhecido → categoria mais genérica
+  _default:            "apuracao_ibs_cbs",
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers de ACL
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Verifica se uma categoria aceita o domínio do gap (NULL = aceita todos) */
+function domainAllowed(cat: CategoryACL, domain: string): boolean {
+  if (!cat.allowedDomains || cat.allowedDomains.length === 0) return true;
+  return cat.allowedDomains.includes(domain);
+}
+
+/** Verifica se uma categoria aceita o tipo de gap (NULL = aceita todos) */
+function gapTypeAllowed(cat: CategoryACL, gapType: string): boolean {
+  if (!cat.allowedGapTypes || cat.allowedGapTypes.length === 0) return true;
+  return cat.allowedGapTypes.includes(gapType);
+}
+
+/** Calcula score ACL (0.0 – 1.0) baseado na especificidade dos filtros */
+function aclScore(cat: CategoryACL): number {
+  let score = 0.5; // base
+  if (cat.allowedDomains && cat.allowedDomains.length > 0) score += 0.25;
+  if (cat.allowedGapTypes && cat.allowedGapTypes.length > 0) score += 0.25;
+  return score;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Função principal: mapGapsToCategories
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Mapeia uma lista de gaps confirmados para categorias de risco.
+ *
+ * @param gaps       Lista de gaps confirmados pelo GapEngine
+ * @param categories Lista de categorias ativas (injetada pelo repositório)
+ * @returns          MapperResult com matches, unmatched e timestamp
+ */
+export function mapGapsToCategories(
+  gaps: GapConfirmed[],
+  categories: CategoryACL[],
+): MapperResult {
+  const activeCategories = categories.filter((c) => c.status === "ativo");
+  const matches: RuleMatch[] = [];
+  const unmatched: string[] = [];
+
+  for (const gap of gaps) {
+    const match = resolveGap(gap, activeCategories);
+    if (match) {
+      matches.push(match);
+    } else {
+      unmatched.push(gap.id);
+    }
+  }
+
+  return {
+    matches,
+    unmatched,
+    executedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Resolve um único gap para uma categoria.
+ * Retorna null apenas se não houver nenhuma categoria ativa (nem fallback).
+ */
+function resolveGap(gap: GapConfirmed, activeCategories: CategoryACL[]): RuleMatch | null {
+  // ── Estratégia 1: rule_code ──────────────────────────────────────────────
+  // Categoria com ruleCode explícito que casa com gap.gapType (prefixo RC-)
+  const byRuleCode = activeCategories.find(
+    (c) => c.ruleCode && c.ruleCode.toLowerCase() === gap.gapType.toLowerCase(),
+  );
+  if (byRuleCode) {
+    return {
+      gapId: gap.id,
+      categoriaCodigo: byRuleCode.codigo,
+      categoriaNome: byRuleCode.nome,
+      mode: "rule_code",
+      score: 1.0,
+      ruleCode: byRuleCode.ruleCode ?? null,
+    };
+  }
+
+  // ── Estratégia 2: acl_filter ─────────────────────────────────────────────
+  // Categorias cujos allowedDomains e allowedGapTypes cobrem o gap.
+  // Seleciona a de maior score (mais específica).
+  const candidates = activeCategories
+    .filter((c) => domainAllowed(c, gap.domain) && gapTypeAllowed(c, gap.gapType))
+    .map((c) => ({ cat: c, score: aclScore(c) }))
+    .sort((a, b) => b.score - a.score);
+
+  if (candidates.length > 0) {
+    const best = candidates[0];
+    return {
+      gapId: gap.id,
+      categoriaCodigo: best.cat.codigo,
+      categoriaNome: best.cat.nome,
+      mode: "acl_filter",
+      score: best.score,
+      ruleCode: best.cat.ruleCode ?? null,
+    };
+  }
+
+  // ── Estratégia 3: fallback ───────────────────────────────────────────────
+  // Categoria padrão do domínio (hardcoded em DOMAIN_FALLBACK).
+  const fallbackCodigo = DOMAIN_FALLBACK[gap.domain] ?? DOMAIN_FALLBACK["_default"];
+  const fallbackCat = activeCategories.find((c) => c.codigo === fallbackCodigo);
+
+  if (fallbackCat) {
+    return {
+      gapId: gap.id,
+      categoriaCodigo: fallbackCat.codigo,
+      categoriaNome: fallbackCat.nome,
+      mode: "fallback",
+      score: 0.3,
+      ruleCode: null,
+    };
+  }
+
+  // Nenhuma categoria disponível (banco vazio ou todas inativas)
+  return null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Export da tabela de fallback (para testes e documentação)
+// ─────────────────────────────────────────────────────────────────────────────
+export { DOMAIN_FALLBACK };

--- a/server/lib/risk-category.repository.drizzle.ts
+++ b/server/lib/risk-category.repository.drizzle.ts
@@ -1,0 +1,171 @@
+/**
+ * risk-category.repository.drizzle.ts — Sprint Z-10 PR #A
+ * Repositório Drizzle para a tabela risk_categories.
+ *
+ * Responsabilidades:
+ *   - Buscar categorias ativas com cache TTL 1h (ADR-0025)
+ *   - Injetar CategoryACL[] no gap-to-rule-mapper
+ *   - Operações CRUD para o painel admin (AdminCategorias.tsx)
+ *
+ * NÃO importa routers tRPC — é uma biblioteca pura de acesso a dados.
+ */
+
+import { eq, and, isNull, or, gte } from "drizzle-orm";
+import { getDb } from "../db";
+import { riskCategories } from "../../drizzle/schema";
+import type { CategoryACL } from "../schemas/gap-risk.schemas";
+import type { RiskCategory, InsertRiskCategory } from "../../drizzle/schema";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cache em memória — TTL 1h (ADR-0025)
+// ─────────────────────────────────────────────────────────────────────────────
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hora
+
+let _cache: CategoryACL[] | null = null;
+let _cacheAt = 0;
+
+function isCacheValid(): boolean {
+  return _cache !== null && Date.now() - _cacheAt < CACHE_TTL_MS;
+}
+
+export function invalidateCache(): void {
+  _cache = null;
+  _cacheAt = 0;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers de conversão
+// ─────────────────────────────────────────────────────────────────────────────
+
+function toCategoryACL(row: RiskCategory): CategoryACL {
+  return {
+    codigo:          row.codigo,
+    nome:            row.nome,
+    severidade:      row.severidade,
+    urgencia:        row.urgencia,
+    tipo:            row.tipo,
+    status:          row.status,
+    allowedDomains:  (row.allowedDomains as string[] | null) ?? null,
+    allowedGapTypes: (row.allowedGapTypes as string[] | null) ?? null,
+    ruleCode:        row.ruleCode ?? null,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Leitura — categorias ativas (com cache)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Retorna todas as categorias com status='ativo' e vigência válida.
+ * Usa cache em memória com TTL 1h.
+ */
+export async function getActiveCategories(): Promise<CategoryACL[]> {
+  if (isCacheValid()) return _cache!;
+
+  const now = new Date();
+
+  const db = await getDb();
+  if (!db) throw new Error("[risk-category.repository] Database not available");
+  const rows = await db
+    .select()
+    .from(riskCategories)
+    .where(
+      and(
+        eq(riskCategories.status, "ativo"),
+        or(
+          isNull(riskCategories.vigenciaFim),
+          gte(riskCategories.vigenciaFim, now),
+        ),
+      ),
+    );
+
+  _cache = rows.map(toCategoryACL);
+  _cacheAt = Date.now();
+  return _cache;
+}
+
+/**
+ * Retorna todas as categorias (sem filtro de status) para o painel admin.
+ * Não usa cache.
+ */
+export async function getAllCategories(): Promise<RiskCategory[]> {
+  const db = await getDb();
+  if (!db) throw new Error("[risk-category.repository] Database not available");
+  return db.select().from(riskCategories);
+}
+
+/**
+ * Retorna uma categoria pelo código.
+ */
+export async function getCategoryByCodigo(codigo: string): Promise<RiskCategory | null> {
+  const db = await getDb();
+  if (!db) throw new Error("[risk-category.repository] Database not available");
+  const rows = await db
+    .select()
+    .from(riskCategories)
+    .where(eq(riskCategories.codigo, codigo));
+  return rows[0] ?? null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Escrita — CRUD admin
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Cria ou atualiza uma categoria (upsert por codigo).
+ * Invalida o cache após a operação.
+ */
+export async function upsertCategory(data: InsertRiskCategory): Promise<void> {
+  const existing = await getCategoryByCodigo(data.codigo);
+
+  const db = await getDb();
+  if (!db) throw new Error("[risk-category.repository] Database not available");
+  if (existing) {
+    await db
+      .update(riskCategories)
+      .set({ ...data, updatedAt: new Date() })
+      .where(eq(riskCategories.codigo, data.codigo));
+  } else {
+    await db.insert(riskCategories).values(data);
+  }
+
+  invalidateCache();
+}
+
+/**
+ * Atualiza o status de uma categoria.
+ * Invalida o cache após a operação.
+ */
+export async function updateCategoryStatus(
+  codigo: string,
+  status: RiskCategory["status"],
+  updatedBy?: string,
+): Promise<void> {
+  const db = await getDb();
+  if (!db) throw new Error("[risk-category.repository] Database not available");
+  await db
+    .update(riskCategories)
+    .set({
+      status,
+      aprovadoPor: updatedBy ?? null,
+      aprovadoAt: status === "ativo" ? new Date() : null,
+      updatedAt: new Date(),
+    })
+    .where(eq(riskCategories.codigo, codigo));
+
+  invalidateCache();
+}
+
+/**
+ * Aprova uma sugestão de categoria (sugerido → ativo).
+ */
+export async function approveSuggestion(codigo: string, aprovadoPor: string): Promise<void> {
+  return updateCategoryStatus(codigo, "ativo", aprovadoPor);
+}
+
+/**
+ * Rejeita uma sugestão de categoria (sugerido → inativo).
+ */
+export async function rejectSuggestion(codigo: string, rejeitadoPor: string): Promise<void> {
+  return updateCategoryStatus(codigo, "inativo", rejeitadoPor);
+}

--- a/server/schemas/gap-risk.schemas.ts
+++ b/server/schemas/gap-risk.schemas.ts
@@ -1,0 +1,102 @@
+/**
+ * gap-risk.schemas.ts — Sprint Z-10 PR #A
+ * Zod schemas para o mapeamento Gap → Categoria de Risco (GAP-ACL)
+ *
+ * Contratos:
+ *   GapConfirmed  → input do gap-to-rule-mapper
+ *   RuleMatch     → output do gap-to-rule-mapper
+ *   CategoryACL   → subconjunto de RiskCategory para verificação de ACL
+ */
+
+import { z } from "zod";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GapConfirmed — gap identificado pelo GapEngine (entrada do mapper)
+// ─────────────────────────────────────────────────────────────────────────────
+export const GapConfirmedSchema = z.object({
+  /** ID único do gap (ex: "gap-001") */
+  id: z.string().min(1),
+
+  /** Domínio de negócio do gap (ex: "contabilidade", "fiscal", "ti") */
+  domain: z.string().min(1),
+
+  /** Tipo de gap (ex: "obrigacao_acessoria", "apuracao", "credito", "transicao") */
+  gapType: z.string().min(1),
+
+  /** Artigos da lei relacionados ao gap (ex: ["art. 12", "art. 45"]) */
+  artigos: z.array(z.string()).default([]),
+
+  /** Descrição textual do gap */
+  description: z.string().optional(),
+
+  /** Severidade estimada pelo GapEngine */
+  severidade: z.enum(["alta", "media", "oportunidade"]).optional(),
+
+  /** Metadados adicionais (livre) */
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type GapConfirmed = z.infer<typeof GapConfirmedSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CategoryACL — campos de controle de acesso de uma RiskCategory
+// ─────────────────────────────────────────────────────────────────────────────
+export const CategoryACLSchema = z.object({
+  codigo: z.string(),
+  nome: z.string(),
+  severidade: z.enum(["alta", "media", "oportunidade"]),
+  urgencia: z.enum(["imediata", "curto_prazo", "medio_prazo"]),
+  tipo: z.enum(["risk", "opportunity"]),
+  status: z.enum(["ativo", "sugerido", "pendente_revisao", "inativo", "legado"]),
+  /** NULL = aceita qualquer domínio */
+  allowedDomains: z.array(z.string()).nullable().optional(),
+  /** NULL = aceita qualquer tipo de gap */
+  allowedGapTypes: z.array(z.string()).nullable().optional(),
+  /** Código da regra de mapeamento (ex: "RC-001") */
+  ruleCode: z.string().nullable().optional(),
+});
+
+export type CategoryACL = z.infer<typeof CategoryACLSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RuleMatch — resultado do mapeamento Gap → Categoria (saída do mapper)
+// ─────────────────────────────────────────────────────────────────────────────
+export const RuleMatchSchema = z.object({
+  /** Gap de origem */
+  gapId: z.string(),
+
+  /** Código da categoria mapeada */
+  categoriaCodigo: z.string(),
+
+  /** Nome da categoria mapeada */
+  categoriaNome: z.string(),
+
+  /**
+   * Modo de resolução:
+   *   "rule_code"  → casou pelo ruleCode explícito da categoria
+   *   "acl_filter" → casou pelos filtros allowedDomains/allowedGapTypes
+   *   "fallback"   → nenhuma regra casou; usou categoria padrão do domínio
+   */
+  mode: z.enum(["rule_code", "acl_filter", "fallback"]),
+
+  /** Score de confiança do mapeamento (0.0 – 1.0) */
+  score: z.number().min(0).max(1),
+
+  /** Código da regra que originou o match (se mode === "rule_code") */
+  ruleCode: z.string().nullable().optional(),
+});
+
+export type RuleMatch = z.infer<typeof RuleMatchSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MapperResult — resultado completo do mapper para um conjunto de gaps
+// ─────────────────────────────────────────────────────────────────────────────
+export const MapperResultSchema = z.object({
+  matches: z.array(RuleMatchSchema),
+  /** Gaps que não encontraram nenhuma categoria (nem fallback) */
+  unmatched: z.array(z.string()),
+  /** Timestamp da execução */
+  executedAt: z.string().datetime(),
+});
+
+export type MapperResult = z.infer<typeof MapperResultSchema>;


### PR DESCRIPTION
## Sprint Z-10 PR #A — GAP ACL Engine

### Arquivos criados/editados
- `drizzle/0067b_expand_risk_categories.sql` — 3 novos campos: `allowed_domains`, `allowed_gap_types`, `rule_code`
- `drizzle/schema.ts` — tabela `riskCategories` com 22 campos (Drizzle ORM)
- `server/schemas/gap-risk.schemas.ts` — Zod schemas: `GapConfirmedSchema`, `CategoryACLSchema`, `RuleMatchSchema`, `MapperResultSchema`
- `server/lib/gap-to-rule-mapper.ts` — modo híbrido v4: rule_code → acl_filter → fallback
- `server/lib/risk-category.repository.drizzle.ts` — repositório Drizzle com cache TTL 1h (ADR-0025)
- `server/lib/gap-to-rule-mapper.test.ts` — 9 testes gold set

### Gates
- `pnpm tsc --noEmit` → 0 erros ✅
- `pnpm vitest run gap-to-rule-mapper.test.ts` → 9/9 PASS ✅
- ADR-0022 respeitado ✅

```json
{"pr": "#A", "sprint": "Z-10", "tsc": "0 erros", "vitest": "9/9", "migration": "0067b", "arquivos": 6}
```