### PR TITLE
feat(rag): Z-13 Item B — ingestão RAG CGIBS Lote D (6 chunks)

### DIFF
--- a/server/rag-corpus-cgibs-template.ts
+++ b/server/rag-corpus-cgibs-template.ts
@@ -1,35 +1,16 @@
 /**
  * RAG Corpus — Resoluções CGIBS (Lote D)
  *
- * Template para ingestão das Resoluções do Comitê Gestor do IBS (CGIBS)
- * nº 1, 2 e 3/2026.
+ * Reexporta o corpus real de rag-corpus-cgibs-lote-d.ts adaptando
+ * para o formato esperado pelo script rag-ingest-cgibs.mjs.
  *
- * INSTRUÇÕES PARA O P.O.:
- * 1. Forneça os PDFs das resoluções ao Manus.
- * 2. O Manus irá extrair o texto e preencher os arrays abaixo.
- * 3. Após preenchimento, execute:
- *      node server/rag-ingest-cgibs.mjs
+ * Corpus real: server/rag-corpus-cgibs-lote-d.ts (6 chunks, 3 resoluções)
+ * Ingestão: node server/rag-ingest-cgibs.mjs
  *
- * METADADOS OBRIGATÓRIOS POR ENTRADA:
- *   lei:      'resolucao_cgibs_1' | 'resolucao_cgibs_2' | 'resolucao_cgibs_3'
- *   artigo:   identificador do dispositivo (ex: "Art. 1", "Art. 2, § 1")
- *   titulo:   título descritivo do dispositivo
- *   conteudo: texto integral do dispositivo
- *   topicos:  palavras-chave separadas por vírgula
- *   cnaeGroups: grupos CNAE afetados (ex: "47,49,62") ou "" para todos
- *   vigente:  true = dispositivo já vigente | false = dependente de regulamentação
- *   dependente_regulamentacao: true = aguarda ato normativo complementar
- *
- * DISTINÇÃO VIGENTE vs. DEPENDENTE DE REGULAMENTAÇÃO:
- *   - vigente=true, dependente_regulamentacao=false:
- *       Dispositivo com eficácia imediata. Incluir no corpus principal.
- *   - vigente=true, dependente_regulamentacao=true:
- *       Dispositivo vigente mas condicionado a regulamentação posterior.
- *       Incluir com flag para alerta na UI ("aguarda regulamentação").
- *   - vigente=false:
- *       Dispositivo com vacatio legis ou entrada em vigor futura.
- *       Incluir com flag para alerta na UI ("entrada em vigor: [data]").
+ * Preenchido em: 2026-04-12 (Sprint Z-13 — Item B)
  */
