### PR TITLE
fix(z13): B-Z13-003 remover JOIN inválido com questionnaireQuestionsCache

### DIFF
--- a/server/routers/gapEngine.ts
+++ b/server/routers/gapEngine.ts
@@ -269,11 +269,8 @@ export const gapEngineRouter = router({
 
         // 3. Buscar respostas do questionário do projeto
         const [answers] = await pool.query<mysql.RowDataPacket[]>(
-          `SELECT qa.id, qa.cnaeCode, qa.questionIndex, qa.questionText, qa.answerValue,
-                  qq.requirement_id, qq.source_reference, qq.evidence_type
+          `SELECT qa.id, qa.cnaeCode, qa.questionIndex, qa.questionText, qa.answerValue
            FROM questionnaireAnswersV3 qa
-           LEFT JOIN questionnaireQuestionsCache qq ON qq.project_id = qa.projectId
-             AND qq.question_index = qa.questionIndex
            WHERE qa.projectId = ?
            ORDER BY qa.questionIndex`,
           [input.project_id]


### PR DESCRIPTION
## B-Z13-003 — Unknown column 'qq.project_id' in 'on clause'

**Causa raiz:** `gapEngine.ts:275` fazia `LEFT JOIN questionnaireQuestionsCache` usando `qq.project_id` e `qq.question_index`, mas:
- A tabela tem `projectId` (camelCase), não `project_id`
- A tabela não tem `question_index` — armazena `questionsJson` como blob
- As colunas `requirement_id`, `source_reference` e `evidence_type` também não existem na tabela

**Fix:** Remover o JOIN completamente. A query busca apenas `questionnaireAnswersV3`. O código downstream usa `req.code` como chave de mapeamento (não `requirement_id` do cache), então o comportamento é preservado.

**Evidência:** `grep qq. server/routers/gapEngine.ts → 0 ocorrências`
**tsc:** 0 erros · **Gate E:** desbloqueado