### PR TITLE
docs: Sprint Log B-01

### DIFF
--- a/docs/governance/SPRINT-Z14-LOG.md
+++ b/docs/governance/SPRINT-Z14-LOG.md
@@ -110,3 +110,9 @@ Processo: spec na issue → 9/9 primeira rodada.
 [IMPL] Claude Code implementando testes E2E
 [PARALLEL] Manus preparando ambiente E2E
 PROJECT_ID referência: 30760
+
+### B-01 identificado — 14/04/2026
+
+[BLOQUEADOR] Geração automática pós-briefing ausente
+Issue B-01 sendo criada — P0 bloqueador da suite E2E
+Executor: Claude Code


### PR DESCRIPTION
## Objetivo

Registrar no Sprint Log Z-14 a identificação do bloqueador B-01 (geração automática pós-briefing ausente).

## Arquivos que serão tocados

- `docs/governance/SPRINT-Z14-LOG.md`

## Escopo da alteração

**Tipo:**
- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Migration (DB)
- [ ] Observabilidade
- [x] Governança / Docs
- [ ] Infra / CI

**Componentes afetados:**
- [ ] Backend (Node / tRPC)
- [ ] Frontend (React)
- [ ] Banco de dados / Schema
- [ ] RAG (CNAE / requisitos) ❗
- [ ] Infraestrutura / CI
- [x] Apenas documentação

## Classificação de risco

- [x] Baixo — sem impacto em dados ou fluxo principal
- [ ] Médio — impacto controlado e reversível
- [ ] Alto — impacto estrutural, requer aprovação explícita

**Risk Score (Gate 2.5):** 0 → **low**

**Justificativa:** Apenas documentação de sprint log, sem alteração de código.

## Declaração de escopo

Esta PR:
- [x] NÃO altera comportamento visível ao usuário final
- [x] NÃO toca no adaptador `getDiagnosticSource()`
- [x] NÃO impacta o domínio RAG
- [x] NÃO ativa `DIAGNOSTIC_READ_MODE=new`
- [x] NÃO executa DROP COLUMN em colunas legadas

## Validação executada

**Testes:**
- [x] `pnpm tsc --noEmit` — 0 erros
- [x] Sem alterações de código — testes não aplicáveis

**Evidência estruturada (obrigatório):**

```json
{
  "head": "da8f4f1",
  "branch": "docs/z14-sprint-log-b01",
  "arquivos": ["docs/governance/SPRINT-Z14-LOG.md"],
  "testes_passando": 0,
  "typescript_errors": 0,
  "risk_level": "low",
  "data_integrity": true,
  "regression": false,
  "rag_impact": false,
  "unexpected_behavior": false,
  "tests_passed": true
}
```

## Classificação da task

- [x] Nível 1 — Seguro
- [ ] Nível 2 — Controlado
- [ ] Nível 3 — Crítico

## Checklist final

- [x] Escopo declarado respeitado (apenas docs/governance/SPRINT-Z14-LOG.md)
- [x] Sem DROP COLUMN, sem DIAGNOSTIC_READ_MODE=new
- [x] Sem features implementadas
- [x] TypeScript: 0 erros
- [x] Sem impacto em produção

## Declaração final

Resultado: APTO PARA COMMIT

PR de documentação apenas. Registro do bloqueador B-01 no Sprint Log Z-14.