+
+import { cgibsLoteD } from './rag-corpus-cgibs-lote-d.js';
 
 export interface CgibsCorpusEntry {
   lei: 'resolucao_cgibs_1' | 'resolucao_cgibs_2' | 'resolucao_cgibs_3';
@@ -39,6 +20,7 @@ export interface CgibsCorpusEntry {
   topicos: string;
   cnaeGroups: string;
   chunkIndex: number;
+  anchor_id?: string;
   // Metadados específicos CGIBS
   vigente: boolean;
   dependente_regulamentacao: boolean;
@@ -48,40 +30,25 @@ export interface CgibsCorpusEntry {
   data_revisao?: string;    // ISO 8601
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
-// RESOLUÇÃO CGIBS Nº 1/2026
-// Preencher após receber o PDF do P.O.
-// ─────────────────────────────────────────────────────────────────────────────
-export const RAG_CORPUS_CGIBS_1: CgibsCorpusEntry[] = [
-  // EXEMPLO — substituir pelo conteúdo real após extração do PDF:
-  // {
-  //   lei: 'resolucao_cgibs_1',
-  //   artigo: 'Art. 1',
-  //   titulo: 'Resolução CGIBS nº 1/2026 — Objeto',
-  //   conteudo: 'Art. 1º Esta Resolução dispõe sobre...',
-  //   topicos: 'CGIBS, IBS, Comitê Gestor, resolução',
-  //   cnaeGroups: '',
-  //   chunkIndex: 0,
-  //   vigente: true,
-  //   dependente_regulamentacao: false,
-  //   autor: 'CGIBS',
-  //   data_revisao: '2026-04-11',
-  // },
-];
+// Adaptar cgibsLoteD para o formato CgibsCorpusEntry
+export const RAG_CORPUS_CGIBS: CgibsCorpusEntry[] = cgibsLoteD.map((entry, idx) => ({
+  lei: entry.lei,
+  artigo: entry.artigo,
+  titulo: entry.titulo,
+  conteudo: entry.conteudo,
+  topicos: Array.isArray(entry.topicos) ? entry.topicos.join(', ') : String(entry.topicos),
+  cnaeGroups: Array.isArray(entry.cnaeGroups) ? entry.cnaeGroups.join(',') : String(entry.cnaeGroups ?? ''),
+  chunkIndex: idx,
+  anchor_id: entry.anchor_id,
+  vigente: entry.vigente,
+  dependente_regulamentacao: entry.dependente_regulamentacao,
+  data_vigencia: entry.data_publicacao,
+  autor: 'CGIBS',
+  revisado_por: 'Manus',
+  data_revisao: '2026-04-12',
+}));
 
-// ─────────────────────────────────────────────────────────────────────────────
-// RESOLUÇÃO CGIBS Nº 2/2026
-// ─────────────────────────────────────────────────────────────────────────────
-export const RAG_CORPUS_CGIBS_2: CgibsCorpusEntry[] = [];
-
-// ─────────────────────────────────────────────────────────────────────────────
-// RESOLUÇÃO CGIBS Nº 3/2026
-// ─────────────────────────────────────────────────────────────────────────────
-export const RAG_CORPUS_CGIBS_3: CgibsCorpusEntry[] = [];
-
-// Corpus unificado (usado pelo script de ingestão)
-export const RAG_CORPUS_CGIBS = [
-  ...RAG_CORPUS_CGIBS_1,
-  ...RAG_CORPUS_CGIBS_2,
-  ...RAG_CORPUS_CGIBS_3,
-];
+// Aliases por resolução
+export const RAG_CORPUS_CGIBS_1 = RAG_CORPUS_CGIBS.filter(e => e.lei === 'resolucao_cgibs_1');
+export const RAG_CORPUS_CGIBS_2 = RAG_CORPUS_CGIBS.filter(e => e.lei === 'resolucao_cgibs_2');
+export const RAG_CORPUS_CGIBS_3 = RAG_CORPUS_CGIBS.filter(e => e.lei === 'resolucao_cgibs_3');


### PR DESCRIPTION
## Descrição
Conecta `rag-corpus-cgibs-template.ts` ao corpus real (`rag-corpus-cgibs-lote-d.ts`), habilitando a ingestão incremental das Resoluções CGIBS nº 1, 2 e 3/2026.

## Arquivo alterado
- `server/rag-corpus-cgibs-template.ts`: reexporta `cgibsLoteD` adaptando para o formato esperado pelo script de ingestão (topicos/cnaeGroups como string, chunkIndex numérico)

## Evidência SQL (AFTER)
```
lei                  | total
---------------------|------
resolucao_cgibs_1    | 4
resolucao_cgibs_2    | 1
resolucao_cgibs_3    | 1
TOTAL CGIBS: 6 (esperado: 6) ✅
```

3 leis · 6 chunks · todos vigentes · 0 dependentes de regulamentação

## Gates Q1–Q6
- Q1: branch separada ✅
- Q2: tsc 0 erros ✅
- Q3: sem DROP COLUMN ✅
- Q4: sem DIAGNOSTIC_READ_MODE=new ✅
- Q5: sem F-04 Fase 3 ✅
- Q6: evidência SQL AFTER fornecida ✅