### PR TITLE
chore(governance): UX governance model v1 — Gate UX + REGRA-ORQ-08/09/10

### DIFF
--- a/.claude/agents/ux-spec-validator.md
+++ b/.claude/agents/ux-spec-validator.md
@@ -1,0 +1,85 @@
+---
+name: ux-spec-validator
+description: >
+  Valida implementacao de componentes frontend contra a UX Spec
+  antes de qualquer issue ser criada. Use SEMPRE que um prompt
+  mencionar componente frontend, tela, pagina, modal ou UX.
+  NUNCA implementa. Apenas audita e reporta gaps.
+tools: Bash, Read
+---
+
+Voce e um agente validator read-only de UX.
+
+NUNCA escreva codigo.
+NUNCA modifique arquivos.
+APENAS leia arquivos e execute grep de leitura.
+
+## Regra critica
+
+Se a tela NAO estiver no UX_DICTIONARY:
+- NAO prosseguir
+- Reportar: "Tela nao documentada — atualizar UX_DICTIONARY.md antes de implementar"
+- Status: BLOQUEAR
+
+## Protocolo Gate UX (obrigatorio)
+
+Quando acionado antes de issue de frontend:
+
+0. Verificar entradas no UX_DICTIONARY:
+   ```bash
+   grep -A 5 "[nome_da_tela]" docs/governance/UX_DICTIONARY.md
+   ```
+   Se tela nao esta no dicionario: BLOQUEAR
+
+1. Ler spec da tela (path indicado no dicionario)
+
+2. Ler componente atual (path indicado no dicionario)
+
+3. Executar grep de procedures:
+   ```bash
+   grep -n "trpc\." [componente] | sort -u
+   ```
+
+4. Cruzar spec vs implementacao:
+   Para cada funcionalidade da spec:
+   - Existe no componente? SIM / NAO / PARCIAL
+
+5. Reportar gaps
+
+## Output obrigatorio
+
+```
+GATE UX — Validation Report
+Tela: [nome]
+Componente: [path]
+Spec: [path]
+
+| Funcionalidade spec | Status | Observacao |
+|---|---|---|
+| ... | implementado / ausente / parcial | ... |
+
+Procedures spec vs implementacao:
+| Procedure | Spec exige? | Componente chama? |
+|---|---|---|
+
+Gaps identificados: N
+Decisao: LIBERAR | BLOQUEAR
+```
+
+Se BLOQUEAR: lista exata do que falta antes de implementar.
+
+## Exemplo (Z-07 — teria detectado o erro)
+
+```
+GATE UX — Validation Report
+Tela: RiskDashboardV4
+Componente: client/src/components/RiskDashboardV4.tsx
+
+Gaps identificados: 3
+  1. upsertActionPlan — spec exige, componente nao chama
+  2. SummaryBar — spec exige, nao existe no JSX
+  3. HistoryTab com audit log — aba existe, sem conteudo
+
+Decisao: BLOQUEAR
+Razao: fluxo principal de criacao de plano quebrado
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,39 @@ ANTES de qualquer implementacao que toca banco de dados:
 **SEM EXCECAO** — nem para fixes "simples".
 Violacao desta regra = causa raiz garantida de bug (post-mortem B-Z13.5-001/002).
 
+## Gate UX — Verificacao de spec (obrigatorio para frontend)
+
+ANTES de qualquer implementacao de componente frontend:
+
+1. **Orquestrador** consulta `docs/governance/UX_DICTIONARY.md` — verificar estado atual da tela
+2. **Claude Code** executa agente `.claude/agents/ux-spec-validator.md` — reportar gaps vs spec
+3. **Orquestrador** cria issue com spec HIBRIDA:
+   - Conteudo copiado no corpo da issue
+   - Link para arquivo fonte
+   - Lock apos aprovacao P.O.
+   - PATCH (<=5 linhas): comentario na issue
+   - AMENDMENT (estrutural): nova issue
+4. **P.O.** aprova issue com spec congelada
+5. **Claude Code** implementa somente apos aprovacao — todo prompt DEVE iniciar com `gh issue view [N]`
+
+**SEM EXCECAO** — nem para ajustes visuais "simples".
+Violacao desta regra = causa raiz do retrabalho Z-07 (spec existia mas nao foi incluida no prompt).
+
+### REGRA-ORQ-08
+Todo prompt de implementacao DEVE iniciar com `gh issue view [N]`.
+O implementador le a issue diretamente do GitHub. Nunca depende do orquestrador copiar a spec.
+
+### REGRA-ORQ-09
+Gate UX obrigatorio antes de qualquer frontend.
+`ux-spec-validator` deve reportar LIBERAR antes de codar.
+
+### REGRA-ORQ-10
+Integration Checkpoint (F4.5) obrigatorio antes do merge:
+- `grep -n "trpc\." [componente]` executado
+- Cruzar com Contrato API da issue
+- 100% das procedures da issue devem estar sendo chamadas
+- Procedure nao chamada = merge bloqueado
+
 ## Sprint Z-07 — Sistema de Riscos v4 — CONCLUÍDA (Z-12)
 
 **Status:** CONCLUÍDA — Hot swap final executado na Sprint Z-12 (PR feat/z12-hot-swap-final).

--- a/docs/governance/MODELO-ORQUESTRACAO-V2.md
+++ b/docs/governance/MODELO-ORQUESTRACAO-V2.md
@@ -1,0 +1,109 @@
+# MODELO DE ORQUESTRACAO v2 — IA SOLARIS
+
+**Criado:** Sprint Z-13.5 | **Motivo:** Post-mortem Z-07 + Z-13.5
+**Destino:** Copiar para `/mnt/skills/user/solaris-contexto/SKILL.md` pelo Orquestrador
+
+> Este arquivo e a referencia canonica do modelo de orquestracao.
+> O Orquestrador deve copiar a secao "Checklist por sprint" para o SKILL.md.
+
+---
+
+## Checklist por sprint
+
+### F0 — Discovery (nunca pular)
+- [ ] Gate 0: `SHOW FULL COLUMNS` tabelas afetadas (Manus)
+- [ ] Gate UX: `ux-spec-validator` nos componentes afetados (Claude Code)
+- [ ] `UX_DICTIONARY.md` consultado
+- [ ] `DATA_DICTIONARY.md` consultado
+- [ ] Estado real dos componentes reportado
+
+### F1 — Issues (7 blocos obrigatorios)
+- [ ] Contexto + dependencias
+- [ ] UX Spec (copiada inline + link fonte)
+- [ ] Skeleton (estrutura sem logica)
+- [ ] Schema real do banco (saida do Gate 0)
+- [ ] Contrato API (existe? chamado pelo componente?)
+- [ ] Estado atual do componente (tabela implementado/ausente)
+- [ ] Criterios de aceite + plano de testes
+
+**Issue sem os 7 blocos = INVALIDA**
+
+### F2 — Auditoria (assimetrica)
+- [ ] Frontend puro: Claude Code audita (Manus opcional)
+- [ ] Banco/migration: Manus audita (Claude Code opcional)
+- [ ] Issue P0 critica: ambos obrigatorio
+
+### F3 — Aprovacao P.O.
+- [ ] Todas as issues do batch aprovadas
+- [ ] Spec congelada (lock)
+
+### F4 — Implementacao
+- [ ] `gh issue view [N]` no inicio de cada prompt (REGRA-ORQ-08)
+- [ ] 1 issue = 1 PR
+- [ ] PR contem `Closes #N`
+- [ ] Claude Code: frontend, TS, logica, testes
+- [ ] Manus: banco, migrations, deploy
+
+### F4.5 — Integration Checkpoint (obrigatorio)
+- [ ] `grep -n "trpc\." [componente]` executado
+- [ ] Cruzar com Contrato API da issue
+- [ ] 100% procedures da issue estao sendo chamadas
+- [ ] Procedure ausente = BLOQUEAR merge, reportar ao Orquestrador
+
+### F5 — Gate final
+- [ ] tsc 0 erros global
+- [ ] Testes unitarios passando
+- [ ] Testes integration passando
+- [ ] UAT P.O. com checklist da issue
+- [ ] Gate 7 (padrao existente)
+
+---
+
+## Mini-gate por PR (antes de abrir)
+
+- [ ] tsc 0 erros
+- [ ] Testes da issue passando
+- [ ] Responsavel confirma spec implementada
+- [ ] Se toca banco: Manus confirma schema
+- [ ] F4.5 executado e aprovado
+
+---
+
+## Regras mandatorias
+
+| Regra | Descricao |
+|---|---|
+| REGRA-ORQ-01 | Nenhuma implementacao sem issue completa |
+| REGRA-ORQ-02 | Spec hibrida (inline + link + lock) |
+| REGRA-ORQ-03 | Auditoria assimetrica antes de codar |
+| REGRA-ORQ-04 | Claude Code implementa frontend/logica |
+| REGRA-ORQ-05 | Manus valida banco/ambiente |
+| REGRA-ORQ-06 | UAT so apos batch completo |
+| REGRA-ORQ-07 | R-SYNC-01 (S3 != GitHub = bloqueio) |
+| REGRA-ORQ-08 | `gh issue view [N]` obrigatorio no prompt |
+| REGRA-ORQ-09 | Gate UX obrigatorio antes de frontend |
+| REGRA-ORQ-10 | F4.5 Integration Checkpoint obrigatorio |
+
+---
+
+## Matriz de responsabilidade
+
+| Area | Manus | Claude Code |
+|---|---|---|
+| Banco / SQL | PRINCIPAL | suporte |
+| Migrations / deploy | PRINCIPAL | — |
+| Frontend React / TS | — | PRINCIPAL |
+| Engine / logica | — | PRINCIPAL |
+| Testes unitarios | — | PRINCIPAL |
+| grep / auditoria codigo | — | PRINCIPAL |
+| Auditoria banco | PRINCIPAL | suporte |
+| Debug ambiente | PRINCIPAL | — |
+
+---
+
+## Regra de mudanca de spec
+
+| Tipo | Definicao | Acao |
+|---|---|---|
+| **PATCH** | Ajuste <= 5 linhas, nao muda estrutura | Comentario na issue existente |
+| **AMENDMENT** | Mudanca estrutural, novo comportamento | Nova issue obrigatoria |

