### PR TITLE
feat(engine): integrate risks pipeline into router

### DIFF
--- a/docs/risks/RISK-TECH-01.md
+++ b/docs/risks/RISK-TECH-01.md
@@ -1,0 +1,29 @@
+# RISK-TECH-01 — Busca RAG baseada em LIKE pode gerar falsos negativos
+
+**ID:** RISK-TECH-01  
+**Sprint:** Z-13.5  
+**Status:** ABERTO  
+**Severidade:** Média
+
+## Causa
+
+TiDB Cloud não suporta FULLTEXT index nativamente. A busca no corpus RAG (`ragDocuments.conteudo`) usa `LIKE '%termo%'` que:
+- Não tem ranking de relevância
+- Pode falhar com termos parciais ou acentuação diferente
+- Performance O(n) em tabelas grandes
+
+## Impacto
+
+Um risco válido pode ser marcado como `rag_validated = false` (tinyint 0) mesmo quando a base legal existe no corpus. Isso reduz a confiança do risco em 25% (`confidence *= 0.75`) mas NÃO remove o risco.
+
+## Mitigação atual
+
+1. **Busca por artigo estruturado** (primária): `WHERE artigo LIKE '%Art. X%'`
+2. **Fallback textual** por termos da categoria: `WHERE conteudo LIKE '%split payment%'`
+3. Risco nunca é removido por falta de validação RAG — apenas reduz confidence
+
+## Resolução futura
+
+- Migrar para embedding search (OpenAI embeddings + cosine similarity)
+- Ou migrar para PostgreSQL com `pg_trgm` para fuzzy matching
+- Ou implementar FULLTEXT index quando TiDB suportar (roadmap TiDB 8.x)

