### PR TITLE
feat(admin): Z-13 Item C+D — coluna descricao /admin/categorias + R-SYNC-01 CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ GAPs resolvidos: ARCH-06 · ARCH-07 · ARCH-08 · ARCH-09
 
 Correções pendentes: CONTRACT-01 · CONTRACT-02 · CONTRACT-03
 
-## Regra anti-bifurcação — Manus + Claude Code
+## R-SYNC-01 — Regra anti-bifurcação — Manus + Claude Code
 
 Quando Claude Code e Manus trabalham em paralelo,
 o S3 (storage de checkpoint do Manus) pode divergir

--- a/client/src/pages/AdminCategorias.tsx
+++ b/client/src/pages/AdminCategorias.tsx
@@ -413,6 +413,7 @@ export default function AdminCategorias() {
                   <TableHead>Vigência</TableHead>
                   <TableHead>Origem</TableHead>
                   <TableHead>Escopo</TableHead>
+                  <TableHead className="max-w-[220px]">Descrição</TableHead>
                   <TableHead className="w-[100px]">Ações</TableHead>
                 </TableRow>
               </TableHeader>
@@ -428,6 +429,17 @@ export default function AdminCategorias() {
                     </TableCell>
                     <TableCell className="text-xs text-gray-500">{cat.origem}</TableCell>
                     <TableCell className="text-xs text-gray-500">{cat.escopo}</TableCell>
+                    <TableCell
+                      className="text-xs text-gray-600 max-w-[220px] truncate"
+                      title={cat.descricao ?? undefined}
+                      data-testid={`cat-descricao-${cat.codigo}`}
+                    >
+                      {cat.descricao
+                        ? cat.descricao.length > 80
+                          ? cat.descricao.slice(0, 80) + "…"
+                          : cat.descricao
+                        : <span className="text-gray-300 italic">—</span>}
+                    </TableCell>
                     <TableCell>
                       <div className="flex gap-1">
                         <Button

--- a/server/lib/db-queries-risk-categories.ts
+++ b/server/lib/db-queries-risk-categories.ts
@@ -44,6 +44,7 @@ export interface RiskCategory {
   aprovado_por: string | null;
   aprovado_at: Date | null;
   chunk_origem_id: number | null;
+  descricao: string | null; // migration 0073 — Sprint Z-12
   created_at: Date;
   updated_at: Date;
 }


### PR DESCRIPTION
## Descrição
PR #B da Sprint Z-13 — dois itens cosméticos/UI sem alteração de schema.

## Item C — Coluna Descrição em /admin/categorias-de-risco

**Arquivos alterados:**
- `client/src/pages/AdminCategorias.tsx`: coluna Descrição adicionada na tabela de categorias ativas — truncada a 80 chars, tooltip nativo (`title`) mostra texto completo ao hover, `data-testid="cat-descricao-{codigo}"`
- `server/lib/db-queries-risk-categories.ts`: campo `descricao: string | null` adicionado à interface `RiskCategory` (campo já existe no banco via migration 0073, query usa `SELECT *`)

**Sem alteração de schema ou migration.**

## Item D — Cosmético CLAUDE.md

```diff
- ## Regra anti-bifurcação — Manus + Claude Code
+ ## R-SYNC-01 — Regra anti-bifurcação — Manus + Claude Code
```

Padroniza com `MANUS-GOVERNANCE.md`.

## Gates Q1–Q5
- Q1: branch separada ✅
- Q2: tsc 0 erros ✅
- Q3: sem DROP COLUMN ✅
- Q4: sem DIAGNOSTIC_READ_MODE=new ✅
- Q5: sem F-04 Fase 3 ✅