### PR TITLE
chore(governance): Gate 0 + DATA_DICTIONARY + db-schema-validator

### DIFF
--- a/.claude/agents/db-schema-validator.md
+++ b/.claude/agents/db-schema-validator.md
@@ -1,0 +1,47 @@
+---
+name: db-schema-validator
+description: >
+  Valida nomes de campos do banco ANTES de qualquer implementacao
+  que toca tabelas ou campos JSON. Use SEMPRE que um prompt mencionar
+  tabelas, colunas, JSON fields, ou campos de banco de dados.
+  NUNCA implementa codigo. Apenas verifica e reporta.
+tools: Bash
+---
+
+Voce e um agente validator read-only de schema de banco.
+
+NUNCA escreva codigo.
+NUNCA modifique arquivos.
+APENAS execute queries de leitura e reporte divergencias.
+
+## Protocolo obrigatorio (Gate 0)
+
+Quando acionado antes de qualquer implementacao:
+
+1. Ler docs/governance/DATA_DICTIONARY.md
+2. Identificar tabelas/campos que o prompt assume
+3. Executar para cada tabela afetada:
+   ```sql
+   SHOW FULL COLUMNS FROM [tabela];
+   ```
+4. Para campos JSON, executar:
+   ```sql
+   SELECT JSON_KEYS([campo]) FROM [tabela] WHERE [campo] IS NOT NULL LIMIT 3;
+   ```
+5. Comparar: campo assumido vs campo real
+6. Se divergencia: BLOQUEAR e reportar
+7. Se OK: confirmar e liberar para implementacao
+
+## Output obrigatorio
+
+Formato de report:
+
+```
+GATE 0 — Schema Validation
+Tabela: [nome]
+Campo assumido: [nome_assumido]
+Campo real: [nome_real]
+Status: OK | DIVERGENCIA
+
+Decisao: LIBERAR | BLOQUEAR
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,20 @@ Prettier with: double quotes, semicolons, trailing commas (es5), 2-space indent,
 - Auth uses OAuth + JWT cookies with role-based access (equipe_solaris, advogado_senior, cliente)
 - Health endpoints: `/api/health`, `/api/health/cnae`, `/api/health/cnae/validate`
 
+## Gate 0 — Verificacao de Schema (OBRIGATORIO)
+
+ANTES de qualquer implementacao que toca banco de dados:
+
+1. Orquestrador consulta `docs/governance/DATA_DICTIONARY.md`
+2. Se campo nao estiver documentado:
+   - Executar: `SHOW FULL COLUMNS FROM [tabela]`
+   - Executar: `SELECT JSON_KEYS([campo]) FROM [tabela] WHERE [campo] IS NOT NULL LIMIT 3`
+3. Orquestrador confirma nomes reais
+4. So entao despacha prompt para implementacao
+
+**SEM EXCECAO** — nem para fixes "simples".
+Violacao desta regra = causa raiz garantida de bug (post-mortem B-Z13.5-001/002).
+
 ## Sprint Z-07 — Sistema de Riscos v4 — CONCLUÍDA (Z-12)
 
 **Status:** CONCLUÍDA — Hot swap final executado na Sprint Z-12 (PR feat/z12-hot-swap-final).

--- a/docs/governance/DATA_DICTIONARY.md
+++ b/docs/governance/DATA_DICTIONARY.md
@@ -1,0 +1,107 @@
+# DATA DICTIONARY — IA SOLARIS
+
+**Criado:** Sprint Z-13.5 | **Motivo:** Post-mortem B-Z13.5-001 / B-Z13.5-002
+**Regra:** Este documento e fonte autoritativa para nomes de campos do banco.
+
+## Regra de ouro
+
+**NUNCA assumir nome de campo sem verificar este documento.**
+Se o campo nao estiver aqui, executar antes de codar:
+
+```sql
+SHOW FULL COLUMNS FROM [tabela];
+SELECT JSON_KEYS([campo_json]) FROM [tabela] WHERE [campo_json] IS NOT NULL LIMIT 3;
+```
+
+---
+
+## projects (camelCase no banco — exceto campos adicionados por migration)
+
+| Campo | Tipo | Observacao |
+|---|---|---|
+| confirmedCnaes | json camelCase | array de strings `["4639-7/01"]` |
+| operationProfile | json camelCase | ver sub-campos abaixo |
+| product_answers | json snake_case | array `[{ncm, descricao}]` |
+| taxRegime | camelCase | `'lucro_real'` \| `'lucro_presumido'` \| `'simples'` |
+| companySize | camelCase | `'media'` \| `'grande'` \| etc |
+
+### operationProfile — sub-campos (schema novo, gerado pela UI)
+
+| Campo JSON | Tipo | Observacao |
+|---|---|---|
+| operationType | string | `'comercio'` \| `'servicos'` \| `'industria'` |
+| multiState | boolean | true/false |
+| clientType | string[] | `['B2B']` \| `['B2C']` |
+| paymentMethods | string[] | `['cartao','pix']` |
+| hasIntermediaries | boolean | true/false |
+
+### operationProfile — sub-campos (schema legado, projetos antigos)
+
+| Campo JSON | Tipo | Observacao |
+|---|---|---|
+| tipoOperacao | string | fallback para operationType |
+| multiestadual | boolean | fallback para multiState |
+| tipoCliente | string[] | fallback para clientType |
+| meiosPagamento | string[] | fallback para paymentMethods |
+| intermediarios | boolean | fallback para hasIntermediaries |
+
+---
+
+## risks_v4 (raw SQL — sem Drizzle)
+
+| Campo | Tipo | Observacao |
+|---|---|---|
+| type | enum | `'risk'` \| `'opportunity'` |
+| severidade | enum | `'alta'` \| `'media'` \| `'oportunidade'` |
+| status | enum | `'active'` \| `'deleted'` (NAO is_active) |
+| evidence | json | `{gaps: EvidenceItem[], rag_*}` |
+| risk_key | varchar | `categoria::op:X::geo:Y::cli:Z` |
+| operational_context | json | `{tipoOperacao, multiestadual, ...}` |
+
+---
+
+## project_gaps_v3 (campos extras fora do Drizzle)
+
+| Campo | Tipo | Observacao |
+|---|---|---|
+| risk_category_code | varchar | snake_case |
+| gap_classification | enum | `'ausencia'` \| `'parcial'` \| `'inadequado'` |
+| evaluation_confidence | decimal | snake_case |
+| source_reference | varchar | snake_case |
+| source | varchar | snake_case (NAO `fonte`) |
+| answer_value | text | snake_case |
+
+---
+
+## risk_categories
+
+| Campo | Tipo | Observacao |
+|---|---|---|
+| status | enum | `'ativo'` \| `'inativo'` (NAO is_active) |
+| codigo | varchar | chave de negocio |
+
+---
+
+## regulatory_requirements_v3
+
+| Campo | Tipo | Observacao |
+|---|---|---|
+| active | tinyint(1) | NAO is_active |
+
+---
+
+## normative_product_rules
+
+| Campo | Tipo | Observacao |
+|---|---|---|
+| active | tinyint(1) | NAO is_active |
+| match_mode | enum | `'exact'` \| `'prefix'` |
+
+---
+
+## ragDocuments
+
+| Campo | Tipo | Observacao |
+|---|---|---|
+| conteudo | text | coluna de texto (NAO `content`, NAO `text`) |
+| lei | enum | `'lc214'` \| `'ec132'` \| etc |


### PR DESCRIPTION
## Summary
- **`docs/governance/DATA_DICTIONARY.md`** — Authoritative field name reference. Documents all tables with JSON sub-fields, including the dual EN/PT schema for `operationProfile`. Rule: never assume a field name without checking this document first.
- **`.claude/agents/db-schema-validator.md`** — Read-only validation agent. Runs `SHOW FULL COLUMNS` + `JSON_KEYS` before any DB-touching implementation. Reports LIBERAR/BLOQUEAR.
- **`CLAUDE.md` Gate 0 section** — Mandatory pre-implementation gate. No exceptions, not even for "simple" fixes.

## Motivation
Post-mortem B-Z13.5-001/002: the extractor assumed PT field names (`tipoOperacao`, `meiosPagamento`) but the UI writes EN names (`operationType`, `paymentMethods`). This cost multiple hours of debugging across two PRs (#506, #509). Gate 0 prevents this class of bug permanently.

## Files changed
| File | Type | Purpose |
|---|---|---|
| `docs/governance/DATA_DICTIONARY.md` | new | Field name reference |
| `.claude/agents/db-schema-validator.md` | new | Validation agent |
| `CLAUDE.md` | modified | Gate 0 section added |

## Gates
- [x] `tsc --noEmit` — 0 errors (docs-only change, no runtime impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)