### PR TITLE
fix(stepper): redirect /matrizes-v3 → /risk-dashboard-v4

### DIFF
--- a/client/src/components/FlowStepper.tsx
+++ b/client/src/components/FlowStepper.tsx
@@ -29,7 +29,7 @@ const STEPS: { label: string; shortLabel: string; route: (id: number) => string 
   { label: "Projeto",       shortLabel: "Projeto",     route: (id) => `/projetos/${id}/formulario` },
   { label: "Questionário",  shortLabel: "Quest.",      route: (id) => `/projetos/${id}/questionario-v3` },
   { label: "Briefing",      shortLabel: "Briefing",    route: (id) => `/projetos/${id}/briefing-v3` },
-  { label: "Riscos",        shortLabel: "Riscos",      route: (id) => `/projetos/${id}/matrizes-v3` },
+  { label: "Riscos",        shortLabel: "Riscos",      route: (id) => `/projetos/${id}/risk-dashboard-v4` },
   { label: "Plano de Ação", shortLabel: "Plano",       route: (id) => `/projetos/${id}/plano-v3` },
 ];
 

--- a/client/src/pages/BriefingV3.tsx
+++ b/client/src/pages/BriefingV3.tsx
@@ -272,7 +272,7 @@ export default function BriefingV3() {
       await approveBriefing.mutateAsync({ projectId, briefingContent: briefing });
       clearTempData(projectId, 'etapa3');
       toast.success("Briefing aprovado! Avançando para Matrizes de Riscos...");
-      setLocation(`/projetos/${projectId}/matrizes-v3`);
+      setLocation(`/projetos/${projectId}/risk-dashboard-v4`);
     } catch {
       toast.error("Erro ao aprovar o briefing. Tente novamente.");
     } finally {

--- a/client/src/pages/FormularioProjeto.tsx
+++ b/client/src/pages/FormularioProjeto.tsx
@@ -60,7 +60,7 @@ export default function FormularioProjeto() {
     if (step <= 1) return `/projetos/${projectId}/questionario-v3`;
     if (step <= 2) return `/projetos/${projectId}/questionario-v3`;
     if (step <= 3) return `/projetos/${projectId}/briefing-v3`;
-    if (step <= 4) return `/projetos/${projectId}/matrizes-v3`;
+    if (step <= 4) return `/projetos/${projectId}/risk-dashboard-v4`;
     return `/projetos/${projectId}/plano-v3`;
   })();
 

--- a/client/src/pages/PlanoAcaoV3.tsx
+++ b/client/src/pages/PlanoAcaoV3.tsx
@@ -1486,7 +1486,7 @@ export default function PlanoAcaoV3() {
         )}
         {/* Header */}
         <div className="flex items-center gap-4">
-          <Button variant="ghost" className="gap-2 text-sm shrink-0" onClick={() => handleVoltarClick(`/projetos/${projectId}/matrizes-v3`, 4, "Riscos")}>
+          <Button variant="ghost" className="gap-2 text-sm shrink-0" onClick={() => handleVoltarClick(`/projetos/${projectId}/risk-dashboard-v4`, 4, "Riscos")}>
             <ArrowLeft className="h-4 w-4" />
             <span className="hidden sm:inline">Voltar às Matrizes</span>
             <span className="sm:hidden">Voltar</span>


### PR DESCRIPTION
## Summary
Redirects 4 hardcoded `/matrizes-v3` navigation points to `/risk-dashboard-v4`, completing the stepper migration to the v4 engine.

## Changes (4 files, 4 lines each)
| File | Line | Before | After |
|---|---|---|---|
| `BriefingV3.tsx` | 275 | `setLocation(.../matrizes-v3)` | `setLocation(.../risk-dashboard-v4)` |
| `FormularioProjeto.tsx` | 63 | `return .../matrizes-v3` | `return .../risk-dashboard-v4` |
| `PlanoAcaoV3.tsx` | 1489 | `handleVoltarClick(.../matrizes-v3, ...)` | `handleVoltarClick(.../risk-dashboard-v4, ...)` |
| `FlowStepper.tsx` | 32 | `route: .../matrizes-v3` | `route: .../risk-dashboard-v4` |

## Preserved (NOT changed)
- `App.tsx` — legacy route definition (backward compat)
- `MatrizesV3.tsx` — legacy component
- `DiagnosticoStepper.tsx` — already has `useNewRiskEngine` conditional
- `ProjetoDetalhesV2.tsx` — already has `useNewRiskEngine` conditional

## Verification
After changes, `grep -rn "matrizes-v3" client/src/` returns only:
- `App.tsx:139` (route definition)
- `ProjetoDetalhesV2.tsx:44` (conditional fallback)
- `DiagnosticoStepper.tsx:140` (conditional fallback)
- `DiagnosticoStepper.tsx:11` (docstring comment)

## Q1–Q5 Checklist
- [x] **Q1 — tsc** `tsc --noEmit`: **0 errors**
- [x] **Q2 — Backward compat** Legacy route in App.tsx preserved
- [x] **Q3 — No forbidden edits** Does NOT touch `routers-fluxo-v3.ts`, `riskEngine.ts`, `MatrizesV3.tsx`
- [x] **Q4 — No schema changes** Frontend-only
- [x] **Q5 — Scope** 4 files, 4 lines each — minimal surgical change

## Test plan
- [ ] Complete briefing → click "Aprovar" → navigates to `/risk-dashboard-v4` (not `/matrizes-v3`)
- [ ] Open FormularioProjeto at step 4 → redirects to `/risk-dashboard-v4`
- [ ] Open PlanoAcaoV3 → "Voltar às Matrizes" button → goes to `/risk-dashboard-v4`
- [ ] FlowStepper "Riscos" step → links to `/risk-dashboard-v4`
- [ ] Direct access to `/projetos/:id/matrizes-v3` still works (legacy route preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)