--- a/server/lib/db-queries-risks-v4.ts
+++ b/server/lib/db-queries-risks-v4.ts
@@ -272,6 +272,22 @@ export async function insertRiskV4(data: InsertRiskV4): Promise<string> {
 }
 
 /**
+ * Sprint Z-13.5: Remove todos os riscos de um projeto (hard delete para re-geração).
+ * Também remove action_plans e tasks associados (cascade manual).
+ */
+export async function deleteRisksByProject(projectId: number): Promise<number> {
+  // Cascade: tasks → action_plans → risks
+  await query(`DELETE t FROM tasks t
+    INNER JOIN action_plans ap ON t.action_plan_id = ap.id
+    WHERE ap.project_id = ?`, [projectId]);
+  await query(`DELETE FROM action_plans WHERE project_id = ?`, [projectId]);
+  const result = await query<{ affectedRows?: number }>(
+    `DELETE FROM risks_v4 WHERE project_id = ?`, [projectId]);
+  // MySQL2 returns ResultSetHeader with affectedRows — extract safely
+  return (result as any)?.affectedRows ?? 0;
+}
+
+/**
  * Lista todos os riscos ativos de um projeto.
  */
 export async function getRisksV4ByProject(

--- a/server/lib/generate-risks-pipeline.ts
+++ b/server/lib/generate-risks-pipeline.ts
@@ -1,0 +1,117 @@
+// generate-risks-pipeline.ts — Sprint Z-13.5
+// Orquestra: consolidateRisks → inferNormativeRisks → merge → enrichWithRag
+// Arquivo novo — não altera nenhum arquivo existente.
+
+import { consolidateRisks, type GapRule, type OperationalContext } from "./risk-engine-v4";
+import { inferNormativeRisks } from "./normative-inference";
+import { enrichRiskWithRag } from "./rag-risk-validator";
+import { extractProjectProfile } from "./project-profile-extractor";
+import type { InsertRiskV4 } from "./db-queries-risks-v4";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface PipelineSummary {
+  total: number;
+  alta: number;
+  media: number;
+  oportunidades: number;
+  rag_validated: number;
+  inferred: number;
+}
+
+export interface PipelineResult {
+  risks: InsertRiskV4[];
+  summary: PipelineSummary;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function mergeByRiskKey(risks: InsertRiskV4[]): InsertRiskV4[] {
+  const map = new Map<string, InsertRiskV4>();
+  for (const risk of risks) {
+    const key = risk.risk_key ?? risk.rule_id;
+    map.set(key, risk);
+  }
+  return Array.from(map.values());
+}
+
+async function enrichAllWithRag(
+  risks: InsertRiskV4[],
+  timeoutMs: number,
+): Promise<InsertRiskV4[]> {
+  try {
+    const enriched = await Promise.race([
+      Promise.all(risks.map((r) => enrichRiskWithRag(r))),
+      new Promise<InsertRiskV4[]>((_, reject) =>
+        setTimeout(() => reject(new Error("RAG timeout")), timeoutMs)
+      ),
+    ]);
+    return enriched;
+  } catch {
+    // Timeout or error — return risks without RAG enrichment
+    return risks;
+  }
+}
+
+// ─── Pipeline principal ──────────────────────────────────────────────────────
+
+/**
+ * Pipeline completa de geração de riscos v4.
+ * 1. Extrai perfil do projeto
+ * 2. Consolida gaps em riscos
+ * 3. Infere riscos normativos
+ * 4. Merge + dedup por risk_key
+ * 5. Enriquece com RAG (timeout 3s)
+ *
+ * NÃO persiste — o caller (router) é responsável por persistir.
+ */
+export async function generateRisksV4Pipeline(
+  projectId: number,
+  gaps: GapRule[],
+  actorId: number,
+): Promise<PipelineResult> {
+  // 1. Extrair perfil do projeto
+  const profile = await extractProjectProfile(projectId);
+
+  // 2. Extrair contexto operacional
+  const context: OperationalContext = profile
+    ? {
+        tipoOperacao: profile.tipoOperacao ?? undefined,
+        tipoCliente: profile.tipoCliente ?? undefined,
+        multiestadual: profile.multiestadual ?? undefined,
+        meiosPagamento: profile.meiosPagamento ?? undefined,
+        intermediarios: profile.intermediarios ?? undefined,
+      }
+    : {};
+
+  // 3. Consolidar gaps em riscos
+  const consolidated = await consolidateRisks(projectId, gaps, context, actorId);
+
+  // 4. Inferir riscos normativos independentes
+  let inferred: InsertRiskV4[] = [];
+  if (profile) {
+    try {
+      inferred = await inferNormativeRisks(projectId, profile);
+    } catch {
+      // Non-fatal — normative inference is additive
+    }
+  }
+
+  // 5. Merge + dedup por risk_key (último vence em colisão)
+  const merged = mergeByRiskKey([...consolidated, ...inferred]);
+
+  // 6. Enriquecer com RAG (timeout 3s)
+  const enriched = await enrichAllWithRag(merged, 3000);
+
+  // 7. Summary
+  const summary: PipelineSummary = {
+    total: enriched.length,
+    alta: enriched.filter((r) => r.severidade === "alta").length,
+    media: enriched.filter((r) => r.severidade === "media").length,
+    oportunidades: enriched.filter((r) => r.type === "opportunity").length,
+    rag_validated: enriched.filter((r) => r.rag_validated === 1).length,
+    inferred: inferred.length,
+  };
+
+  return { risks: enriched, summary };
+}

--- a/server/routers/risks-v4.ts
+++ b/server/routers/risks-v4.ts
@@ -15,6 +15,7 @@ import { TRPCError } from "@trpc/server";
 import { router, protectedProcedure } from "../_core/trpc";
 import { computeRiskMatrix, buildActionPlans } from "../lib/risk-engine-v4";
 import type { GapRule } from "../lib/risk-engine-v4";
+import { generateRisksV4Pipeline } from "../lib/generate-risks-pipeline";
 // Sprint Z-10 PR #B — ACL Gap→Risk
 import { GapToRuleMapper } from "../lib/gap-to-rule-mapper";
 import { getActiveCategories, getCategoryByCodigo } from "../lib/risk-category.repository.drizzle";
@@ -38,6 +39,7 @@ import {
   updateTaskStatus,
   softDeleteTaskV4,
   getProjectAuditLog,
+  deleteRisksByProject,
 } from "../lib/db-queries-risks-v4";
 import type {
   CategoriaV4,
@@ -101,54 +103,58 @@ export const risksV4Router = router({
         user_role: ctx.user.role ?? "user",
       };
 
-      // Engine determinístico — função pura
-      const risks = computeRiskMatrix(gaps as GapRule[]);
-      const actionPlans = buildActionPlans(risks);
+      // Sprint Z-13.5: limpar snapshot anterior
+      await deleteRisksByProject(projectId);
 
+      // Sprint Z-13.5: pipeline consolidada
+      const { risks, summary } = await generateRisksV4Pipeline(
+        projectId,
+        gaps as GapRule[],
+        ctx.user.id,
+      );
+
+      // Persistir riscos consolidados
       const riskIds: string[] = [];
-
       for (const risk of risks) {
-        const id = await insertRiskV4WithAudit(
-          {
-            project_id: projectId,
-            rule_id: risk.ruleId,
-            type: risk.severity === "oportunidade" ? "opportunity" : "risk",
-            categoria: risk.categoria as CategoriaV4,
-            titulo: `[${risk.categoria}] ${risk.artigo}`,
-            descricao: risk.sourceReference,
-            artigo: risk.artigo,
-            severidade: risk.severity as SeveridadeV4,
-            urgencia: risk.urgency as UrgenciaV4,
-            evidence: { gapClassification: risk.gapClassification, requirementId: risk.requirementId },
-            breadcrumb: risk.breadcrumb,
-            source_priority: risk.fonte as SourcePriorityV4,
-            confidence: 1.0,
-            created_by: ctx.user.id,
-            updated_by: ctx.user.id,
-          },
-          actor
-        );
+        const id = await insertRiskV4WithAudit(risk, actor);
         riskIds.push(id);
       }
 
-      // Persistir planos de ação para riscos não-oportunidade
+      // Gerar planos de ação para riscos não-oportunidade
+      const actionPlans = buildActionPlans(
+        risks
+          .filter((r) => r.type === "risk")
+          .map((r) => ({
+            ruleId: r.rule_id,
+            categoria: r.categoria,
+            artigo: r.artigo,
+            fonte: r.source_priority,
+            severity: r.severidade as "alta" | "media" | "oportunidade",
+            urgency: r.urgencia as "imediata" | "curto_prazo" | "medio_prazo",
+            breadcrumb: (Array.isArray(r.breadcrumb) ? r.breadcrumb : []) as [string, string, string, string],
+            gapClassification: "consolidado",
+            requirementId: r.rule_id,
+            sourceReference: r.descricao ?? "",
+            domain: "",
+          }))
+      );
+
+      const prazoMap: Record<string, PrazoActionPlan> = {
+        imediata: "30_dias",
+        curto_prazo: "60_dias",
+        medio_prazo: "90_dias",
+      };
       const planIds: string[] = [];
       for (let i = 0; i < actionPlans.length; i++) {
         const plan = actionPlans[i];
-        const riskId = riskIds[i];
+        const riskId = riskIds.find((_id, idx) => risks[idx]?.rule_id === plan.riskRuleId);
         if (!riskId) continue;
-
-        const prazoMap: Record<string, PrazoActionPlan> = {
-          imediata: "30_dias",
-          curto_prazo: "60_dias",
-          medio_prazo: "90_dias",
-        };
 
         const id = await insertActionPlanV4WithAudit(
           {
             project_id: projectId,
             risk_id: riskId,
-            titulo: `Plano: [${plan.categoria}] ${plan.artigo}`,
+            titulo: `Plano: ${plan.categoria} — ${plan.artigo}`,
             responsavel: "equipe_compliance",
             prazo: prazoMap[plan.prioridade] ?? "60_dias",
             created_by: ctx.user.id,
@@ -164,6 +170,7 @@ export const risksV4Router = router({
         actionPlansGenerated: planIds.length,
         riskIds,
         planIds,
+        summary,
       };
     }),
 
@@ -551,38 +558,28 @@ export const risksV4Router = router({
       mappedRules: z.array(GapRuleSchema),
     }))
     .mutation(async ({ input, ctx }) => {
-      const risks = computeRiskMatrix(input.mappedRules as GapRule[]);
-      const actionPlans = buildActionPlans(risks);
       const actor = {
         user_id: ctx.user.id,
         user_name: ctx.user.name ?? ctx.user.email ?? "unknown",
         user_role: ctx.user.role ?? "user",
       };
+
+      // Sprint Z-13.5: limpar snapshot anterior + pipeline consolidada
+      await deleteRisksByProject(input.projectId);
+
+      const { risks, summary } = await generateRisksV4Pipeline(
+        input.projectId,
+        input.mappedRules as GapRule[],
+        ctx.user.id,
+      );
+
       const riskIds: string[] = [];
       for (const risk of risks) {
-        const id = await insertRiskV4WithAudit(
-          {
-            project_id: input.projectId,
-            rule_id: risk.ruleId,
-            type: risk.severity === "oportunidade" ? "opportunity" : "risk",
-            categoria: risk.categoria as import("../lib/db-queries-risks-v4").CategoriaV4,
-            titulo: `[${risk.categoria}] ${risk.artigo}`,
-            descricao: risk.sourceReference,
-            artigo: risk.artigo,
-            severidade: risk.severity as import("../lib/db-queries-risks-v4").SeveridadeV4,
-            urgencia: risk.urgency as import("../lib/db-queries-risks-v4").UrgenciaV4,
-            evidence: { gapClassification: risk.gapClassification, requirementId: risk.requirementId },
-            breadcrumb: risk.breadcrumb,
-            source_priority: risk.fonte as import("../lib/db-queries-risks-v4").SourcePriorityV4,
-            confidence: 1.0,
-            created_by: ctx.user.id,
-            updated_by: ctx.user.id,
-          },
-          actor
-        );
+        const id = await insertRiskV4WithAudit(risk, actor);
         riskIds.push(id);
       }
-      return { risks, actionPlans, inserted: riskIds.length };
+
+      return { inserted: riskIds.length, summary };
     }),
 
   /**


### PR DESCRIPTION
## Summary
Sprint Z-13.5 integration — connects the consolidated risk pipeline to the router.

**4 files changed**: 215 insertions, 56 deletions. 1 new pipeline file, 1 risk doc.

## Changes

### `generate-risks-pipeline.ts` (NEW)
Orchestrates the full pipeline:
1. `extractProjectProfile(projectId)` → context
2. `consolidateRisks(gaps, context)` → N gaps → M risks
3. `inferNormativeRisks(projectId, profile)` → normative opportunities
4. `mergeByRiskKey()` → dedup consolidated + inferred
5. `enrichAllWithRag()` → RAG validation (3s timeout)
6. Returns `{ risks, summary }` — does NOT persist

### `db-queries-risks-v4.ts`
- `deleteRisksByProject(projectId)` — cascade delete tasks → action_plans → risks_v4

### `risks-v4.ts` router
- `generateRisks`: clears previous snapshot → runs pipeline → persists → action plans
- `generateRisksFromGaps`: same pipeline integration
- Both return `summary` with counts (alta/media/oportunidades/rag_validated/inferred)

### `docs/risks/RISK-TECH-01.md` (NEW)
Documents LIKE-based RAG search limitation on TiDB Cloud.

## Q1–Q5 Checklist
- [x] **Q1 — tsc** `tsc --noEmit`: **0 errors**
- [x] **Q2 — Backward compat** `computeRiskMatrix` preserved as export
- [x] **Q3 — No forbidden edits** `routers-fluxo-v3.ts` untouched
- [x] **Q4 — Schema** Uses existing migrations 0075+0076 (no new migrations)
- [x] **Q5 — Tests** 40/40 pass

## Test plan
- [ ] Call `generateRisks` with 50+ gaps → verify fewer risks than gaps (consolidation working)
- [ ] Verify `summary` in response includes `rag_validated`, `inferred` counts
- [ ] Call `generateRisks` twice → second call clears first snapshot (no duplicates)
- [ ] Profile with payment triggers → `split_payment` risk inferred
- [ ] RAG timeout (simulate slow DB) → risks returned without RAG enrichment

🤖 Generated with [Claude Code](https://claude.com/claude-code)