### PR TITLE
docs(governance): ORQ-15 adendo — risk_level obrigatorio em ingles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,6 +240,13 @@ Todo PR DEVE conter no body os campos exatos do `.github/PULL_REQUEST_TEMPLATE.m
 Nunca confiar em memoria para gerar PR body. Copiar do template.
 Sem este bloco: `validate-pr` FALHA no CI.
 
+**ORQ-15 ADENDO — risk_level OBRIGATORIO em ingles:**
+O campo `risk_level` no JSON de evidencia DEVE ser em ingles:
+- `"low"` — nao `"baixo"`
+- `"medium"` — nao `"medio"`
+- `"high"` — nao `"alto"`
+Valor em portugues: `validate-pr` FALHA com `RISK_LEVEL INVALIDO`.
+
 ### REGRA-ORQ-11 — Fast-track hotfix P0
 
 Para bugs criticos em producao que nao podem esperar o fluxo normal.


### PR DESCRIPTION
## Objetivo
Adicionar adendo à REGRA-ORQ-15 no CLAUDE.md especificando que o campo `risk_level` no JSON de evidência deve ser em inglês (`"low"` | `"medium"` | `"high"`), não em português.

## Escopo da alteração
- [x] Apenas arquivos declarados nesta issue foram modificados
- [x] Sem refatoração fora do escopo
- [x] Sem dependências novas

## Classificação de risco
- [x] Baixo — sem impacto em dados ou fluxo principal

## Declaração de escopo
- [x] Arquivo único: `CLAUDE.md` — adição de 7 linhas após bloco ORQ-15
- [x] Sem alterações de código, schema ou testes

## Validação executada
- [x] Grep confirma adendo presente na linha 243
- [x] Sem alterações de código ou schema

## Classificação da task
- [x] Nível 1 — Seguro

## Checklist final
- [x] TypeScript: N/A (apenas documentação)
- [x] Testes: N/A (apenas documentação)
- [x] CLAUDE.md atualizado com regra ORQ-15 adendo

## Declaração final
Resultado: APTO PARA COMMIT

## Evidência

```json
{
  "data_integrity": "apenas documentação — sem impacto em dados",
  "regression": "nenhuma",
  "rag_impact": "nenhum",
  "unexpected_behavior": "nenhum",
  "tests_passed": "N/A",
  "typescript_errors": 0,
  "risk_level": "low"
}
```

## Auto-auditoria
- Q1: Escopo respeitado? SIM — apenas CLAUDE.md
- Q2: Regressão introduzida? NÃO
- Q3: TypeScript limpo? N/A
- Q4: Testes passando? N/A
- Q5: Governança respeitada? SIM
