### PR TITLE
feat(matriz): add CategoryBadge for risk_category_code in MatrizRiscosSession

### DIFF
--- a/client/src/pages/MatrizRiscosSession.tsx
+++ b/client/src/pages/MatrizRiscosSession.tsx
@@ -13,6 +13,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ArrowLeft, ArrowRight, AlertTriangle } from "lucide-react";
 import { FluxoStepper } from "@/components/FluxoStepper";
+import { CategoryBadge } from "@/components/compliance-v3/shared/Badges";
 
 // ─── Tipos ─────────────────────────────────────────────────────────────────────
 
@@ -26,6 +27,7 @@ interface MatrixItem {
   priority: string;
   riskLevel: string;
   status: string;
+  riskCategoryCode?: string | null;
 }
 
 interface BranchSummary {
@@ -202,7 +204,12 @@ export default function MatrizRiscosSession() {
                                   className="bg-white/80 rounded px-1.5 py-1 text-xs text-slate-700 leading-tight cursor-default hover:bg-white transition-colors shadow-sm"
                                 >
                                   <span className="font-medium block truncate">{item.action}</span>
-                                  <span className="text-slate-400 text-[10px]">{item.branchName}</span>
+                                  <div className="flex items-center gap-1 mt-0.5">
+                                    <span className="text-slate-400 text-[10px]">{item.branchName}</span>
+                                    {item.riskCategoryCode && (
+                                      <CategoryBadge value={item.riskCategoryCode} className="text-[9px] px-1 py-0" />
+                                    )}
+                                  </div>
                                 </div>
                               ))}
                             </div>

--- a/server/routers-session-action-plan.ts
+++ b/server/routers-session-action-plan.ts
@@ -31,6 +31,8 @@ interface PlanItem {
   riskLevel: "critico" | "alto" | "medio" | "baixo";
   category: string; // ex: "Sistemas", "Treinamento", "Processos", "Documentação"
   estimatedCost: "baixo" | "medio" | "alto"; // custo estimado de implementação
+  /** Sprint Z-12: Categoria canônica LC 214/2025 (10 códigos) */
+  riskCategoryCode?: string;
 }
 
 interface BranchAnalysis {
@@ -103,7 +105,8 @@ Retorne APENAS JSON válido com este formato exato:
       "status": "pendente",
       "riskLevel": "critico",
       "category": "Sistemas",
-      "estimatedCost": "alto"
+      "estimatedCost": "alto",
+      "riskCategoryCode": "split_payment"
     }
   ],
   "executiveSummary": "Texto do resumo executivo...",
@@ -117,6 +120,7 @@ Regras:
 - responsible: "Equipe Fiscal", "TI/Sistemas", "Diretoria", "Contabilidade", "RH", "Jurídico", "Todos"
 - category: "Sistemas", "Treinamento", "Processos", "Documentação", "Governança", "Consultoria"
 - estimatedCost: "baixo" (< R$5k), "medio" (R$5k-50k), "alto" (> R$50k)
