### PR TITLE
fix(z10): user_id → createdById gapEngine + onError analyzeGaps

### DIFF
--- a/client/src/components/RiskDashboardV4.tsx
+++ b/client/src/components/RiskDashboardV4.tsx
@@ -7,6 +7,7 @@
  */
 
 import { useState } from "react";
+import { toast } from "sonner";
 import { trpc } from "@/lib/trpc";
 import { useAuth } from "@/_core/hooks/useAuth";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -297,6 +298,7 @@ export function RiskDashboardV4({ projectId }: RiskDashboardV4Props) {
     onSuccess: () => utils.risksV4.listRisks.invalidate({ projectId }),
   });
   const analyzeGapsMutation = trpc.gapEngine.analyzeGaps.useMutation({
+    onError: (err) => toast.error("Erro ao analisar gaps", { description: err.message }),
     onSuccess: async (result) => {
       const gapInputs = (result.gaps ?? []).map((g: any) => ({
         id: g.requirement_id,

--- a/server/routers/gapEngine.ts
+++ b/server/routers/gapEngine.ts
@@ -239,7 +239,7 @@ export const gapEngineRouter = router({
       try {
         // 1. Buscar projeto
         const [[project]] = await pool.query<mysql.RowDataPacket[]>(
-          "SELECT id, name, status, client_id FROM projects WHERE id = ? AND user_id = ?",
+          "SELECT id, name, status, client_id FROM projects WHERE id = ? AND createdById = ?",
           [input.project_id, ctx.user.id]
         );
 
@@ -460,7 +460,7 @@ export const gapEngineRouter = router({
       const pool = mysql.createPool(process.env.DATABASE_URL ?? "");
       try {
         const [[project]] = await pool.query<mysql.RowDataPacket[]>(
-          "SELECT id FROM projects WHERE id = ? AND user_id = ?",
+          "SELECT id FROM projects WHERE id = ? AND createdById = ?",
           [input.project_id, ctx.user.id]
         );
         if (!project) throw new TRPCError({ code: "NOT_FOUND", message: "Projeto não encontrado" });
@@ -492,7 +492,7 @@ export const gapEngineRouter = router({
       const pool = mysql.createPool(process.env.DATABASE_URL ?? "");
       try {
         const [[project]] = await pool.query<mysql.RowDataPacket[]>(
-          "SELECT id FROM projects WHERE id = ? AND user_id = ?",
+          "SELECT id FROM projects WHERE id = ? AND createdById = ?",
           [input.project_id, ctx.user.id]
         );
         if (!project) throw new TRPCError({ code: "NOT_FOUND", message: "Projeto não encontrado" });


### PR DESCRIPTION
Bug pré-existente: gapEngine.ts usava user_id (inexistente). Campo correto: createdById. Pipeline de 3 passos agora executa. onError adicionado para erros não ficarem silenciosos.