--- a/docs/governance/UX_DICTIONARY.md
+++ b/docs/governance/UX_DICTIONARY.md
@@ -1,0 +1,129 @@
+# UX DICTIONARY — IA SOLARIS
+
+**Criado:** Sprint Z-13.5 | **Motivo:** Post-mortem Z-07 (spec nao incluida no prompt)
+**Regra:** Este documento e fonte autoritativa para estado de telas e componentes frontend.
+
+## Regra de ouro
+
+**NUNCA implementar frontend sem entrada neste dicionario.**
+Se a tela nao estiver aqui, executar `.claude/agents/ux-spec-validator.md`
+e criar entrada antes de codar.
+
+## Regra de spec
+
+Spec HIBRIDA obrigatoria:
+- Conteudo copiado na issue (para execucao)
+- Link para arquivo fonte (para referencia)
+- Lock apos aprovacao P.O.
+- **PATCH** (ajuste <= 5 linhas): comentario na issue
+- **AMENDMENT** (mudanca estrutural): nova issue
+
+---
+
+## TELA 1 — RiskDashboardV4
+
+**Componente:** `client/src/components/RiskDashboardV4.tsx`
+**Rota:** `/projetos/:id/risk-dashboard-v4`
+**Spec:** `docs/sprints/Z-07/UX_SPEC_RISCOS_V4.md`
+**Mock:** `docs/sprints/Z-07/MOCKUPS_SISTEMA_RISCOS_V4.md`
+**Linhas:** 877
+
+### Estado atual (Discovery 13/04/2026)
+
+| Funcionalidade | Status | Observacao |
+|---|---|---|
+| KPI cards (4 contadores) | implementado | alta, media, oportunidade, excluidos |
+| 3 abas (Riscos/Opps/Hist) | implementado | com contagem dinamica |
+| Filtros severidade | implementado | Todos/Alta/Media |
+| Filtros categoria | implementado | chips inline, top 5 + expand |
+| Aprovar risco individual | implementado | modal AlertDialog |
+| Excluir risco (soft delete) | implementado | motivo obrigatorio 10-200 chars |
+| Restaurar risco | implementado | tab Historico |
+| EvidencePanel expansivel | implementado | 2 items default, expand all |
+| Breadcrumb 4 nos | implementado | chips coloridos com tooltip |
+| Link para ActionPlanPage | implementado | ?riskId= query param |
+| Gerar riscos (pipeline) | implementado | 3 estados: gaps, regras, riscos |
+| Agrupamento por categoria | ausente | lista plana atualmente |
+| SummaryBar sticky | ausente | |
+| Banner N aguardando | ausente | |
+| Botao criar plano no card | ausente | |
+| HistoryTab com audit log | ausente | aba existe, sem conteudo de auditoria |
+| BulkApprove | ausente | procedure nao existe no router |
+| RAG validation badge | parcial | dados no banco (rag_validated), sem badge visual |
+
+### Procedures (confirmed Discovery)
+
+| Procedure | Existe no router? | Chamada pelo componente? |
+|---|---|---|
+| listRisks | SIM | SIM |
+| deleteRisk | SIM | SIM |
+| restoreRisk | SIM | SIM |
+| approveRisk | SIM | SIM |
+| generateRisks | SIM | SIM |
+| mapGapsToRules | SIM | SIM |
+| generateRisksFromGaps | SIM | SIM |
+| upsertActionPlan | SIM | NAO (gap — nao chamada no dashboard) |
+| bulkApprove | NAO | NAO (procedure nao existe) |
+| getProjectAuditLog | SIM | NAO (nao usada no dashboard) |
+
+### Principios UX (spec Z-07)
+
+1. **Rastreabilidade visivel** — advogado sabe de onde veio cada risco
+2. **Aprovacao explicita** — nada avanca sem ato consciente
+3. **Reversibilidade** — tudo pode ser desfeito com motivo registrado
+4. **Progressao bloqueada** — tarefa so libera apos plano aprovado
+5. **Feedback imediato** — toda acao < 300ms
+
+---
+
+## TELA 2 — ActionPlanPage
+
+**Componente:** `client/src/pages/ActionPlanPage.tsx`
+**Rota:** `/projetos/:id/planos-v4`
+**Spec:** `docs/sprints/Z-07/UX_SPEC_RISCOS_V4.md`
+**Mock:** `docs/sprints/Z-07/MOCKUPS_SISTEMA_RISCOS_V4.md`
+**Linhas:** 733
+**Cardinalidade:** 1 plano → N tarefas atomicas
+
+### Estado atual (Discovery 13/04/2026)
+
+| Funcionalidade | Status | Observacao |
+|---|---|---|
+| TraceabilityBanner sticky | implementado | 5 chips, backdrop-blur, z-20 |
+| Listar planos | implementado | via listRisks join |
+| Aprovar plano | implementado | approvePlanMutation |
+| Excluir plano | implementado | motivo obrigatorio |
+| Listar tarefas | implementado | TaskRow com status cycle |
+| Adicionar tarefa | implementado | inline form |
+| Atualizar status tarefa | implementado | NEXT_STATUS map |
+| Excluir tarefa | implementado | com motivo |
+| Audit log global | implementado | getProjectAuditLog |
+| Audit log por plano | implementado | getAuditLog |
+| Lock tarefas (plan=rascunho) | implementado | opacity-40, cursor-not-allowed |
+| Criar novo plano | ausente | upsertActionPlan nao chamada |
+| Editar plano existente | ausente | sem form de edicao |
+| Filtro por status de plano | ausente | |
+| Kanban tarefas | ausente | lista simples atualmente |
+
+### Procedures (confirmed Discovery)
+
+| Procedure | Existe no router? | Chamada pelo componente? |
+|---|---|---|
+| listRisks | SIM | SIM |
+| getProjectAuditLog | SIM | SIM |
+| approveActionPlan | SIM | SIM |
+| deleteActionPlan | SIM | SIM |
+| upsertTask | SIM | SIM |
+| deleteTask | SIM | SIM |
+| getAuditLog | SIM | SIM |
+| upsertActionPlan | SIM | NAO (gap — nao chamada) |
+
+---
+
+## Aviso de driver TiDB
+
+> **ATENCAO — Driver TiDB/mysql2**
+>
+> Campos JSON podem ser retornados como objetos ja parseados pelo mysql2.
+> Usar `safeParseObject()` e `safeParseArray()` — nunca `JSON.parse()` direto.
+> Funcoes em: `server/lib/project-profile-extractor.ts`


