### PR TITLE
docs(z11-e7): ADR-0027 + ADR-0028 — fonte de verdade e categorização Onda 2

### DIFF
--- a/docs/adr/ADR-0027-fonte-verdade-respostas-por-onda.md
+++ b/docs/adr/ADR-0027-fonte-verdade-respostas-por-onda.md
@@ -1,0 +1,30 @@
+# ADR-0027 — Fonte de Verdade das Respostas por Onda
+## Status: Aceito · 2026-04-10
+
+## Contexto
+O smoke test da Z-10 revelou que analyzeGaps() lia
+questionnaireAnswersV3 (pipeline legado com 0 registros),
+enquanto as respostas reais estavam em solaris_answers (48)
+e iagen_answers (7). Pipeline de riscos retornava 0 resultados.
+
+## Decisão
+analyzeGapsFromQuestionnaires() (NOVA) lê de solaris_answers + iagen_answers.
+analyzeGaps() existente NÃO é alterada (Onda 3 intacta).
+
+  Tabela           → Onda → Chave de classificação
+  solaris_answers  → 1    → solaris_questions.risk_category_code
+  iagen_answers    → 2    → iagen_answers.risk_category_code
+  (RAG engine)     → 3    → regulatory_requirements_v3.code
+
+## Regra inviolável
+Resposta sem risk_category_code válido não entra no pipeline
+de riscos. Entra apenas no briefing como evidência diagnóstica.
+
+## Consequências
+- Dois pipelines paralelos: Ondas 1+2 (novo) e Onda 3 (existente)
+- Ambos convergem em risks_v4 via ACL mapper
+- Respostas legadas sem risk_category_code usam fallback KEYWORD_TO_TOPIC
+
+## Rastreabilidade
+DEC-Z11-ARCH-01 · Sprint Z-11 · PRs #457 #459 #460
+P.O.: Uires Tapajós

--- a/docs/adr/ADR-0028-categorizacao-onda2-iagen.md
+++ b/docs/adr/ADR-0028-categorizacao-onda2-iagen.md
@@ -1,0 +1,38 @@
+# ADR-0028 — Categorização da Onda 2 (IA GEN)
+## Status: Aceito · 2026-04-10
+
+## Contexto
+iagen_answers não tinha risk_category_code.
+iagen-gap-analyzer.ts usava KEYWORD_TO_TOPIC hardcoded
+(~30 keywords → ~6 tópicos). Resultado: categorização
+por palavras-chave — frágil e não auditável.
+
+## Decisão
+O LLM que gera a pergunta já sabe qual categoria investiga.
+risk_category_code é retornado pelo LLM no momento da geração,
+junto com a pergunta, e salvo em iagen_answers.
+
+category_assignment_mode = 'llm_assigned' indica que foi o LLM.
+Dr. Rodrigues pode revisar e mudar para 'human_validated'.
+
+Categorias enviadas ao LLM são lidas do banco dinamicamente
+(NÃO hardcoded no código).
+
+## Guardrails obrigatórios
+1. risk_category_code retornado pelo LLM deve existir em risk_categories.
+   Se não existir → pergunta rejeitada → fallback.
+2. used_profile_fields.length >= 2.
+   Se < 2 → pergunta rejeitada (genérica).
+3. temperature = 0.1 (determinístico).
+4. Pré-filtro de categorias por perfil antes do LLM.
+5. ONDA2_PROMPT_VERSION salvo para rastreabilidade de regressão.
+
+## Consequências
+- Prompt enriquecido com 5 JSONs do projeto + categorias do banco
+- Limite dinâmico 3-12 perguntas calculado pelo perfil
+- Fallback legado (KEYWORD_TO_TOPIC) mantido para respostas sem categoria
+- Few-shot examples obrigatórios no prompt
+
+## Rastreabilidade
+DEC-Z11-ARCH-03 · DEC-Z11-02 · Sprint Z-11 · PR #461
+P.O.: Uires Tapajós · Consultor: ChatGPT (análise arquitetural)


### PR DESCRIPTION
Z-11 ENTREGA 7.
- ADR-0027: analyzeGapsFromQuestionnaires lê solaris_answers + iagen_answers (não questionnaireAnswersV3)
- ADR-0028: Categorização Onda 2 via risk_category_code no LLM + guardrails