### PR TITLE
fix(B-Z13.5-002): suporte dual-schema operationProfile

### DIFF
--- a/server/lib/project-profile-extractor.ts
+++ b/server/lib/project-profile-extractor.ts
@@ -157,17 +157,34 @@ export async function extractProjectProfile(
     })
     .filter(Boolean);
 
+  // B-Z13.5-002: suporte dual-schema
+  // Novo formulário: operationType / multiState / clientType (array)
+  // Schema legado:   tipoOperacao  / multiestadual / tipoCliente (array)
+  const tipoOperacaoRaw =
+    (opProfile.operationType as string) ??
+    (opProfile.tipoOperacao as string) ??
+    null;
+
+  const clientTypeRaw = opProfile.clientType ?? opProfile.tipoCliente;
+  const tipoClienteRaw = Array.isArray(clientTypeRaw)
+    ? (clientTypeRaw as string[]).join(",")
+    : (clientTypeRaw as string) ?? null;
+
+  const multiestadualRaw =
+    opProfile.multiState != null
+      ? Boolean(opProfile.multiState)
+      : opProfile.multiestadual != null
+        ? Boolean(opProfile.multiestadual)
+        : null;
+
   return {
     projectId: row.id,
     cnaes,
     taxRegime: row.taxRegime ?? null,
     companySize: row.companySize ?? null,
-    tipoOperacao: (opProfile.tipoOperacao as string) ?? null,
-    tipoCliente: (opProfile.tipoCliente as string) ?? null,
-    multiestadual:
-      opProfile.multiestadual != null
-        ? Boolean(opProfile.multiestadual)
-        : null,
+    tipoOperacao: tipoOperacaoRaw,
+    tipoCliente: tipoClienteRaw,
+    multiestadual: multiestadualRaw,
     meiosPagamento: Array.isArray(opProfile.meiosPagamento)
       ? (opProfile.meiosPagamento as string[])
       : null,


### PR DESCRIPTION
## Problema

O `project-profile-extractor.ts` só lia campos do schema legado (`tipoOperacao`, `multiestadual`, `tipoCliente`). O novo formulário de criação de projetos salva com nomes diferentes (`operationType`, `multiState`, `clientType`), causando `risk_key = ::op:na::geo:mono` em todos os projetos novos.

## Evidência (JSON_KEYS auditoria Sprint Z-13.5)

```json
// Projeto 30382 (novo formulário)
{"operationType": "comercio", "multiState": true, "clientType": ["b2b"]}

// Projeto 1 (legado)
{"tipoOperacao": "comercio", "multiestadual": true, "tipoCliente": ["B2B"]}
```

## Fix

Fallback chain no extractor:
- `operationType ?? tipoOperacao`
- `multiState ?? multiestadual`  
- `clientType ?? tipoCliente`

## Testes
- tsc: 0 erros
- Compatibilidade retroativa: projetos legados continuam funcionando

```json
{"evidence": {"proj_30382_keys": ["clientType","multiState","operationType","principaisProdutos","principaisServicos"], "proj_1_keys": ["intermediarios","meiosPagamento","multiestadual","tipoCliente","tipoOperacao"], "tsc_errors": 0}}
```