### PR DESCRIPTION
## Summary
Implements **Gate UX** symmetric to Gate 0 (bank schema validation) — now frontend is covered too.

Closes the gap identified in Z-07 post-mortem: spec existed but was not included in the implementation prompt, causing full rework of 2 main screens.

## Artifacts (4 files, 0 runtime changes)

| File | Type | Description |
|---|---|---|
| `docs/governance/UX_DICTIONARY.md` | New | Authoritative UX state for RiskDashboardV4 (877L) and ActionPlanPage (733L) with Discovery data, procedure mapping |
| `.claude/agents/ux-spec-validator.md` | New | Read-only agent: spec vs component diff before any issue |
| `CLAUDE.md` | Updated | Gate UX section + REGRA-ORQ-08 (`gh issue view`), 09 (Gate UX mandatory), 10 (F4.5 Integration Checkpoint) |
| `docs/governance/MODELO-ORQUESTRACAO-V2.md` | New | Full orchestration model v2: F0-F5 checklist, mini-gate per PR, responsibility matrix. To be copied to SKILL.md by Orchestrator |

## New rules
- **REGRA-ORQ-08:** Every implementation prompt MUST start with `gh issue view [N]`
- **REGRA-ORQ-09:** Gate UX mandatory before any frontend work
- **REGRA-ORQ-10:** F4.5 Integration Checkpoint — 100% procedures from issue must be called

## Note
SKILL.md (`/mnt/skills/user/solaris-contexto/`) is not accessible from Claude Code (Manus sandbox only). The orchestration model is in `MODELO-ORQUESTRACAO-V2.md` for the Orchestrator to copy manually.

## Gates
- [x] tsc 0 errors (docs-only, no runtime impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)