### PR TITLE
fix(z13.5): complete operationProfile field mapping (B-Z13.5-002)

### DIFF
--- a/server/lib/project-profile-extractor.ts
+++ b/server/lib/project-profile-extractor.ts
@@ -165,10 +165,13 @@ export async function extractProjectProfile(
     (opProfile.tipoOperacao as string) ??
     null;
 
+  // clientType na UI é string[] (ex: ["B2B"]). Normalizar para string único lowercase.
   const clientTypeRaw = opProfile.clientType ?? opProfile.tipoCliente;
   const tipoClienteRaw = Array.isArray(clientTypeRaw)
-    ? (clientTypeRaw as string[]).join(",")
-    : (clientTypeRaw as string) ?? null;
+    ? (clientTypeRaw[0] as string)?.toLowerCase() ?? null
+    : typeof clientTypeRaw === "string"
+    ? clientTypeRaw
+    : null;
 
   const multiestadualRaw =
     opProfile.multiState != null
@@ -185,12 +188,17 @@ export async function extractProjectProfile(
     tipoOperacao: tipoOperacaoRaw,
     tipoCliente: tipoClienteRaw,
     multiestadual: multiestadualRaw,
-    meiosPagamento: Array.isArray(opProfile.meiosPagamento)
-      ? (opProfile.meiosPagamento as string[])
-      : null,
-    intermediarios: Array.isArray(opProfile.intermediarios)
-      ? (opProfile.intermediarios as string[])
-      : null,
+    meiosPagamento: (() => {
+      const raw = opProfile.paymentMethods ?? opProfile.meiosPagamento;
+      return Array.isArray(raw) ? (raw as string[]) : null;
+    })(),
+    intermediarios: (() => {
+      // hasIntermediaries na UI é boolean | null. intermediarios em legados é string[].
+      const raw = opProfile.hasIntermediaries ?? opProfile.intermediarios;
+      if (Array.isArray(raw)) return raw as string[];
+      if (raw === true) return ["sim"]; // boolean true → sinalizar presença
+      return null;
+    })(),
     productNcms,
   };
 }


### PR DESCRIPTION
## Summary
- Maps `paymentMethods` → `meiosPagamento` (was reading only PT name, always null for UI-created projects)
- Maps `hasIntermediaries` (boolean) → `intermediarios` (converts `true` → `["sim"]` for payment trigger)
- Fixes `clientType` normalization: was `.join(",")` → now `.toLowerCase()` of first element (e.g. `["B2B"]` → `"b2b"`)
- All fields retain dual-schema fallback (EN from UI → PT from legacy/test projects)

## Root cause
PR #506 mapped `operationType`/`multiState`/`clientType` but missed `paymentMethods` and `hasIntermediaries`. The extractor still read only the PT-named fields (`meiosPagamento`, `intermediarios`) which don't exist in UI-created projects. Result: `meiosPagamento=null` → split_payment trigger never fires; `intermediarios=null` → payment intermediary check incomplete.

## Verification
After deploy, project 30382 should produce:
- `tipoOperacao = "comercio"` (was already fixed in #506)
- `meiosPagamento = [...]` (was null)
- `intermediarios = null` or `["sim"]` depending on project config
- Risk titles: "nas operações de **comercio**" (not "geral")
- Split payment trigger fires correctly

## Gates
- [x] `tsc --noEmit` — 0 errors
- [x] `vitest run server/lib/` — 124/124 passing
- [ ] UAT Gate E post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)