### PR TITLE
chore: add Claude Code permissions settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git status*)",
+      "Bash(git add*)",
+      "Bash(git commit*)",
+      "Bash(git push*)",
+      "Bash(git checkout*)",
+      "Bash(git pull*)",
+      "Bash(npx tsc*)",
+      "Bash(pnpm tsc*)",
+      "Bash(pnpm test*)",
+      "Bash(pnpm build*)",
+      "Bash(grep*)",
+      "Bash(find*)",
+      "Bash(cat*)",
+      "Bash(ls*)",
+      "Bash(head*)",
+      "Bash(tail*)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` with pre-approved permissions for safe dev commands
- Covers: git ops, tsc, pnpm test/build, grep, find, cat, ls, head, tail

## Test plan
- [ ] Open a new Claude Code session in the repo and verify git/tsc/pnpm commands run without approval prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)