### PR TITLE
fix(B-Z13-004): add risk_category_code to GapSchema + gap object + INSERT

### DIFF
--- a/server/routers/gapEngine.ts
+++ b/server/routers/gapEngine.ts
@@ -46,6 +46,8 @@ export const GapSchema = z.object({
   action_priority: z.enum(["imediata", "curto_prazo", "medio_prazo", "planejamento"]),
   estimated_days: z.number().int().min(1),
   recommended_actions: z.string(),
+  // B-Z13-004: risk_category_code propagado do regulatory_requirements_v3
+  risk_category_code: z.string().nullable().optional(),
 });
 
 export type Gap = z.infer<typeof GapSchema>;
@@ -357,6 +359,8 @@ export const gapEngineRouter = router({
             action_priority: actionPriority as Gap["action_priority"],
             estimated_days: estimatedDays,
             recommended_actions: `Regularizar ${req.name} conforme ${req.source_reference}`,
+            // B-Z13-004: propagar risk_category_code para o GapToRuleMapper (Caso A)
+            risk_category_code: req.risk_category_code ?? null,
           };
 
           gaps.push(gap);
@@ -381,8 +385,9 @@ export const gapEngineRouter = router({
                 gap_description, deterministic_reason, unmet_criteria, recommended_actions,
                 analysis_version, created_at, updated_at,
                 requirement_id, gap_classification, evaluation_confidence,
-                evaluation_confidence_reason, question_id, answer_value, source_reference
-              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW(), ?, ?, ?, ?, ?, ?, ?)`,
+                evaluation_confidence_reason, question_id, answer_value, source_reference,
+                risk_category_code
+              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW(), ?, ?, ?, ?, ?, ?, ?, ?)`,
               [
                 project.clientId ?? 1,
                 input.project_id,
@@ -413,6 +418,8 @@ export const gapEngineRouter = router({
                 gap.question_id,
                 gap.answer_value,
                 gap.source_reference,
+                // B-Z13-004: persistir risk_category_code para novos gaps
+                gap.risk_category_code ?? null,
               ]
             );
           }


### PR DESCRIPTION
## Descrição

**Bug:** B-Z13-004 — Gate E bloqueado: "Sem categoria: 138" (persistente após PR #495)

### Causa Raiz Exata

O **GapSchema** em `gapEngine.ts` não declarava o campo `risk_category_code`. Por isso:

1. O objeto `gap` construído no engine não incluía `risk_category_code`
2. O frontend recebia `g.risk_category_code = undefined`
3. `GapToRuleMapper` caía no **Caso B** (resolução por artigo) → 0 candidatos → 138 unmapped

O PR #495 já havia adicionado `categoria: g.risk_category_code ?? undefined` no frontend, mas o campo chegava `undefined` porque o backend não o propagava.

### 3 Fixes em `server/routers/gapEngine.ts`

| # | Local | Fix |
|---|---|---|
| 1 | GapSchema (L50) | `risk_category_code: z.string().nullable().optional()` |
| 2 | gap object (L363) | `risk_category_code: req.risk_category_code ?? null` |
| 3 | INSERT project_gaps_v3 (L389+422) | coluna + valor `risk_category_code` |

### Arquivo alterado

- `server/routers/gapEngine.ts` — +9 linhas, -2 linhas

### Evidência JSON

```json
{
  "bug": "B-Z13-004",
  "file": "server/routers/gapEngine.ts",
  "fixes": [
    "GapSchema +risk_category_code optional",
    "gap object +risk_category_code: req.risk_category_code",
    "INSERT +risk_category_code column+value"
  ],
  "tsc": "0 erros",
  "banco": "138 mapeados, 0 nulls em regulatory_requirements_v3",
  "backfill": "138 gaps projeto 2281 atualizados (backfill manual)",
  "sprint": "Z-13",
  "gate": "E"
}
```

### Checklist
- [x] tsc: 0 erros
- [x] Apenas arquivo do escopo declarado (gapEngine.ts)
- [x] Sem alteração de schema/migration
- [x] Fix cirúrgico (+9 linhas)