### PR TITLE
fix(gap-engine): client_id → clientId — corrige erro ao analisar gaps

### DIFF
--- a/client/public/__manus__/version.json
+++ b/client/public/__manus__/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1200ec38",
-  "timestamp": 1775905743662
+  "version": "144b332c",
+  "timestamp": 1775907311633
 }

--- a/server/routers/gapEngine.ts
+++ b/server/routers/gapEngine.ts
@@ -239,7 +239,7 @@ export const gapEngineRouter = router({
       try {
         // 1. Buscar projeto
         const [[project]] = await pool.query<mysql.RowDataPacket[]>(
-          "SELECT id, name, status, client_id FROM projects WHERE id = ? AND createdById = ?",
+          "SELECT id, name, status, clientId FROM projects WHERE id = ? AND createdById = ?",
           [input.project_id, ctx.user.id]
         );
 
@@ -386,7 +386,7 @@ export const gapEngineRouter = router({
                 evaluation_confidence_reason, question_id, answer_value, source_reference
               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW(), ?, ?, ?, ?, ?, ?, ?)`,
               [
-                project.client_id ?? 1,
+                project.clientId ?? 1,
                 input.project_id,
                 gap.requirement_id,
                 gap.requirement_name,


### PR DESCRIPTION
Corrige 'Unknown column client_id in field list': a tabela projects usa clientId (camelCase), não client_id. SELECT e referência project.clientId corrigidos em gapEngine.ts linha 242 e 389.