### PR TITLE
fix(z11): B-Z11-009 + B-Z11-010 — CNAE skip button + briefing approve guard

### DIFF
--- a/client/public/__manus__/version.json
+++ b/client/public/__manus__/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "144b332c",
-  "timestamp": 1775907311633
+  "version": "64f9bd3e",
+  "timestamp": 1775946506504
 }

--- a/client/src/pages/BriefingV3.tsx
+++ b/client/src/pages/BriefingV3.tsx
@@ -16,7 +16,7 @@ import { statusToCompletedStep } from "@/lib/flowStepperUtils";
 import {
   ArrowLeft, ChevronRight, Loader2, Sparkles,
   CheckCircle2, RefreshCw, MessageSquare, ThumbsUp, Edit3, Info, Download,
-  History, Clock, ChevronDown, ChevronUp, AlertTriangle,
+  History, Clock, ChevronDown, ChevronUp, AlertTriangle, AlertCircle,
   Layers, TrendingUp, BarChart3, Flame, StickyNote
 } from "lucide-react";
 import { toast } from "sonner";
@@ -259,6 +259,9 @@ export default function BriefingV3() {
       setIsGenerating(false);
     }
   };
+
+  // B-Z11-010: guard — só permite aprovar quando status é diagnostico_cnae ou briefing
+  const canApprove = ['diagnostico_cnae', 'briefing'].includes((project as any)?.status ?? '');
 
   const handleApprove = async () => {
     if (!briefing) return;
@@ -737,8 +740,26 @@ export default function BriefingV3() {
                     <p className="text-xs text-amber-700 mt-0.5">Leia com atenção. Se estiver correto e completo, aprove para avançar. Se precisar de ajustes, use as opções abaixo.</p>
                   </div>
                 </div>
+                {/* B-Z11-010: aviso quando status não permite aprovar */}
+                {!canApprove && (
+                  <div className="flex items-start gap-3 p-4 rounded-xl bg-red-50 border border-red-200">
+                    <AlertCircle className="h-5 w-5 text-red-600 shrink-0 mt-0.5" />
+                    <div>
+                      <p className="text-sm font-semibold text-red-800">Diagnóstico incompleto</p>
+                      <p className="text-xs text-red-700 mt-0.5">Conclua o <strong>Diagnóstico Setorial CNAE</strong> (Etapa 5) antes de aprovar o briefing.</p>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="mt-2 text-xs h-7 border-red-300 text-red-700 hover:bg-red-100"
+                        onClick={() => setLocation(`/projetos/${projectId}/questionario-cnae`)}
+                      >
+                        Ir para Diagnóstico Setorial CNAE
+                      </Button>
+                    </div>
+                  </div>
+                )}
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
-                  <Button size="lg" onClick={handleApprove} disabled={isApproving} className="gap-2">
+                  <Button size="lg" onClick={handleApprove} disabled={isApproving || !canApprove} className="gap-2">
                     {isApproving ? <Loader2 className="h-4 w-4 animate-spin" /> : <ThumbsUp className="h-4 w-4" />}
                     Aprovar Briefing
                   </Button>

--- a/client/src/pages/QuestionarioCNAE.tsx
+++ b/client/src/pages/QuestionarioCNAE.tsx
@@ -32,7 +32,17 @@ import {
   AlertCircle,
   Save,
   ArrowLeft,
+  SkipForward,
+  AlertTriangle,
 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { toast } from "sonner";
 import {
   buildCnaePrefill,
@@ -121,6 +131,8 @@ export default function QuestionarioCNAE() {
   const [respostas, setRespostas] = useState<Record<string, any>>({});
   const [salvando, setSalvando] = useState(false);
   const [concluido, setConcluido] = useState(false);
+  // B-Z11-009: estado do modal de confirmação de pular
+  const [confirmSkipAll, setConfirmSkipAll] = useState(false);
 
   // Buscar projeto
   const { data: projeto, isLoading } = trpc.projects.getById.useQuery(
@@ -204,6 +216,13 @@ export default function QuestionarioCNAE() {
       layer: "cnae",
       answers: respostas,
     });
+  }
+
+  // B-Z11-009: pular questionário CNAE — submete com respostas vazias
+  function handleSkipAll() {
+    toast.warning("Questionário Setorial CNAE pulado — diagnóstico com confiança reduzida.", { duration: 6000 });
+    completarCamada.mutate({ projectId, layer: "cnae", answers: {} });
+    setConfirmSkipAll(false);
   }
 
   if (isLoading) {
@@ -378,6 +397,53 @@ export default function QuestionarioCNAE() {
             ))}
           </CardContent>
         </Card>
+
+        {/* B-Z11-009: Botão Pular questionário */}
+        <div className="flex justify-center mt-4">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setConfirmSkipAll(true)}
+            data-testid="btn-pular-questionario-cnae"
+            className="text-xs text-muted-foreground hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-950/30 gap-1.5"
+          >
+            <SkipForward className="h-3.5 w-3.5" />
+            Pular este questionário
+          </Button>
+        </div>
+        {/* Modal de confirmação — Pular questionário CNAE */}
+        <Dialog open={confirmSkipAll} onOpenChange={setConfirmSkipAll}>
+          <DialogContent data-testid="modal-confirmar-pular-questionario-cnae">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <AlertTriangle className="h-5 w-5 text-amber-500" />
+                Pular questionário Setorial CNAE?
+              </DialogTitle>
+              <DialogDescription>
+                Ao pular este questionário, o diagnóstico será gerado com{" "}
+                <strong>confiança reduzida</strong>. Você poderá voltar e
+                responder as perguntas depois.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter className="gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setConfirmSkipAll(false)}
+                data-testid="btn-cancelar-pular-cnae"
+              >
+                Cancelar
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={handleSkipAll}
+                disabled={completarCamada.isPending}
+                data-testid="btn-confirmar-pular-cnae"
+              >
+                {completarCamada.isPending ? "Pulando..." : "Confirmar — Pular questionário"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
 
         {/* Navegação entre seções */}
         <div className="flex items-center justify-between mt-6">


### PR DESCRIPTION
## Resumo

Corrige dois bugs da Sprint Z-11 (GATE E).

---

## B-Z11-009 — Questionário CNAE sem botão 'Pular'

**Causa:** QuestionarioCNAE.tsx não tinha o padrão de skip implementado nas outras etapas.

**Fix:**
- Importa SkipForward, AlertTriangle, Dialog*
- Estado confirmSkipAll + handleSkipAll (chama completeDiagnosticLayer com answers:{})
- Modal de confirmação com data-testid obrigatórios
- Segue padrão idêntico ao QuestionarioProduto.tsx (ADR-0016)

**Arquivos:** client/src/pages/QuestionarioCNAE.tsx

---

## B-Z11-010 — 'Erro ao aprovar o briefing' (status q_produto)

**Causa raiz:** Projeto com status='q_produto' tentava chamar approveBriefing, que executa assertValidTransition('q_produto', 'briefing'). A transição não existe em VALID_TRANSITIONS, gerando TRPCError FORBIDDEN.

**Fix (frontend guard):**
- canApprove = status in ['diagnostico_cnae', 'briefing']

**Arquivos:** client/src/pages/BriefingV3.tsx

---

## Evidência JSON

```json
{
  "bugs": ["B-Z11-009", "B-Z11-010"],
  "sprint": "Z-11",
  "gate": "E",
  "tsc_errors": 0,
  "files_changed": [
    "client/src/pages/QuestionarioCNAE.tsx",
    "client/src/pages/BriefingV3.tsx"
  ],
  "scope_only": true,
  "db_migrations": false,
  "breaking_changes": false
}
```

---

## Checklist

- [x] Apenas arquivos do escopo declarado
- [x] tsc: 0 erros
- [x] Sem DROP COLUMN / migrações destrutivas
- [x] data-testid adicionados (B-Z11-009)
- [x] Padrão ADR-0016 seguido (skip button)
- [x] DIAGNOSTIC_READ_MODE não alterado