### PR TITLE
fix(governance): mockup HTML obrigatorio em issues frontend

### DIFF
--- a/.github/ISSUE_TEMPLATE/sprint-issue.md
+++ b/.github/ISSUE_TEMPLATE/sprint-issue.md
@@ -28,7 +28,18 @@ assignees: ''
 > Arquivo completo como referencia adicional.
 > Implementador DEVE conseguir codar sem abrir o arquivo.
 
-**Arquivo fonte:** `docs/sprints/Z-XX/UX_SPEC_XXX.md`
+**Arquivos de referencia obrigatorios:**
+
+| Arquivo | Tipo | Uso |
+|---|---|---|
+| `docs/sprints/Z-XX/UX_SPEC_XXX.md` | Spec textual | estados, validacoes, toasts |
+| `docs/sprints/Z-XX/MOCKUPS_XXX.md` | Mockup ASCII | layout, estrutura |
+| `docs/sprints/Z-XX/MOCKUP_XXX.html` | Mockup interativo | estados reais, cores, seletores CSS |
+
+> O mockup HTML e obrigatorio para issues de frontend.
+> Abrir no browser antes de implementar — nao apenas ler o .md.
+> Seletores no Bloco 9 devem ser baseados no HTML renderizado.
+> Se o mockup HTML nao existe: solicitar ao Orquestrador ANTES de produzir a issue.
 
 ### Resumo funcional (obrigatorio inline)
 [estados do componente, acoes disponiveis, validacoes, toasts]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,11 @@ O implementador le a issue diretamente do GitHub. Nunca depende do orquestrador 
 Gate UX obrigatorio antes de qualquer frontend.
 `ux-spec-validator` deve reportar LIBERAR antes de codar.
 
+#### Mockup HTML (complemento REGRA-ORQ-09)
+Antes de criar issue de frontend, verificar: `ls docs/sprints/Z-XX/MOCKUP_*.html`
+- Se nao existe: solicitar ao Orquestrador criacao do mockup HTML antes de produzir a issue
+- Se existe: referenciar no Bloco 2 + documentar seletores no Bloco 9 baseados no HTML
+
 ### REGRA-ORQ-10
 Integration Checkpoint (F4.5) obrigatorio antes do merge:
 - `grep -n "trpc\." [componente]` executado

--- a/docs/governance/MODELO-ORQUESTRACAO-V2.md
+++ b/docs/governance/MODELO-ORQUESTRACAO-V2.md
@@ -99,6 +99,12 @@ Criterio de done:
 Cada issue produzida com template obrigatorio (.github/ISSUE_TEMPLATE/sprint-issue.md)
 Blocos 1-8 obrigatorios + Bloco 9 se componente existente >200L
 
+  Antes de produzir issue de frontend:
+  Verificar: mockup HTML existe em docs/sprints/Z-XX/?
+    ls docs/sprints/Z-XX/MOCKUP_*.html
+  Se nao: Orquestrador cria mockup HTML PRIMEIRO
+  Se sim: referenciar no Bloco 2 + seletores no Bloco 9
+
 Regra de lotes:
   Criterio de corte: "usuario consegue usar a feature sem o lote anterior?"
   Dentro do lote: desenvolvimento PARALELO, merge respeita ordem

--- a/docs/governance/UX_DICTIONARY.md
+++ b/docs/governance/UX_DICTIONARY.md
@@ -9,6 +9,19 @@
 Se a tela nao estiver aqui, executar `.claude/agents/ux-spec-validator.md`
 e criar entrada antes de codar.
 
+## Regra do mockup HTML (adicionada Z-14)
+
+Todo mockup HTML deve ser:
+1. Criado pelo Orquestrador antes da issue de implementacao
+2. Referenciado no Bloco 2 da issue
+3. Aberto no browser pelo implementador antes de codar
+4. Fonte dos seletores CSS documentados no Bloco 9
+
+Quando criar mockup HTML:
+- Toda nova tela ou componente significativo
+- Quando spec ASCII nao captura estados visuais
+- Quando ha multiplos estados de UI (pending/approved/deleted)
+
 ## Regra de spec
 
 Spec HIBRIDA obrigatoria:
@@ -25,8 +38,9 @@ Spec HIBRIDA obrigatoria:
 **Componente:** `client/src/components/RiskDashboardV4.tsx`
 **Rota:** `/projetos/:id/risk-dashboard-v4`
 **Spec:** `docs/sprints/Z-07/UX_SPEC_RISCOS_V4.md`
-**Mock:** `docs/sprints/Z-07/MOCKUPS_SISTEMA_RISCOS_V4.md`
-**Linhas:** 877
+**Mock ASCII:** `docs/sprints/Z-07/MOCKUPS_SISTEMA_RISCOS_V4.md`
+**Mock HTML:** `docs/sprints/Z-07/MOCKUP_RISK_DASHBOARD_V4.html` (a criar pelo Orquestrador)
+**Linhas:** 1100
 
 ### Estado atual (Discovery 13/04/2026)
 
@@ -81,8 +95,9 @@ Spec HIBRIDA obrigatoria:
 **Componente:** `client/src/pages/ActionPlanPage.tsx`
 **Rota:** `/projetos/:id/planos-v4`
 **Spec:** `docs/sprints/Z-07/UX_SPEC_RISCOS_V4.md`
-**Mock:** `docs/sprints/Z-07/MOCKUPS_SISTEMA_RISCOS_V4.md`
-**Linhas:** 733
+**Mock ASCII:** `docs/sprints/Z-07/MOCKUPS_SISTEMA_RISCOS_V4.md`
+**Mock HTML:** `docs/sprints/Z-07/MOCKUP_ACTION_PLAN_PAGE.html` (a criar pelo Orquestrador)
+**Linhas:** 818
 **Cardinalidade:** 1 plano → N tarefas atomicas
 
 ### Estado atual (Discovery 13/04/2026)


### PR DESCRIPTION
Issues de frontend agora referenciam mockups HTML interativos. 4 arquivos de governanca atualizados. Mockups HTML a criar pelo Orquestrador.