+- riskCategoryCode: uma das 10 categorias canônicas da LC 214/2025: "imposto_seletivo", "ibs_cbs", "regime_diferenciado", "aliquota_reduzida", "aliquota_zero", "split_payment", "cadastro_fiscal", "obrigacao_acessoria", "transicao", "enquadramento_geral"
 - Priorize ações críticas relacionadas ao prazo da Reforma Tributária (2026-2033)`;
 
   try {
@@ -154,8 +158,9 @@ Regras:
                     riskLevel: { type: "string", enum: ["critico", "alto", "medio", "baixo"] },
                     category: { type: "string" },
                     estimatedCost: { type: "string", enum: ["baixo", "medio", "alto"] },
+                    riskCategoryCode: { type: "string", enum: ["imposto_seletivo", "ibs_cbs", "regime_diferenciado", "aliquota_reduzida", "aliquota_zero", "split_payment", "cadastro_fiscal", "obrigacao_acessoria", "transicao", "enquadramento_geral"] },
                   },
-                  required: ["id", "branchCode", "branchName", "action", "description", "priority", "deadline", "responsible", "status", "riskLevel", "category", "estimatedCost"],
+                  required: ["id", "branchCode", "branchName", "action", "description", "priority", "deadline", "responsible", "status", "riskLevel", "category", "estimatedCost", "riskCategoryCode"],
                   additionalProperties: false,
                 },
               },
@@ -210,6 +215,7 @@ function generateFallbackPlan(branchAnalyses: BranchAnalysis[]): {
       riskLevel: "critico" as const,
       category: "Sistemas",
       estimatedCost: "alto" as const,
+      riskCategoryCode: "ibs_cbs",
     },
     {
       id: `a${idx * 3 + 2}`,
@@ -224,6 +230,7 @@ function generateFallbackPlan(branchAnalyses: BranchAnalysis[]): {
       riskLevel: "alto" as const,
       category: "Treinamento",
       estimatedCost: "medio" as const,
+      riskCategoryCode: "transicao",
     },
     {
       id: `a${idx * 3 + 3}`,
@@ -238,6 +245,7 @@ function generateFallbackPlan(branchAnalyses: BranchAnalysis[]): {
       riskLevel: "medio" as const,
       category: "Documentação",
       estimatedCost: "baixo" as const,
+      riskCategoryCode: "obrigacao_acessoria",
     },
   ]);
 
@@ -507,6 +515,7 @@ export const sessionActionPlanRouter = router({
         priority: item.priority,
         riskLevel: item.riskLevel,
         status: item.status,
+        riskCategoryCode: item.riskCategoryCode ?? null,
       }));
 
       return { matrixData, branches, overallRiskLevel: row.overallRiskLevel, complianceScore: row.complianceScore };


### PR DESCRIPTION
## Summary
- Adds `riskCategoryCode` (10 canonical LC 214/2025 codes) to the LLM prompt, JSON schema, and fallback plan in `routers-session-action-plan.ts`
- Passes `riskCategoryCode` through the `getMatrix` tRPC endpoint to the frontend
- Renders a compact `CategoryBadge` next to each item's `branchName` inside the 4×4 matrix cells in `MatrizRiscosSession.tsx`
- Backward-compatible: old stored plans without the field render gracefully (no badge shown)

## Files changed
| File | Change |
|---|---|
| `server/routers-session-action-plan.ts` | `PlanItem.riskCategoryCode`, LLM prompt + schema + fallback + `getMatrix` mapping |
| `client/src/pages/MatrizRiscosSession.tsx` | Import `CategoryBadge`, `MatrixItem.riskCategoryCode`, render in cells |

## Q1–Q5 Checklist
- [x] **Q1 — tsc** `pnpm check` (tsc --noEmit): **0 errors**
- [x] **Q2 — Backward compat** Old plans without `riskCategoryCode` render without badge (`item.riskCategoryCode && ...` guard)
- [x] **Q3 — ADR alignment** Follows ADR-0013 (CategoryBadge) + ADR-0025 (10 canonical codes from `risk_categories`)
- [x] **Q4 — No forbidden edits** Does NOT touch `routers-fluxo-v3.ts`, `riskEngine.ts`, `MatrizesV3.tsx`, or `project_risks_v3`
- [x] **Q5 — Scope** Only 2 files changed, 19 insertions, 3 deletions — minimal footprint

## Test plan
- [ ] Generate a new session action plan → verify `riskCategoryCode` appears in the API response
- [ ] Open Matriz de Riscos (session flow) → verify colored CategoryBadge appears next to each item's branch name
- [ ] Load an older session (without `riskCategoryCode`) → verify no badge, no crash
- [ ] Verify fallback plan items show correct badges (IBS/CBS, Transição, Obrig. Acessória)

🤖 Generated with [Claude Code](https://claude.com/claude-code)