### PR TITLE
feat(action-plan): edicao de plano via UI — Closes #532

### DIFF
--- a/client/src/pages/ActionPlanPage.tsx
+++ b/client/src/pages/ActionPlanPage.tsx
@@ -32,6 +32,7 @@ import {
   ThumbsUp,
   CheckSquare,
   Lock,
+  Pencil,
 } from "lucide-react";
 import { Link } from "wouter";
 import { toast } from "sonner";
@@ -273,9 +274,10 @@ interface ActionPlanCardProps {
   canApprove: boolean;
   onApprove: (planId: string) => void;
   onDelete: (planId: string, reason: string) => void;
+  onEdit?: (plan: ActionPlanCardProps["plan"]) => void;
 }
 
-function ActionPlanCard({ plan, canApprove, onApprove, onDelete }: ActionPlanCardProps) {
+function ActionPlanCard({ plan, canApprove, onApprove, onDelete, onEdit }: ActionPlanCardProps) {
   const utils = trpc.useUtils();
   const [showTasks, setShowTasks] = useState(false);
   const [showAddTask, setShowAddTask] = useState(false);
@@ -363,6 +365,17 @@ function ActionPlanCard({ plan, canApprove, onApprove, onDelete }: ActionPlanCar
               onClick={() => onApprove(plan.id)}
             >
               <ThumbsUp className="h-3.5 w-3.5" />
+            </Button>
+          )}
+          {onEdit && !isDeleted && plan.status !== "concluido" && (
+            <Button
+              size="icon"
+              variant="ghost"
+              className="h-7 w-7 text-blue-600 hover:text-blue-700 hover:bg-blue-50"
+              title="Editar plano"
+              onClick={() => onEdit(plan)}
+            >
+              <Pencil className="h-3.5 w-3.5" />
             </Button>
           )}
           <Button
@@ -539,19 +552,37 @@ export default function ActionPlanPage() {
   });
 
   const [showNewPlan, setShowNewPlan] = useState(false);
+  const [editPlanTarget, setEditPlanTarget] = useState<{ id: string; risk_id: string; titulo: string; responsavel: string; prazo: string; descricao?: string | null; status: string } | null>(null);
   const [npTitulo, setNpTitulo] = useState("");
   const [npResponsavel, setNpResponsavel] = useState("");
   const [npPrazo, setNpPrazo] = useState("");
   const [npDescricao, setNpDescricao] = useState("");
 
-  const createPlanMutation = trpc.risksV4.upsertActionPlan.useMutation({
+  const isEditMode = !!editPlanTarget;
+
+  const openEditPlan = (plan: typeof editPlanTarget) => {
+    if (!plan) return;
+    setEditPlanTarget(plan);
+    setNpTitulo(plan.titulo);
+    setNpResponsavel(plan.responsavel);
+    setNpPrazo(plan.prazo);
+    setNpDescricao((plan as any).descricao ?? "");
+    setShowNewPlan(true);
+  };
+
+  const closePlanModal = () => {
+    setShowNewPlan(false);
+    setEditPlanTarget(null);
+    setNpTitulo(""); setNpResponsavel(""); setNpPrazo(""); setNpDescricao("");
+  };
+
+  const upsertPlanMutation = trpc.risksV4.upsertActionPlan.useMutation({
     onSuccess: () => {
       utils.risksV4.listRisks.invalidate({ projectId });
-      toast.success("Plano criado", { duration: 5000 });
-      setShowNewPlan(false);
-      setNpTitulo(""); setNpResponsavel(""); setNpPrazo(""); setNpDescricao("");
+      toast.success(isEditMode ? "Plano atualizado" : "Plano criado", { duration: isEditMode ? 3000 : 5000 });
+      closePlanModal();
     },
-    onError: (err) => toast.error("Erro ao criar plano", { description: err.message }),
+    onError: (err) => toast.error(isEditMode ? "Erro ao salvar plano" : "Erro ao criar plano", { description: err.message }),
   });
 
   const deletePlanMutation = trpc.risksV4.deleteActionPlan.useMutation({
@@ -621,13 +652,13 @@ export default function ActionPlanPage() {
           )}
         </div>
 
-        {/* Modal: Novo plano */}
-        {showNewPlan && riskIdParam && (
-          <Dialog open onOpenChange={(open) => { if (!open) setShowNewPlan(false); }}>
+        {/* Modal: Novo / Editar plano */}
+        {showNewPlan && (riskIdParam || editPlanTarget) && (
+          <Dialog open onOpenChange={(open) => { if (!open) closePlanModal(); }}>
             <DialogContent className="sm:max-w-md">
               <DialogHeader>
-                <DialogTitle>Novo plano de ação</DialogTitle>
-                <DialogDescription>Vinculado ao risco selecionado</DialogDescription>
+                <DialogTitle>{isEditMode ? "Editar plano de ação" : "Novo plano de ação"}</DialogTitle>
+                <DialogDescription>{isEditMode ? "Altere os campos e salve" : "Vinculado ao risco selecionado"}</DialogDescription>
               </DialogHeader>
               <div className="space-y-3">
                 <div>
@@ -658,19 +689,22 @@ export default function ActionPlanPage() {
                 </div>
               </div>
               <DialogFooter>
-                <Button variant="outline" onClick={() => setShowNewPlan(false)}>Cancelar</Button>
+                <Button variant="outline" onClick={closePlanModal}>Cancelar</Button>
                 <Button
-                  disabled={npTitulo.length < 5 || !npResponsavel || !npPrazo || createPlanMutation.isPending}
-                  onClick={() => createPlanMutation.mutate({
+                  disabled={npTitulo.length < 5 || !npResponsavel || !npPrazo || upsertPlanMutation.isPending}
+                  onClick={() => upsertPlanMutation.mutate({
                     projectId,
-                    riskId: riskIdParam,
+                    riskId: editPlanTarget?.risk_id ?? riskIdParam!,
                     titulo: npTitulo,
                     responsavel: npResponsavel,
                     prazo: npPrazo as "30_dias" | "60_dias" | "90_dias",
                     descricao: npDescricao || undefined,
+                    ...(editPlanTarget ? { planId: editPlanTarget.id } : {}),
                   })}
                 >
-                  {createPlanMutation.isPending ? <><Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />Criando...</> : "Criar plano"}
+                  {upsertPlanMutation.isPending
+                    ? <><Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />{isEditMode ? "Salvando..." : "Criando..."}</>
+                    : isEditMode ? "Salvar alterações" : "Criar plano"}
                 </Button>
               </DialogFooter>
             </DialogContent>
@@ -738,6 +772,7 @@ export default function ActionPlanPage() {
                         onDelete={(planId, reason) =>
                           deletePlanMutation.mutate({ projectId, planId, reason })
                         }
+                        onEdit={(p) => openEditPlan(p)}
                       />
                     ))}
                   </CardContent>


### PR DESCRIPTION
Closes #532

## F4.5 — Integration Checkpoint
- [x] upsertActionPlan called with planId in edit mode (L700)
- [x] NewPlanModal reused with isEditMode flag (no duplicate)
- [x] Status NOT sent in update
- [x] Edit button hidden for concluido/deleted
- [x] Toast: "Plano atualizado" (edit) vs "Plano criado" (create)

## Mini-gate
- [x] tsc 0 errors
- [x] vitest 124/124
- [x] gh issue view 532 read before coding

🤖 Generated with [Claude Code](https://claude.com/claude-code)