### PR TITLE
fix(B-Z13-004): pass risk_category_code as categoria in gapInputs

### DIFF
--- a/client/src/components/RiskDashboardV4.tsx
+++ b/client/src/components/RiskDashboardV4.tsx
@@ -442,6 +442,8 @@ export function RiskDashboardV4({ projectId }: RiskDashboardV4Props) {
         gapType: g.gap_type ?? "normativo",
         area: g.domain ?? "",
         descricao: g.gap_description ?? "",
+        // B-Z13-004: risk_category_code → categoria para o GapToRuleMapper (Caso A)
+        categoria: g.risk_category_code ?? undefined,
         sourceOrigin: "solaris" as const,
         requirementId: g.requirement_id,
         sourceReference: g.source_reference ?? "",


### PR DESCRIPTION
## Descrição

**Bug:** B-Z13-004 — Gate E bloqueado: "Sem categoria: 138"

### Causa Raiz

`RiskDashboardV4.tsx` construía `gapInputs` a partir do resultado de `analyzeGaps` mas omitia o campo `categoria`. Sem ele, `GapToRuleMapper` caía no **Caso B** (resolução por artigo), que retornava 0 candidatos → todos os 138 gaps ficavam `unmapped`.

O banco estava correto: `SELECT COUNT(risk_category_code) FROM regulatory_requirements_v3` → 138 mapeados, 0 NULLs.

### Fix

```tsx
// B-Z13-004: risk_category_code → categoria para o GapToRuleMapper (Caso A)
categoria: g.risk_category_code ?? undefined,
```

### Arquivo alterado

- `client/src/components/RiskDashboardV4.tsx` — +2 linhas

### Evidência JSON

```json
{
  "bug": "B-Z13-004",
  "file": "client/src/components/RiskDashboardV4.tsx",
  "linha": 445,
  "fix": "categoria: g.risk_category_code ?? undefined",
  "causa": "campo omitido no mapeamento gapInputs → GapToRuleMapper",
  "impacto": "138 unmapped → mapeados via Caso A",
  "tsc": "0 erros",
  "banco": "138 mapeados, 0 nulls",
  "sprint": "Z-13",
  "gate": "E"
}
```

### Checklist
- [x] tsc: 0 erros
- [x] Apenas arquivo do escopo declarado
- [x] Sem alteração de schema/migration
- [x] Fix cirúrgico (2 linhas)