### PR TITLE
fix(z10): gap-to-rule-mapper ACL determinística — sem DOMAIN_FALLBACK

### DIFF
--- a/server/lib/gap-to-rule-mapper.test.ts
+++ b/server/lib/gap-to-rule-mapper.test.ts
@@ -1,338 +1,211 @@
 /**
- * gap-to-rule-mapper.test.ts — Sprint Z-10 PR #A
- * Gold set: 7 testes que cobrem os 3 modos de resolução + edge cases
+ * gap-to-rule-mapper.test.ts — Sprint Z-10 Gold Set (7 testes)
  *
- * Testes:
- *   T1 — rule_code: gap com gapType que casa com ruleCode explícito → score 1.0
- *   T2 — acl_filter: gap com domain+gapType cobertos por allowedDomains/allowedGapTypes → score 0.75+
- *   T3 — fallback: gap sem nenhuma regra ACL → usa DOMAIN_FALLBACK → score 0.3
- *   T4 — prioridade rule_code > acl_filter: quando ambos casam, rule_code vence
- *   T5 — acl_filter mais específico vence: categoria com ambos os filtros > categoria com apenas um
- *   T6 — domínio desconhecido → fallback _default → "apuracao_ibs_cbs"
- *   T7 — lista vazia de gaps → MapperResult com matches=[] e unmatched=[]
+ * Testes unitários para o ACL Gap→GapRule v2 (classe GapToRuleMapper).
+ * Não requer banco — usa resolver mockado.
+ *
+ * PROIBIDO nos testes: score, confidence, ranking, fallback por domínio.
  */
 
-import { describe, it, expect } from "vitest";
-import { mapGapsToCategories, DOMAIN_FALLBACK } from "./gap-to-rule-mapper";
-import type { GapConfirmed, CategoryACL } from "../schemas/gap-risk.schemas";
+import { describe, it, expect, vi } from "vitest";
+import {
+  GapToRuleMapper,
+  type CategoryResolver,
+} from "./gap-to-rule-mapper";
+import type { GapInput, CategoryACL } from "../schemas/gap-risk.schemas";
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Fixtures de categorias (mock do banco)
-// ─────────────────────────────────────────────────────────────────────────────
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
-const CAT_RULE: CategoryACL = {
-  codigo: "split_payment",
-  nome: "Split Payment Obrigatório",
-  severidade: "alta",
-  urgencia: "imediata",
-  tipo: "risk",
-  status: "ativo",
-  allowedDomains: null,
-  allowedGapTypes: null,
-  ruleCode: "obrigacao_acessoria", // casa com gapType exato
-};
+function makeGap(overrides: Partial<GapInput> = {}): GapInput {
+  return {
+    id: "GAP-001",
+    canonicalId: "CAN-001",
+    gapStatus: "nao_compliant",
+    gapSeverity: "alta",
+    gapType: "ausencia",
+    area: "fiscal",
+    descricao: "Gap de teste",
+    categoria: undefined,
+    sourceOrigin: "cnae",
+    requirementId: "REQ-001",
+    sourceReference: "Art. 9 LC 214/2025",
+    domain: "fiscal",
+    ...overrides,
+  };
+}
 
-const CAT_ACL_FULL: CategoryACL = {
-  codigo: "apuracao_ibs_cbs",
-  nome: "Apuração IBS/CBS",
-  severidade: "alta",
-  urgencia: "imediata",
-  tipo: "risk",
-  status: "ativo",
-  allowedDomains: ["contabilidade", "fiscal"],
-  allowedGapTypes: ["apuracao", "credito"],
-  ruleCode: null,
-};
+function makeCat(overrides: Partial<CategoryACL> = {}): CategoryACL {
+  return {
+    codigo: "split_payment",
+    nome: "Split Payment",
+    severidade: "alta",
+    urgencia: "imediata",
+    tipo: "risk",
+    status: "ativo",
+    allowedDomains: null,
+    allowedGapTypes: null,
+    ruleCode: null,
+    ...overrides,
+  };
+}
 
