### PR TITLE
feat(dashboard): bulkApprove UI — aprovar em lote — Closes #534

### DIFF
--- a/client/src/components/RiskDashboardV4.tsx
+++ b/client/src/components/RiskDashboardV4.tsx
@@ -537,6 +537,7 @@ export function RiskDashboardV4({ projectId }: RiskDashboardV4Props) {
   const [deleteTarget, setDeleteTarget] = useState<RiskData | null>(null);
   const [deleteReason, setDeleteReason] = useState("");
   const [newPlanTarget, setNewPlanTarget] = useState<RiskData | null>(null);
+  const [showBulkConfirm, setShowBulkConfirm] = useState(false);
 
   // ── Queries ───────────────────────────────────────────────────────────────
   const { data, isLoading, error } = trpc.risksV4.listRisks.useQuery(
@@ -580,6 +581,15 @@ export function RiskDashboardV4({ projectId }: RiskDashboardV4Props) {
       toast.success("Risco aprovado com sucesso", { duration: 3000 });
     },
     onError: (err) => toast.error("Erro ao aprovar risco", { description: err.message, duration: 6000 }),
+  });
+
+  const bulkApproveMutation = trpc.risksV4.bulkApprove.useMutation({
+    onSuccess: (data) => {
+      utils.risksV4.listRisks.invalidate({ projectId });
+      toast.success(`${data.approved} riscos aprovados com sucesso`, { duration: 3000 });
+      setShowBulkConfirm(false);
+    },
+    onError: () => toast.error("Erro ao aprovar riscos", { description: "Tentar novamente", duration: 6000 }),
   });
 
   const generateMutation = trpc.risksV4.generateRisks.useMutation({
@@ -725,7 +735,7 @@ export function RiskDashboardV4({ projectId }: RiskDashboardV4Props) {
             <p className="text-xs font-medium text-amber-800 dark:text-amber-300">
               {activeRisks.filter((r) => !r.approved_at).length} itens aguardando sua análise
             </p>
-            <Button size="sm" variant="outline" className="text-xs h-7" disabled title="Aprovar todos (Issue #4b)">
+            <Button size="sm" variant="outline" className="text-xs h-7" onClick={() => setShowBulkConfirm(true)}>
               Aprovar todos
             </Button>
           </div>
@@ -1006,6 +1016,28 @@ export function RiskDashboardV4({ projectId }: RiskDashboardV4Props) {
           </Card>
         </TabsContent>
       </Tabs>
+
+      {/* ── Modal: Aprovar em lote ── */}
+      <AlertDialog open={showBulkConfirm} onOpenChange={(open) => { if (!open) setShowBulkConfirm(false); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Aprovar todos os riscos pendentes</AlertDialogTitle>
+            <AlertDialogDescription>
+              Você está aprovando {activeRisks.filter((r) => !r.approved_at).length} riscos de uma vez.
+              Esta ação será registrada com data e hora no histórico de auditoria.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => bulkApproveMutation.mutate({ projectId })}
+              disabled={bulkApproveMutation.isPending}
+            >
+              {bulkApproveMutation.isPending ? "Aprovando..." : "Confirmar aprovação em lote"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       {/* ── Modal: Novo plano de ação ── */}
       {newPlanTarget && (


### PR DESCRIPTION
Closes #534

Depende de: PR #536 mergeado (bulkApprove backend)

## Objetivo
Implementar o botão "Aprovar todos" no `RiskDashboardV4.tsx` para chamar a procedure `trpc.risksV4.bulkApprove` (implementada no PR #536) e aprovar em lote todos os riscos pendentes de um projeto. O botão exibe um `AlertDialog` de confirmação com o número de riscos pendentes e emite toast de sucesso após aprovação.

## Arquivos que serão tocados
- `client/src/components/RiskDashboardV4.tsx`
- `docs/governance/SPRINT-Z14-LOG.md`

## Escopo da alteração
**Tipo:**
- [x] Feature

**Componentes afetados:**
- [x] Frontend (React)

## Classificação de risco (Gate 0 D3 / Gate 2.5)
- [x] Baixo — sem impacto em dados ou fluxo principal

**Risk Score (Gate 2.5):**
| Critério | Pontos |
|---|---|
| Novo arquivo em `server/lib/` | 0 |
| Nova migration | 0 |
| Alteração em pipeline de dados existente | 0 |
| Integração com sistema externo | 0 |
| Mudança em enum global | 0 |
| Fire-and-forget sem teste de integração | 0 |
| Feature flag ausente (risco medium/high) | 0 |

**Score total:** 0 → **Baixo**

**Justificativa:**
PR toca apenas componente React de UI. Nenhuma alteração de schema, pipeline ou backend. A procedure `bulkApprove` já foi implementada e testada no PR #536.

## Declaração de escopo (obrigatório)
Esta PR:
- [x] NÃO altera comportamento visível ao usuário final (além da feature solicitada)
- [x] NÃO toca no adaptador `getDiagnosticSource()`
- [x] NÃO impacta o domínio RAG
- [x] NÃO ativa `DIAGNOSTIC_READ_MODE=new`
- [x] NÃO executa DROP COLUMN em colunas legadas

## Validação executada
**Testes:**
- [x] `pnpm tsc --noEmit` — 0 erros
- [x] `pnpm test` — 124/124 passando
- [x] Invariants verificados (INV-001..INV-008)

**Evidência estruturada (obrigatório):**
```json
{
  "head": "09b9894",
  "branch": "feat/z14-bulk-approve-ui",
  "arquivos": ["client/src/components/RiskDashboardV4.tsx", "docs/governance/SPRINT-Z14-LOG.md"],
  "tests_passed": 124,
  "testes_passando": 124,
  "typescript_errors": 0,
  "risk_level": "low",
  "rag_impact": false,
  "unexpected_behavior": false,
  "data_integrity": true,
  "regression": false
}
```

## Classificação da task
- [x] Nível 1 — Seguro

## Checklist final
- [x] Código revisado pelo próprio autor
- [x] Evidência JSON preenchida e verdadeira
- [x] Sem arquivos fora do escopo declarado modificados
- [x] Documentação atualizada se necessário
- [x] Feature flag não necessária (risk score Baixo)

## Auto-auditoria Q1–Q7 + observabilidade (Gate 2 v5.0)
```
Q1 — Tipos nulos:         [ OK ] — bulkApproveMutation tipado via tRPC inference
Q2 — SQL TiDB:            [ N/A ] — PR não toca SQL
Q3 — Filtros NULL/'':     [ N/A ] — PR não toca queries
Q4 — Endpoint registrado: [ OK ] — trpc.risksV4.bulkApprove já registrado no PR #536
Q5 — isError ≠ vazio:     [ OK ] — onError exibe toast de erro
Q6 — Retorno explícito:   [ N/A ] — PR não toca server/lib/
Q7 — Driver único:        [ N/A ] — PR não toca banco de dados
R9 — Evento estruturado:  [ N/A ] — PR não toca server
S6 — Rollback declarado:  [ N/A ] — sem migration
Risk score (herdado Gate 0): Baixo
Resultado: APTO PARA COMMIT
```

## Declaração final
Declaro que a implementação é determinística, não há risco oculto,
a alteração é auditável e atende o nível de confiabilidade exigido.

## F4.5 — Integration Checkpoint
- [x] trpc.risksV4.bulkApprove chamada (L1033)
- [x] Botao disabled removido (L741)
- [x] AlertDialog com pendingCount (L1021)
- [x] Toast N riscos aprovados
- [x] invalidate listRisks apos sucesso

🤖 Generated with [Claude Code](https://claude.com/claude-code)
