### PR TITLE
feat(z13.5-backend): migrations 0075/0076 + project-profile-extractor

### DIFF
--- a/drizzle/0075_risks_v4_rag_fields.sql
+++ b/drizzle/0075_risks_v4_rag_fields.sql
@@ -1,0 +1,17 @@
+-- Migration 0075 — Sprint Z-13.5 Tarefa A
+-- Adiciona campos de contexto operacional e validação RAG em risks_v4.
+-- Regra: ADD COLUMN apenas — nunca DROP COLUMN (ADR-0013 / bloqueio permanente).
+-- ─────────────────────────────────────────────────────────────────────────────
+
+ALTER TABLE risks_v4
+  ADD COLUMN risk_key              varchar(255)     NULL COMMENT 'Chave de dedup: {project_id}:{rule_id}:{categoria}',
+  ADD COLUMN operational_context   json             NULL COMMENT 'Contexto operacional do projeto: cnaes, taxRegime, companySize, tipoOperacao, etc.',
+  ADD COLUMN evidence_count        int              NOT NULL DEFAULT 0 COMMENT 'Número de gaps consolidados neste risco',
+  ADD COLUMN rag_validated         tinyint(1)       NOT NULL DEFAULT 0 COMMENT '1 = validado pelo RAG; 0 = não validado',
+  ADD COLUMN rag_confidence        decimal(3,2)     NOT NULL DEFAULT 0 COMMENT 'Confiança da validação RAG (0.00–1.00)',
+  ADD COLUMN rag_artigo_exato      varchar(255)     NULL COMMENT 'Artigo exato encontrado no RAG',
+  ADD COLUMN rag_paragrafo         varchar(100)     NULL COMMENT 'Parágrafo do artigo encontrado no RAG',
+  ADD COLUMN rag_inciso            varchar(100)     NULL COMMENT 'Inciso do artigo encontrado no RAG',
+  ADD COLUMN rag_trecho_legal      text             NULL COMMENT 'Trecho legal exato do documento RAG',
+  ADD COLUMN rag_query             varchar(500)     NULL COMMENT 'Query usada para busca no RAG',
+  ADD COLUMN rag_validation_note   text             NULL COMMENT 'Nota de validação RAG (motivo de não validação ou observações)';

--- a/drizzle/0076_normative_product_rules.sql
+++ b/drizzle/0076_normative_product_rules.sql
@@ -1,0 +1,42 @@
+-- Migration 0076 — Sprint Z-13.5 Tarefa B
+-- Cria tabela normative_product_rules para inferência de alíquota zero
+-- por NCM (cesta básica Art. 125 Anexo I + Art. 148 Anexo XV LC 214/2025).
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS normative_product_rules (
+  id              int AUTO_INCREMENT PRIMARY KEY,
+  regime          varchar(64)   NOT NULL COMMENT 'Categoria de risco: aliquota_zero, etc.',
+  legal_reference varchar(255)  NOT NULL COMMENT 'Referência legal: Art. 125 c/c Anexo I LC 214/2025',
+  ncm_code        varchar(20)   NOT NULL COMMENT 'Código NCM (prefixo ou exato)',
+  match_mode      enum('exact','prefix') NOT NULL DEFAULT 'exact' COMMENT 'Modo de match: exact = código exato; prefix = começa com',
+  active          tinyint(1)    NOT NULL DEFAULT 1,
+  source_version  varchar(64)   NOT NULL DEFAULT 'LC214_2025',
+  created_at      timestamp     DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_normative_regime  (regime),
+  INDEX idx_normative_ncm     (ncm_code),
+  INDEX idx_normative_active  (active)
+);
+
+-- Seed: NCMs da cesta básica — Art. 125 Anexo I LC 214/2025 (alíquota zero IBS/CBS)
+INSERT INTO normative_product_rules (regime, legal_reference, ncm_code, match_mode, active, source_version) VALUES
+  ('aliquota_zero', 'Art. 125 c/c Anexo I LC 214/2025', '1006.20',    'prefix', 1, 'LC214_2025'),
+  ('aliquota_zero', 'Art. 125 c/c Anexo I LC 214/2025', '1006.30',    'prefix', 1, 'LC214_2025'),
+  ('aliquota_zero', 'Art. 125 c/c Anexo I LC 214/2025', '1006.40.00', 'exact',  1, 'LC214_2025'),
+  ('aliquota_zero', 'Art. 125 c/c Anexo I LC 214/2025', '0401.10',    'prefix', 1, 'LC214_2025'),
+  ('aliquota_zero', 'Art. 125 c/c Anexo I LC 214/2025', '0401.20',    'prefix', 1, 'LC214_2025'),
+  ('aliquota_zero', 'Art. 125 c/c Anexo I LC 214/2025', '0402',       'prefix', 1, 'LC214_2025'),
+  ('aliquota_zero', 'Art. 125 c/c Anexo I LC 214/2025', '1901.10',    'prefix', 1, 'LC214_2025'),
+  ('aliquota_zero', 'Art. 125 c/c Anexo I LC 214/2025', '2106.90.90', 'exact',  1, 'LC214_2025'),
+-- Seed: NCMs da cesta básica — Art. 148 Anexo XV LC 214/2025 (alíquota zero IBS/CBS)
+  ('aliquota_zero', 'Art. 148 c/c Anexo XV LC 214/2025', '0407.2', 'prefix', 1, 'LC214_2025'),
+  ('aliquota_zero', 'Art. 148 c/c Anexo XV LC 214/2025', '07.01',  'prefix', 1, 'LC214_2025'),
+  ('aliquota_zero', 'Art. 148 c/c Anexo XV LC 214/2025', '07.02',  'prefix', 1, 'LC214_2025'),
+  ('aliquota_zero', 'Art. 148 c/c Anexo XV LC 214/2025', '07.03',  'prefix', 1, 'LC214_2025'),
+  ('aliquota_zero', 'Art. 148 c/c Anexo XV LC 214/2025', '07.04',  'prefix', 1, 'LC214_2025'),
+  ('aliquota_zero', 'Art. 148 c/c Anexo XV LC 214/2025', '07.05',  'prefix', 1, 'LC214_2025'),
+  ('aliquota_zero', 'Art. 148 c/c Anexo XV LC 214/2025', '07.06',  'prefix', 1, 'LC214_2025'),
+  ('aliquota_zero', 'Art. 148 c/c Anexo XV LC 214/2025', '07.09',  'prefix', 1, 'LC214_2025'),
+  ('aliquota_zero', 'Art. 148 c/c Anexo XV LC 214/2025', '08.03',  'prefix', 1, 'LC214_2025'),
+  ('aliquota_zero', 'Art. 148 c/c Anexo XV LC 214/2025', '08.05',  'prefix', 1, 'LC214_2025'),
+  ('aliquota_zero', 'Art. 148 c/c Anexo XV LC 214/2025', '08.07',  'prefix', 1, 'LC214_2025'),
+  ('aliquota_zero', 'Art. 148 c/c Anexo XV LC 214/2025', '08.08',  'prefix', 1, 'LC214_2025');