-const CAT_ACL_DOMAIN_ONLY: CategoryACL = {
-  codigo: "nfe_nfse_adaptacao",
-  nome: "Adaptação NF-e/NFS-e",
-  severidade: "media",
-  urgencia: "curto_prazo",
-  tipo: "risk",
-  status: "ativo",
-  allowedDomains: ["ti"],
-  allowedGapTypes: null, // aceita qualquer tipo de gap
-  ruleCode: null,
-};
+function makeResolver(
+  overrides: Partial<CategoryResolver> = {},
+): CategoryResolver {
+  return {
+    findByCodigo: vi.fn().mockResolvedValue(undefined),
+    findByArticle: vi.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
 
-const CAT_FALLBACK: CategoryACL = {
-  codigo: "apuracao_ibs_cbs",
-  nome: "Apuração IBS/CBS",
-  severidade: "alta",
-  urgencia: "imediata",
-  tipo: "risk",
-  status: "ativo",
-  allowedDomains: null,
-  allowedGapTypes: null,
-  ruleCode: null,
-};
+// ═══════════════════════════════════════════════════════════════════════════
+// Gold Set — 7 testes (spec Z-10 aprovada)
+// ═══════════════════════════════════════════════════════════════════════════
 
-const CAT_INATIVA: CategoryACL = {
-  codigo: "legado_iss",
-  nome: "ISS Legado",
-  severidade: "media",
-  urgencia: "medio_prazo",
-  tipo: "risk",
-  status: "inativo", // não deve ser usada
-  allowedDomains: null,
-  allowedGapTypes: null,
-  ruleCode: null,
-};
+describe("Gap-to-Rule Mapper v2 — Gold Set Z-10", () => {
+  // ─── T1: categoria explícita válida → mapped ──────────────────────────
+  it("T1: gap com categoria explícita válida em risk_categories → mapped", async () => {
+    const cat = makeCat({ codigo: "split_payment", status: "ativo" });
+    const resolver = makeResolver({
+      findByCodigo: vi.fn().mockResolvedValue(cat),
+    });
+    const mapper = new GapToRuleMapper(resolver);
+    const gap = makeGap({ id: "GAP-T1", categoria: "split_payment" });
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Fixtures de gaps
-// ─────────────────────────────────────────────────────────────────────────────
+    const result = await mapper.mapOne(gap);
 
-const GAP_RULE: GapConfirmed = {
-  id: "gap-001",
-  domain: "fiscal",
-  gapType: "obrigacao_acessoria",
-  artigos: ["art. 12"],
-};
-
-const GAP_ACL: GapConfirmed = {
-  id: "gap-002",
-  domain: "contabilidade",
-  gapType: "apuracao",
-  artigos: ["art. 45"],
-};
-
-const GAP_FALLBACK: GapConfirmed = {
-  id: "gap-003",
-  domain: "financeiro",
-  gapType: "desconhecido",
-  artigos: [],
-};
-
-const GAP_UNKNOWN_DOMAIN: GapConfirmed = {
-  id: "gap-004",
-  domain: "dominio_inexistente",
-  gapType: "qualquer",
-  artigos: [],
-};
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Testes
-// ─────────────────────────────────────────────────────────────────────────────
-
-describe("gap-to-rule-mapper — gold set Z-10", () => {
-  // T1 — rule_code
-  it("T1: gap com gapType = ruleCode → mode='rule_code', score=1.0", () => {
-    const result = mapGapsToCategories([GAP_RULE], [CAT_RULE, CAT_ACL_FULL]);
-
-    expect(result.matches).toHaveLength(1);
-    expect(result.unmatched).toHaveLength(0);
-
-    const match = result.matches[0];
-    expect(match.gapId).toBe("gap-001");
-    expect(match.mode).toBe("rule_code");
-    expect(match.score).toBe(1.0);
-    expect(match.categoriaCodigo).toBe("split_payment");
-    expect(match.ruleCode).toBe("obrigacao_acessoria");
+    expect(result.status).toBe("mapped");
+    expect(result.categoria).toBe("split_payment");
+    expect(result.reason).toContain("explicit");
   });
 
-  // T2 — acl_filter
-  it("T2: gap coberto por allowedDomains+allowedGapTypes → mode='acl_filter', score>=0.75", () => {
-    const result = mapGapsToCategories([GAP_ACL], [CAT_ACL_FULL]);
+  // ─── T2: categoria explícita inválida → unmapped ──────────────────────
+  it("T2: gap com categoria explícita inexistente/inativa → unmapped (DEC-Z10-06)", async () => {
+    const resolver = makeResolver({
+      findByCodigo: vi.fn().mockResolvedValue(undefined),
+    });
+    const mapper = new GapToRuleMapper(resolver);
+    const gap = makeGap({ id: "GAP-T2", categoria: "categoria_fantasma" });
 
-    expect(result.matches).toHaveLength(1);
-    const match = result.matches[0];
-    expect(match.mode).toBe("acl_filter");
-    expect(match.score).toBeGreaterThanOrEqual(0.75);
-    expect(match.categoriaCodigo).toBe("apuracao_ibs_cbs");
+    const result = await mapper.mapOne(gap);
+
+    expect(result.status).toBe("unmapped");
+    expect(result.categoria).toBeNull();
+    expect(result.reason).toContain("explicit_not_found");
   });
 
-  // T3 — fallback
-  it("T3: gap sem regra ACL → mode='fallback', score=0.3", () => {
-    // CAT_FALLBACK tem allowedDomains=null e allowedGapTypes=null
-    // mas o domain "financeiro" está no DOMAIN_FALLBACK → "split_payment"
-    // Como CAT_FALLBACK tem codigo "apuracao_ibs_cbs", não casa com fallback "split_payment"
-    // Então o mapper vai para acl_filter (null = aceita todos) → mode="acl_filter"
-    // Para forçar fallback, usamos uma categoria que NÃO aceita o domínio "financeiro"
-    const catRestrita: CategoryACL = {
-      codigo: "nfe_nfse_adaptacao",
-      nome: "NF-e/NFS-e",
-      severidade: "media",
-      urgencia: "curto_prazo",
-      tipo: "risk",
-      status: "ativo",
-      allowedDomains: ["ti"], // não aceita "financeiro"
-      allowedGapTypes: null,
-      ruleCode: null,
-    };
-    const catFallback: CategoryACL = {
+  // ─── T3: artigo com 1 candidato → mapped ─────────────────────────────
+  it("T3: artigo com exatamente 1 candidato em risk_categories → mapped", async () => {
+    const cat = makeCat({
       codigo: "split_payment",
-      nome: "Split Payment",
-      severidade: "alta",
-      urgencia: "imediata",
-      tipo: "risk",
       status: "ativo",
-      allowedDomains: null,
-      allowedGapTypes: null,
-      ruleCode: null,
-    };
+    });
+    const resolver = makeResolver({
+      findByArticle: vi.fn().mockResolvedValue([cat]),
+    });
+    const mapper = new GapToRuleMapper(resolver);
+    const gap = makeGap({
+      id: "GAP-T3",
+      categoria: undefined,
+      sourceReference: "Art. 9 LC 214/2025",
+    });
 
-    // Com catRestrita (não aceita "financeiro") + catFallback (aceita todos via null)
-    // O acl_filter vai casar com catFallback (null=aceita tudo) → mode="acl_filter"
-    // Para testar fallback puro, precisamos que NENHUMA categoria aceite o gap
-    const catSoTi: CategoryACL = {
-      codigo: "nfe_nfse_adaptacao",
-      nome: "NF-e",
-      severidade: "media",
-      urgencia: "curto_prazo",
-      tipo: "risk",
-      status: "ativo",
-      allowedDomains: ["ti"],
-      allowedGapTypes: ["adaptacao"],
-      ruleCode: null,
-    };
-    const catFallbackSplit: CategoryACL = {
-      codigo: "split_payment",
-      nome: "Split Payment",
-      severidade: "alta",
-      urgencia: "imediata",
-      tipo: "risk",
-      status: "ativo",
-      allowedDomains: ["financeiro"], // aceita "financeiro"
-      allowedGapTypes: null,
-      ruleCode: null,
-    };
+    const result = await mapper.mapOne(gap);
 
-    const result = mapGapsToCategories([GAP_FALLBACK], [catSoTi, catFallbackSplit]);
-    expect(result.matches).toHaveLength(1);
-    const match = result.matches[0];
-    // catFallbackSplit aceita domain="financeiro" → acl_filter (score 0.75)
-    expect(match.mode).toBe("acl_filter");
-    expect(match.categoriaCodigo).toBe("split_payment");
+    expect(result.status).toBe("mapped");
+    expect(result.categoria).toBe("split_payment");
+    expect(result.reason).toContain("article");
   });
 
-  // T3b — fallback puro: o mapper encontra a categoria pelo código DOMAIN_FALLBACK
-  it("T3b: nenhuma ACL casa → mapper usa DOMAIN_FALLBACK por código → mode='fallback'", () => {
-    const catSoTi: CategoryACL = {
-      codigo: "nfe_nfse_adaptacao",
-      nome: "NF-e",
-      severidade: "media",
-      urgencia: "curto_prazo",
-      tipo: "risk",
-      status: "ativo",
-      allowedDomains: ["ti"],
-      allowedGapTypes: ["adaptacao"],
-      ruleCode: null,
-    };
-    // DOMAIN_FALLBACK["financeiro"] = "split_payment"
-    // O mapper vai buscar categoria com codigo="split_payment" na lista
-    const catFallbackSplit: CategoryACL = {
-      codigo: "split_payment", // mesmo código que DOMAIN_FALLBACK["financeiro"]
-      nome: "Split Payment",
-      severidade: "alta",
-      urgencia: "imediata",
-      tipo: "risk",
-      status: "ativo",
-      allowedDomains: ["ti"], // NÃO aceita "financeiro" via ACL
-      allowedGapTypes: ["adaptacao"], // NÃO aceita "desconhecido" via ACL
-      ruleCode: null,
-    };
+  // ─── T4: artigo com 2 candidatos → ambiguous (NÃO mapped) ────────────
+  it("T4: artigo com 2+ candidatos → ambiguous, NUNCA mapped", async () => {
+    const cat1 = makeCat({ codigo: "obrigacao_acessoria" });
+    const cat2 = makeCat({ codigo: "regime_diferenciado" });
+    const resolver = makeResolver({
+      findByArticle: vi.fn().mockResolvedValue([cat1, cat2]),
+    });
+    const mapper = new GapToRuleMapper(resolver);
+    const gap = makeGap({
+      id: "GAP-T4",
+      categoria: undefined,
+      sourceReference: "Art. 102 LC 214/2025",
+    });
 
-    // Nenhuma ACL casa (catSoTi e catFallbackSplit não aceitam domain="financeiro")
-    // Mas o fallback encontra catFallbackSplit pelo código → mode="fallback"
-    const result = mapGapsToCategories([GAP_FALLBACK], [catSoTi, catFallbackSplit]);
-    expect(result.matches).toHaveLength(1);
-    expect(result.matches[0].mode).toBe("fallback");
-    expect(result.matches[0].categoriaCodigo).toBe("split_payment");
-    expect(result.matches[0].score).toBe(0.3);
-    expect(result.unmatched).toHaveLength(0);
+    const result = await mapper.mapOne(gap);
+
+    expect(result.status).toBe("ambiguous");
+    expect(result.status).not.toBe("mapped");
+    expect(result.categoria).toBeNull();
+    expect(result.reason).toContain("ambiguous");
   });
 
-  // T4 — prioridade rule_code > acl_filter
-  it("T4: rule_code tem prioridade sobre acl_filter quando ambos casam", () => {
-    const catAcl: CategoryACL = {
-      codigo: "apuracao_ibs_cbs",
-      nome: "Apuração IBS/CBS",
-      severidade: "alta",
-      urgencia: "imediata",
-      tipo: "risk",
+  // ─── T5: artigo sem candidato → unmapped ──────────────────────────────
+  it("T5: artigo sem nenhum candidato em risk_categories → unmapped", async () => {
+    const resolver = makeResolver({
+      findByArticle: vi.fn().mockResolvedValue([]),
+    });
+    const mapper = new GapToRuleMapper(resolver);
+    const gap = makeGap({
+      id: "GAP-T5",
+      categoria: undefined,
+      sourceReference: "Art. 999 LC 214/2025",
+    });
+
+    const result = await mapper.mapOne(gap);
+
+    expect(result.status).toBe("unmapped");
+    expect(result.categoria).toBeNull();
+    expect(result.reason).toContain("article_not_found");
+  });
+
+  // ─── T6: sem source_origin + allowLayerInference=false → unmapped ─────
+  it("T6: gap sem categoria, sem artigo, allowLayerInference=false → unmapped", async () => {
+    const resolver = makeResolver();
+    const mapper = new GapToRuleMapper(resolver, {
+      allowLayerInference: false,
+    });
+    const gap = makeGap({
+      id: "GAP-T6",
+      categoria: undefined,
+      sourceOrigin: undefined,
+      sourceReference: undefined,
+    });
+
+    const result = await mapper.mapOne(gap);
+
+    expect(result.status).toBe("unmapped");
+    expect(result.categoria).toBeNull();
+    expect(result.reason).toContain("unmapped");
+  });
+
+  // ─── T7: allowLayerInference=true + layer=onda2 → fonte=iagen ────────
+  it("T7: allowLayerInference=true + layer=onda2 + artigo 1 candidato → mapped com fonte=iagen", async () => {
+    const cat = makeCat({
+      codigo: "confissao_automatica",
       status: "ativo",
-      allowedDomains: null, // aceita qualquer domínio
-      allowedGapTypes: null, // aceita qualquer tipo
-      ruleCode: null,
-    };
+    });
+    const resolver = makeResolver({
+      findByArticle: vi.fn().mockResolvedValue([cat]),
+    });
+    const mapper = new GapToRuleMapper(resolver, {
+      allowLayerInference: true,
+    });
+    const gap = makeGap({
+      id: "GAP-T7",
+      categoria: undefined,
+      sourceOrigin: undefined,
+      sourceReference: "Art. 45 LC 214/2025",
+      layer: "onda2",
+    });
 
-    // CAT_RULE tem ruleCode="obrigacao_acessoria" que casa com GAP_RULE.gapType
-    const result = mapGapsToCategories([GAP_RULE], [catAcl, CAT_RULE]);
-    expect(result.matches[0].mode).toBe("rule_code");
-    expect(result.matches[0].categoriaCodigo).toBe("split_payment");
-  });
+    const result = await mapper.mapMany([gap]);
 
-  // T5 — acl_filter mais específico vence
-  it("T5: categoria com allowedDomains+allowedGapTypes tem score > categoria com apenas allowedDomains", () => {
-    const result = mapGapsToCategories([GAP_ACL], [CAT_ACL_DOMAIN_ONLY, CAT_ACL_FULL]);
-    // CAT_ACL_FULL tem ambos os filtros → score 1.0
-    // CAT_ACL_DOMAIN_ONLY tem só allowedDomains → score 0.75
-    // GAP_ACL.domain="contabilidade" não está em CAT_ACL_DOMAIN_ONLY.allowedDomains=["ti"]
-    // Então só CAT_ACL_FULL casa
-    expect(result.matches[0].categoriaCodigo).toBe("apuracao_ibs_cbs");
-    expect(result.matches[0].mode).toBe("acl_filter");
-  });
-
-  // T6 — domínio desconhecido → fallback _default por código
-  it("T6: domínio desconhecido → DOMAIN_FALLBACK['_default'] → mode='fallback', codigo='apuracao_ibs_cbs'", () => {
-    // DOMAIN_FALLBACK["_default"] = "apuracao_ibs_cbs"
-    // O mapper não encontra ACL para domain="dominio_inexistente"
-    // Então busca categoria com codigo="apuracao_ibs_cbs" na lista
-    const catDefault: CategoryACL = {
-      codigo: "apuracao_ibs_cbs", // mesmo código que DOMAIN_FALLBACK["_default"]
-      nome: "Apuração IBS/CBS",
-      severidade: "alta",
-      urgencia: "imediata",
-      tipo: "risk",
-      status: "ativo",
-      allowedDomains: ["fiscal"], // NÃO aceita "dominio_inexistente" via ACL
-      allowedGapTypes: ["apuracao"], // NÃO aceita "qualquer" via ACL
-      ruleCode: null,
-    };
-
-    // Nenhuma ACL casa, mas o fallback encontra catDefault pelo código "apuracao_ibs_cbs"
-    const result = mapGapsToCategories([GAP_UNKNOWN_DOMAIN], [catDefault]);
-    expect(result.matches).toHaveLength(1);
-    expect(result.matches[0].mode).toBe("fallback");
-    expect(result.matches[0].categoriaCodigo).toBe("apuracao_ibs_cbs");
-    expect(result.matches[0].score).toBe(0.3);
-    expect(result.unmatched).toHaveLength(0);
-
-    // Quando a categoria do fallback não existe na lista → unmatched
-    const catSemFallback: CategoryACL = {
-      codigo: "nfe_nfse_adaptacao", // código diferente do fallback _default
-      nome: "NF-e",
-      severidade: "media",
-      urgencia: "curto_prazo",
-      tipo: "risk",
-      status: "ativo",
-      allowedDomains: ["ti"],
-      allowedGapTypes: ["adaptacao"],
-      ruleCode: null,
-    };
-    const result2 = mapGapsToCategories([GAP_UNKNOWN_DOMAIN], [catSemFallback]);
-    expect(result2.unmatched).toContain("gap-004");
-    expect(result2.matches).toHaveLength(0);
-  });
-
-  // T7 — lista vazia
-  it("T7: lista vazia de gaps → matches=[], unmatched=[], executedAt válido", () => {
-    const result = mapGapsToCategories([], [CAT_ACL_FULL, CAT_RULE]);
-
-    expect(result.matches).toHaveLength(0);
-    expect(result.unmatched).toHaveLength(0);
-    expect(result.executedAt).toBeTruthy();
-    expect(new Date(result.executedAt).getTime()).toBeGreaterThan(0);
-  });
-
-  // T8 — categorias inativas não são usadas
-  it("T8: categorias inativas são ignoradas", () => {
-    const result = mapGapsToCategories([GAP_ACL], [CAT_INATIVA]);
-    // CAT_INATIVA tem status="inativo" → não deve ser usada
-    // Nenhuma categoria ativa → unmatched
-    expect(result.unmatched).toContain("gap-002");
-    expect(result.matches).toHaveLength(0);
+    expect(result.stats.mapped).toBe(1);
+    expect(result.mappedRules).toHaveLength(1);
+    expect(result.mappedRules[0].categoria).toBe("confissao_automatica");
+    expect(result.mappedRules[0].fonte).toBe("iagen");
   });
 });

--- a/server/lib/gap-to-rule-mapper.ts
+++ b/server/lib/gap-to-rule-mapper.ts
@@ -1,155 +1,277 @@
 /**
- * gap-to-rule-mapper.ts — Sprint Z-10 PR #A
- * Mapper Gap → Categoria de Risco — modo híbrido v4
+ * gap-to-rule-mapper.ts — Sprint Z-10 / ACL Gap→Risk v2
  *
- * Estratégia de resolução (em ordem de prioridade):
- *   1. rule_code  → categoria com ruleCode explícito que casa com gap.gapType
- *   2. acl_filter → categoria cujos allowedDomains/allowedGapTypes cobrem o gap
- *   3. fallback   → categoria padrão do domínio (hardcoded por domínio)
+ * Anti-Corruption Layer: traduz Gap (compliance operacional) em GapRule (normativo).
  *
- * NÃO importa routers nem db — é uma biblioteca pura de mapeamento.
- * O repositório (risk-category.repository.drizzle.ts) injeta as categorias.
+ * Lei central do produto:
+ *   1 candidato  → mapped
+ *   2+ candidatos → ambiguous
+ *   0 candidatos  → unmapped
+ *
+ * PROIBIDO: score, confidence, ranking, fallback por domínio, "melhor candidato".
+ * PROIBIDO: DOMAIN_FALLBACK, sort(...)[0], qualquer heurística de seleção.
+ *
+ * allowLayerInference=true só pode inferir source_origin (fonte), NUNCA categoria.
  */
 
-import type { GapConfirmed, CategoryACL, RuleMatch, MapperResult } from "../schemas/gap-risk.schemas";
+import type {
+  GapInput,
+  GapMappingResult,
+  MapGapsToRulesResult,
+  CategoryACL,
+} from "../schemas/gap-risk.schemas";
+import type { GapRule } from "./risk-engine-v4";
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Fallback por domínio — usado quando nenhuma regra ACL casa
-// Mapeamento: domain → codigo da categoria padrão
-// ─────────────────────────────────────────────────────────────────────────────
-const DOMAIN_FALLBACK: Record<string, string> = {
-  contabilidade:       "apuracao_ibs_cbs",
-  fiscal:              "apuracao_ibs_cbs",
-  ti:                  "nfe_nfse_adaptacao",
-  juridico:            "transicao_iss_ibs",
-  negocio:             "split_payment",
-  rh:                  "apuracao_ibs_cbs",
-  financeiro:          "split_payment",
-  // domínio desconhecido → categoria mais genérica
-  _default:            "apuracao_ibs_cbs",
-};
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Helpers de ACL
-// ─────────────────────────────────────────────────────────────────────────────
-
-/** Verifica se uma categoria aceita o domínio do gap (NULL = aceita todos) */
-function domainAllowed(cat: CategoryACL, domain: string): boolean {
-  if (!cat.allowedDomains || cat.allowedDomains.length === 0) return true;
-  return cat.allowedDomains.includes(domain);
+export interface MapperOptions {
+  allowLayerInference?: boolean;
 }
 
-/** Verifica se uma categoria aceita o tipo de gap (NULL = aceita todos) */
-function gapTypeAllowed(cat: CategoryACL, gapType: string): boolean {
-  if (!cat.allowedGapTypes || cat.allowedGapTypes.length === 0) return true;
-  return cat.allowedGapTypes.includes(gapType);
+export interface CategoryResolver {
+  findByCodigo(codigo: string): Promise<CategoryACL | undefined>;
+  findByArticle(normalizedArticle: string): Promise<CategoryACL[]>;
 }
 
-/** Calcula score ACL (0.0 – 1.0) baseado na especificidade dos filtros */
-function aclScore(cat: CategoryACL): number {
-  let score = 0.5; // base
-  if (cat.allowedDomains && cat.allowedDomains.length > 0) score += 0.25;
-  if (cat.allowedGapTypes && cat.allowedGapTypes.length > 0) score += 0.25;
-  return score;
+// ---------------------------------------------------------------------------
+// Normalização de artigo
+// ---------------------------------------------------------------------------
+
+export function normalizeArticle(ref: string): string {
+  const match = ref.match(/arts?\.?\s*[\d\-,\s]+/i);
+  if (!match) return ref.toLowerCase().trim();
+  return match[0].toLowerCase().replace(/\s+/g, "");
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// Função principal: mapGapsToCategories
-// ─────────────────────────────────────────────────────────────────────────────
+// ---------------------------------------------------------------------------
+// Filtros semânticos (allowed_domains / allowed_gap_types)
+// ---------------------------------------------------------------------------
 
-/**
- * Mapeia uma lista de gaps confirmados para categorias de risco.
- *
- * @param gaps       Lista de gaps confirmados pelo GapEngine
- * @param categories Lista de categorias ativas (injetada pelo repositório)
- * @returns          MapperResult com matches, unmatched e timestamp
- */
-export function mapGapsToCategories(
-  gaps: GapConfirmed[],
-  categories: CategoryACL[],
-): MapperResult {
-  const activeCategories = categories.filter((c) => c.status === "ativo");
-  const matches: RuleMatch[] = [];
-  const unmatched: string[] = [];
+function applySemanticFilters(
+  candidates: CategoryACL[],
+  gap: GapInput,
+): { filtered: CategoryACL[]; hadFilters: boolean } {
+  let hadFilters = false;
+  let filtered = candidates;
 
-  for (const gap of gaps) {
-    const match = resolveGap(gap, activeCategories);
-    if (match) {
-      matches.push(match);
-    } else {
-      unmatched.push(gap.id);
+  if (gap.domain) {
+    const withDomainFilter = filtered.filter(
+      (c) => c.allowedDomains !== null && c.allowedDomains !== undefined,
+    );
+    if (withDomainFilter.length > 0) {
+      hadFilters = true;
+      filtered = filtered.filter((c) => {
+        if (c.allowedDomains === null || c.allowedDomains === undefined) return false;
+        return c.allowedDomains.includes(gap.domain!);
+      });
     }
   }
 
+  if (gap.gapType) {
+    const withTypeFilter = filtered.filter(
+      (c) => c.allowedGapTypes !== null && c.allowedGapTypes !== undefined,
+    );
+    if (withTypeFilter.length > 0) {
+      hadFilters = true;
+      filtered = filtered.filter((c) => {
+        if (c.allowedGapTypes === null || c.allowedGapTypes === undefined) return false;
+        return c.allowedGapTypes.includes(gap.gapType!);
+      });
+    }
+  }
+
+  return { filtered, hadFilters };
+}
+
+// ---------------------------------------------------------------------------
+// GapToRuleMapper — classe principal
+// ---------------------------------------------------------------------------
+
+export class GapToRuleMapper {
+  constructor(
+    private resolver: CategoryResolver,
+    private options: MapperOptions = {},
+  ) {}
+
+  /**
+   * Mapeia um único gap. Retorna APENAS: mapped | ambiguous | unmapped.
+   * NUNCA retorna mapped com heurística. NUNCA usa fallback por domínio.
+   */
+  async mapOne(gap: GapInput): Promise<GapMappingResult> {
+    // Skip compliant/nao_aplicavel — não geram risco
+    if (
+      gap.gapStatus === "compliant" ||
+      gap.gapStatus === "nao_aplicavel"
+    ) {
+      return {
+        gapId: gap.id,
+        status: "unmapped",
+        ruleCode: null,
+        categoria: null,
+        reason: "skip: gapStatus=" + gap.gapStatus,
+      };
+    }
+
+    // ── CASO A: categoria explícita no gap ──────────────────────────
+    if (gap.categoria) {
+      const cat = await this.resolver.findByCodigo(gap.categoria);
+      if (cat && cat.status === "ativo") {
+        return {
+          gapId: gap.id,
+          status: "mapped",
+          ruleCode: cat.ruleCode ?? cat.codigo,
+          categoria: cat.codigo,
+          reason: `explicit: gap.categoria="${gap.categoria}" encontrada em risk_categories`,
+        };
+      }
+      return {
+        gapId: gap.id,
+        status: "unmapped",
+        ruleCode: null,
+        categoria: null,
+        reason: `explicit_not_found: gap.categoria="${gap.categoria}" inexistente ou inativa em risk_categories`,
+      };
+    }
+
+    // ── CASO B: resolução por artigo ────────────────────────────────
+    if (gap.sourceReference) {
+      const normalized = normalizeArticle(gap.sourceReference);
+      const candidates = await this.resolver.findByArticle(normalized);
+
+      if (candidates.length === 0) {
+        return {
+          gapId: gap.id,
+          status: "unmapped",
+          ruleCode: null,
+          categoria: null,
+          reason: `article_not_found: artigo="${normalized}" sem candidatos em risk_categories`,
+        };
+      }
+
+      const { filtered, hadFilters } = applySemanticFilters(candidates, gap);
+
+      if (filtered.length === 1) {
+        const cat = filtered[0];
+        return {
+          gapId: gap.id,
+          status: "mapped",
+          ruleCode: cat.ruleCode ?? cat.codigo,
+          categoria: cat.codigo,
+          reason: `article: artigo="${normalized}" resolveu para "${cat.codigo}"`,
+        };
+      }
+
+      if (filtered.length > 1) {
+        return {
+          gapId: gap.id,
+          status: "ambiguous",
+          ruleCode: null,
+          categoria: null,
+          reason: `ambiguous: artigo="${normalized}" tem ${filtered.length} candidatos: ${filtered.map((c) => c.codigo).join(", ")}`,
+        };
+      }
+
+      // filtered.length === 0
+      if (hadFilters) {
+        return {
+          gapId: gap.id,
+          status: "unmapped",
+          ruleCode: null,
+          categoria: null,
+          reason: `filtered_out: artigo="${normalized}" tinha ${candidates.length} candidatos, filtros semânticos eliminaram todos`,
+        };
+      }
+
+      return {
+        gapId: gap.id,
+        status: "ambiguous",
+        ruleCode: null,
+        categoria: null,
+        reason: `ambiguous: artigo="${normalized}" tem ${candidates.length} candidatos sem filtro semântico`,
+      };
+    }
+
+    // ── Sem categoria, sem artigo ───────────────────────────────────
+    return {
+      gapId: gap.id,
+      status: "unmapped",
+      ruleCode: null,
+      categoria: null,
+      reason: "unmapped: gap sem categoria e sem sourceReference",
+    };
+  }
+
+  /**
+   * Mapeia múltiplos gaps. Gaps compliant/nao_aplicavel são ignorados.
+   */
+  async mapMany(gaps: GapInput[]): Promise<MapGapsToRulesResult> {
+    const { allowLayerInference = false } = this.options;
+    const mappedRules: GapRule[] = [];
+    const reviewQueue: GapMappingResult[] = [];
+    let mapped = 0;
+    let ambiguous = 0;
+    let unmapped = 0;
+
+    for (const gap of gaps) {
+      if (
+        gap.gapStatus === "compliant" ||
+        gap.gapStatus === "nao_aplicavel"
+      ) {
+        continue;
+      }
+
+      const result = await this.mapOne(gap);
+      reviewQueue.push(result);
+
+      if (result.status === "mapped" && result.categoria) {
+        mapped++;
+        mappedRules.push(toGapRule(gap, result, allowLayerInference));
+      } else if (result.status === "ambiguous") {
+        ambiguous++;
+      } else {
+        unmapped++;
+      }
+    }
+
+    return {
+      mappedRules,
+      reviewQueue,
+      stats: { total: reviewQueue.length, mapped, ambiguous, unmapped },
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Conversão GapInput → GapRule
+//
+// allowLayerInference=true permite inferir APENAS source_origin (fonte),
+// NUNCA categoria. A categoria já foi resolvida deterministicamente acima.
+// ---------------------------------------------------------------------------
+
+function inferFonte(gap: GapInput, allowLayerInference: boolean): string {
+  if (gap.sourceOrigin) return gap.sourceOrigin;
+  if (!allowLayerInference) return "solaris";
+  if (gap.layer === "onda2") return "iagen";
+  if (gap.layer === "onda1") return "solaris";
+  return "solaris";
+}
+
+function toGapRule(
+  gap: GapInput,
+  mapping: GapMappingResult,
+  allowLayerInference: boolean,
+): GapRule {
   return {
-    matches,
-    unmatched,
-    executedAt: new Date().toISOString(),
+    ruleId: mapping.ruleCode ?? gap.id,
+    categoria: mapping.categoria!,
+    artigo: gap.sourceReference ?? "N/A",
+    fonte: inferFonte(gap, allowLayerInference),
+    gapClassification:
+      gap.gapStatus === "nao_compliant" ? "ausencia" : "parcial",
+    requirementId: gap.requirementId ?? gap.canonicalId,
+    sourceReference: gap.sourceReference ?? "N/A",
+    domain: gap.domain ?? "geral",
   };
 }
-
-/**
- * Resolve um único gap para uma categoria.
- * Retorna null apenas se não houver nenhuma categoria ativa (nem fallback).
- */
-function resolveGap(gap: GapConfirmed, activeCategories: CategoryACL[]): RuleMatch | null {
-  // ── Estratégia 1: rule_code ──────────────────────────────────────────────
-  // Categoria com ruleCode explícito que casa com gap.gapType (prefixo RC-)
-  const byRuleCode = activeCategories.find(
-    (c) => c.ruleCode && c.ruleCode.toLowerCase() === gap.gapType.toLowerCase(),
-  );
-  if (byRuleCode) {
-    return {
-      gapId: gap.id,
-      categoriaCodigo: byRuleCode.codigo,
-      categoriaNome: byRuleCode.nome,
-      mode: "rule_code",
-      score: 1.0,
-      ruleCode: byRuleCode.ruleCode ?? null,
-    };
-  }
-
-  // ── Estratégia 2: acl_filter ─────────────────────────────────────────────
-  // Categorias cujos allowedDomains e allowedGapTypes cobrem o gap.
-  // Seleciona a de maior score (mais específica).
-  const candidates = activeCategories
-    .filter((c) => domainAllowed(c, gap.domain) && gapTypeAllowed(c, gap.gapType))
-    .map((c) => ({ cat: c, score: aclScore(c) }))
-    .sort((a, b) => b.score - a.score);
-
-  if (candidates.length > 0) {
-    const best = candidates[0];
-    return {
-      gapId: gap.id,
-      categoriaCodigo: best.cat.codigo,
-      categoriaNome: best.cat.nome,
-      mode: "acl_filter",
-      score: best.score,
-      ruleCode: best.cat.ruleCode ?? null,
-    };
-  }
-
-  // ── Estratégia 3: fallback ───────────────────────────────────────────────
-  // Categoria padrão do domínio (hardcoded em DOMAIN_FALLBACK).
-  const fallbackCodigo = DOMAIN_FALLBACK[gap.domain] ?? DOMAIN_FALLBACK["_default"];
-  const fallbackCat = activeCategories.find((c) => c.codigo === fallbackCodigo);
-
-  if (fallbackCat) {
-    return {
-      gapId: gap.id,
-      categoriaCodigo: fallbackCat.codigo,
-      categoriaNome: fallbackCat.nome,
-      mode: "fallback",
-      score: 0.3,
-      ruleCode: null,
-    };
-  }
-
-  // Nenhuma categoria disponível (banco vazio ou todas inativas)
-  return null;
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Export da tabela de fallback (para testes e documentação)
-// ─────────────────────────────────────────────────────────────────────────────
-export { DOMAIN_FALLBACK };

--- a/server/schemas/gap-risk.schemas.ts
+++ b/server/schemas/gap-risk.schemas.ts
@@ -1,46 +1,37 @@
 /**
- * gap-risk.schemas.ts — Sprint Z-10 PR #A
+ * gap-risk.schemas.ts — Sprint Z-10
  * Zod schemas para o mapeamento Gap → Categoria de Risco (GAP-ACL)
  *
- * Contratos:
- *   GapConfirmed  → input do gap-to-rule-mapper
- *   RuleMatch     → output do gap-to-rule-mapper
+ * Contratos existentes (mantidos — repository depende):
+ *   GapConfirmed  → legado PR #448, mantido para repository/admin
  *   CategoryACL   → subconjunto de RiskCategory para verificação de ACL
+ *
+ * Contratos novos (ACL v2 — classe GapToRuleMapper):
+ *   GapInput            → entrada do mapper v2
+ *   GapMappingResult    → resultado do mapper v2 (sem score, sem confidence)
+ *   MapGapsToRulesResult → resultado agregado do mapMany
+ *
+ * PROIBIDO: score, confidence, ranking, fallback por domínio.
  */
 
 import { z } from "zod";
 
-// ─────────────────────────────────────────────────────────────────────────────
-// GapConfirmed — gap identificado pelo GapEngine (entrada do mapper)
-// ─────────────────────────────────────────────────────────────────────────────
+// ═══════════════════════════════════════════════════════════════════════════
+// Contratos existentes — mantidos para repository/admin
+// ═══════════════════════════════════════════════════════════════════════════
+
 export const GapConfirmedSchema = z.object({
-  /** ID único do gap (ex: "gap-001") */
   id: z.string().min(1),
-
-  /** Domínio de negócio do gap (ex: "contabilidade", "fiscal", "ti") */
   domain: z.string().min(1),
-
-  /** Tipo de gap (ex: "obrigacao_acessoria", "apuracao", "credito", "transicao") */
   gapType: z.string().min(1),
-
-  /** Artigos da lei relacionados ao gap (ex: ["art. 12", "art. 45"]) */
   artigos: z.array(z.string()).default([]),
-
-  /** Descrição textual do gap */
   description: z.string().optional(),
-
-  /** Severidade estimada pelo GapEngine */
   severidade: z.enum(["alta", "media", "oportunidade"]).optional(),
-
-  /** Metadados adicionais (livre) */
   metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type GapConfirmed = z.infer<typeof GapConfirmedSchema>;
 
-// ─────────────────────────────────────────────────────────────────────────────
-// CategoryACL — campos de controle de acesso de uma RiskCategory
-// ─────────────────────────────────────────────────────────────────────────────
 export const CategoryACLSchema = z.object({
   codigo: z.string(),
   nome: z.string(),
@@ -48,55 +39,90 @@ export const CategoryACLSchema = z.object({
   urgencia: z.enum(["imediata", "curto_prazo", "medio_prazo"]),
   tipo: z.enum(["risk", "opportunity"]),
   status: z.enum(["ativo", "sugerido", "pendente_revisao", "inativo", "legado"]),
-  /** NULL = aceita qualquer domínio */
   allowedDomains: z.array(z.string()).nullable().optional(),
-  /** NULL = aceita qualquer tipo de gap */
   allowedGapTypes: z.array(z.string()).nullable().optional(),
-  /** Código da regra de mapeamento (ex: "RC-001") */
   ruleCode: z.string().nullable().optional(),
 });
 
 export type CategoryACL = z.infer<typeof CategoryACLSchema>;
 
-// ─────────────────────────────────────────────────────────────────────────────
-// RuleMatch — resultado do mapeamento Gap → Categoria (saída do mapper)
-// ─────────────────────────────────────────────────────────────────────────────
 export const RuleMatchSchema = z.object({
-  /** Gap de origem */
   gapId: z.string(),
-
-  /** Código da categoria mapeada */
   categoriaCodigo: z.string(),
-
-  /** Nome da categoria mapeada */
   categoriaNome: z.string(),
-
-  /**
-   * Modo de resolução:
-   *   "rule_code"  → casou pelo ruleCode explícito da categoria
-   *   "acl_filter" → casou pelos filtros allowedDomains/allowedGapTypes
-   *   "fallback"   → nenhuma regra casou; usou categoria padrão do domínio
-   */
   mode: z.enum(["rule_code", "acl_filter", "fallback"]),
-
-  /** Score de confiança do mapeamento (0.0 – 1.0) */
   score: z.number().min(0).max(1),
-
-  /** Código da regra que originou o match (se mode === "rule_code") */
   ruleCode: z.string().nullable().optional(),
 });
 
 export type RuleMatch = z.infer<typeof RuleMatchSchema>;
 
-// ─────────────────────────────────────────────────────────────────────────────
-// MapperResult — resultado completo do mapper para um conjunto de gaps
-// ─────────────────────────────────────────────────────────────────────────────
 export const MapperResultSchema = z.object({
   matches: z.array(RuleMatchSchema),
-  /** Gaps que não encontraram nenhuma categoria (nem fallback) */
   unmatched: z.array(z.string()),
-  /** Timestamp da execução */
   executedAt: z.string().datetime(),
 });
 
 export type MapperResult = z.infer<typeof MapperResultSchema>;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Contratos novos — ACL v2 (GapToRuleMapper)
+// Sem score, sem confidence — apenas status determinístico.
+// ═══════════════════════════════════════════════════════════════════════════
+
+export const GapInputSchema = z.object({
+  id: z.string(),
+  canonicalId: z.string(),
+  gapStatus: z.enum(["compliant", "nao_compliant", "parcial", "nao_aplicavel"]),
+  gapSeverity: z.enum(["critica", "alta", "media", "baixa"]).optional(),
+  gapType: z.string().optional(),
+  area: z.string().optional(),
+  descricao: z.string().optional(),
+  categoria: z.string().optional(),
+  sourceOrigin: z.enum(["cnae", "ncm", "nbs", "solaris", "iagen"]).optional(),
+  requirementId: z.string().optional(),
+  sourceReference: z.string().optional(),
+  domain: z.string().optional(),
+  layer: z.string().optional(),
+});
+
+export type GapInput = z.infer<typeof GapInputSchema>;
+
+export const MappingStatusSchema = z.enum(["mapped", "ambiguous", "unmapped"]);
+export type MappingStatus = z.infer<typeof MappingStatusSchema>;
+
+export const GapMappingResultSchema = z.object({
+  gapId: z.string(),
+  status: MappingStatusSchema,
+  ruleCode: z.string().nullable(),
+  categoria: z.string().nullable(),
+  reason: z.string(),
+});
+
+export type GapMappingResult = z.infer<typeof GapMappingResultSchema>;
+
+export const GapRuleSchema = z.object({
+  ruleId: z.string(),
+  categoria: z.string(),
+  artigo: z.string(),
+  fonte: z.string(),
+  gapClassification: z.string(),
+  requirementId: z.string(),
+  sourceReference: z.string(),
+  domain: z.string(),
+});
+
+export type GapRuleOutput = z.infer<typeof GapRuleSchema>;
+
+export const MapGapsToRulesResultSchema = z.object({
+  mappedRules: z.array(GapRuleSchema),
+  reviewQueue: z.array(GapMappingResultSchema),
+  stats: z.object({
+    total: z.number(),
+    mapped: z.number(),
+    ambiguous: z.number(),
+    unmapped: z.number(),
+  }),
+});
+
+export type MapGapsToRulesResult = z.infer<typeof MapGapsToRulesResultSchema>;


### PR DESCRIPTION
Corrige PR #448. Remove DOMAIN_FALLBACK, scores e sort()[0]. Implementa GapToRuleMapper com 3 estados: mapped|ambiguous|unmapped. 7/7 testes PASS.