--- a/server/lib/project-profile-extractor.ts
+++ b/server/lib/project-profile-extractor.ts
@@ -1,0 +1,169 @@
+// project-profile-extractor.ts — Sprint Z-13.5 Tarefa C
+// Extrai e normaliza o ProjectProfile a partir do JSON do projeto no banco.
+// Usa raw SQL com os nomes EXATOS das colunas conforme schema real:
+//   confirmedCnaes, operationProfile, product_answers, taxRegime, companySize
+//   (mix de camelCase e snake_case conforme auditoria de schema pré-Z-13.5)
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { drizzle } from "drizzle-orm/mysql2";
+
+// Lazy singleton — mesmo padrão de db-queries-risks-v4.ts
+let _db: ReturnType<typeof drizzle> | null = null;
+async function getDb(): Promise<ReturnType<typeof drizzle>> {
+  if (!_db && process.env.DATABASE_URL) {
+    _db = drizzle(process.env.DATABASE_URL);
+  }
+  if (!_db) throw new Error("[project-profile-extractor] DATABASE_URL não configurado");
+  return _db;
+}
+
+async function query<T = unknown>(sql: string, params: unknown[] = []): Promise<T[]> {
+  const db = await getDb();
+  const [rows] = await (db.$client as any).promise().execute(sql, params);
+  return rows as T[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Interface pública
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface ProjectProfile {
+  projectId: number;
+  /** CNAEs confirmados pelo cliente (array de strings, ex: ["4711-3/01", "4712-1/00"]) */
+  cnaes: string[];
+  /** Regime tributário: simples_nacional | lucro_presumido | lucro_real */
+  taxRegime: string | null;
+  /** Porte da empresa: mei | micro | pequena | media | grande */
+  companySize: string | null;
+  /** Tipo de operação: ex. "varejista", "atacadista", "prestador_servico" */
+  tipoOperacao: string | null;
+  /** Tipo de cliente: ex. "b2b", "b2c", "b2b2c" */
+  tipoCliente: string | null;
+  /** Operação multiestadual: true/false */
+  multiestadual: boolean | null;
+  /** Meios de pagamento aceitos: ex. ["cartao_credito", "pix", "boleto"] */
+  meiosPagamento: string[] | null;
+  /** Intermediários financeiros: ex. ["adquirente", "marketplace"] */
+  intermediarios: string[] | null;
+  /** NCMs dos produtos comercializados (extraídos de product_answers) */
+  productNcms: string[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Row bruto retornado pelo banco
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface ProjectRow {
+  id: number;
+  confirmedCnaes: string | null;       // camelCase no banco
+  operationProfile: string | null;     // camelCase no banco
+  product_answers: string | null;      // snake_case no banco (migration posterior)
+  taxRegime: string | null;            // camelCase no banco
+  companySize: string | null;          // camelCase no banco
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers de parse seguro
+// ─────────────────────────────────────────────────────────────────────────────
+
+function safeParseArray(raw: string | null, fallback: unknown[] = []): unknown[] {
+  if (!raw) return fallback;
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function safeParseObject(raw: string | null): Record<string, unknown> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Extrator principal
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Extrai o ProjectProfile do banco para um projeto específico.
+ * Retorna null se o projeto não for encontrado.
+ */
+export async function extractProjectProfile(
+  projectId: number
+): Promise<ProjectProfile | null> {
+  // Nomes de colunas EXATOS conforme auditoria de schema pré-Z-13.5.
+  // NÃO alterar sem nova auditoria — mix intencional de camelCase e snake_case.
+  const rows = await query<ProjectRow>(
+    `SELECT
+       id,
+       confirmedCnaes,
+       operationProfile,
+       product_answers,
+       taxRegime,
+       companySize
+     FROM projects
+     WHERE id = ?
+     LIMIT 1`,
+    [projectId]
+  );
+
+  if (!rows || rows.length === 0) return null;
+
+  const row = rows[0];
+
+  // Extrair CNAEs confirmados
+  const cnaesRaw = safeParseArray(row.confirmedCnaes);
+  const cnaes = cnaesRaw
+    .map((c: unknown) => {
+      if (typeof c === "string") return c;
+      if (c && typeof c === "object") {
+        const obj = c as Record<string, unknown>;
+        return (obj.cnae ?? obj.code ?? obj.id ?? "") as string;
+      }
+      return "";
+    })
+    .filter(Boolean);
+
+  // Extrair campos do operationProfile
+  const opProfile = safeParseObject(row.operationProfile);
+
+  // Extrair NCMs dos product_answers
+  const productAnswersRaw = safeParseArray(row.product_answers);
+  const productNcms = productAnswersRaw
+    .map((p: unknown) => {
+      if (p && typeof p === "object") {
+        const obj = p as Record<string, unknown>;
+        return ((obj.ncm ?? obj.ncmCode ?? "") as string) || "";
+      }
+      return "";
+    })
+    .filter(Boolean);
+
+  return {
+    projectId: row.id,
+    cnaes,
+    taxRegime: row.taxRegime ?? null,
+    companySize: row.companySize ?? null,
+    tipoOperacao: (opProfile.tipoOperacao as string) ?? null,
+    tipoCliente: (opProfile.tipoCliente as string) ?? null,
+    multiestadual:
+      opProfile.multiestadual != null
+        ? Boolean(opProfile.multiestadual)
+        : null,
+    meiosPagamento: Array.isArray(opProfile.meiosPagamento)
+      ? (opProfile.meiosPagamento as string[])
+      : null,
+    intermediarios: Array.isArray(opProfile.intermediarios)
+      ? (opProfile.intermediarios as string[])
+      : null,
+    productNcms,
+  };
+}


### PR DESCRIPTION
## Sprint Z-13.5 — Backend (Tarefas A, B, C)

### Tarefa A — Migration 0075: novos campos em `risks_v4`
11 colunas adicionadas (ADD COLUMN apenas — sem DROP):
`risk_key`, `operational_context`, `evidence_count`, `rag_validated`, `rag_confidence`, `rag_artigo_exato`, `rag_paragrafo`, `rag_inciso`, `rag_trecho_legal`, `rag_query`, `rag_validation_note`

### Tarefa B — Migration 0076: tabela `normative_product_rules`
Tabela nova para inferência de alíquota zero por NCM.
Seed: 20 NCMs da cesta básica (Art. 125 Anexo I + Art. 148 Anexo XV LC 214/2025)

### Tarefa C — `server/lib/project-profile-extractor.ts`
Função `extractProjectProfile(projectId)` que lê e normaliza o ProjectProfile
com nomes exatos de colunas conforme auditoria schema pré-Z-13.5.

### Evidência JSON
```json
{
  "tarefa_a": { "migration": "0075", "colunas_adicionadas": 11, "banco": "OK" },
  "tarefa_b": { "migration": "0076", "normative_product_rules": 20, "banco": "OK" },
  "tarefa_c": { "arquivo": "server/lib/project-profile-extractor.ts", "tsc": "0 erros" },
  "tsc": "0 erros",
  "head": "1dfe3f0"
}
```