### PR TITLE
fix(migration): prazo 180_dias em action_plans [P0 bloqueador]

### DIFF
--- a/drizzle/0077_add_180_dias_prazo.sql
+++ b/drizzle/0077_add_180_dias_prazo.sql
@@ -1,0 +1,9 @@
+-- Migration: adicionar '180_dias' ao ENUM prazo em action_plans
+-- Issue: #579 — fix(migration): prazo 180_dias em action_plans [P0 bloqueador]
+-- Sprint: Z-14 | Lote: E
+-- RN: RN_PLANOS_TAREFAS_V4.md — prazo = ENUM(30_dias|60_dias|90_dias|180_dias)
+
+ALTER TABLE action_plans
+  MODIFY COLUMN prazo
+  ENUM('30_dias','60_dias','90_dias','180_dias')
+  NOT NULL;

--- a/server/lib/db-queries-risks-v4.ts
+++ b/server/lib/db-queries-risks-v4.ts
@@ -32,7 +32,7 @@ export type UrgenciaV4 = "imediata" | "curto_prazo" | "medio_prazo";
 export type SourcePriorityV4 = "cnae" | "ncm" | "nbs" | "solaris" | "iagen";
 export type RiskStatusV4 = "active" | "deleted";
 
-export type PrazoActionPlan = "30_dias" | "60_dias" | "90_dias";
+export type PrazoActionPlan = "30_dias" | "60_dias" | "90_dias" | "180_dias";
 export type StatusActionPlan =
   | "rascunho"
   | "aprovado"

--- a/server/routers/risks-v4.ts
+++ b/server/routers/risks-v4.ts
@@ -356,7 +356,7 @@ export const risksV4Router = router({
         titulo: z.string().min(1),
         descricao: z.string().optional(),
         responsavel: z.string().min(1),
-        prazo: z.enum(["30_dias", "60_dias", "90_dias"]),
+        prazo: z.enum(["30_dias", "60_dias", "90_dias", "180_dias"]),
       })
     )
     .mutation(async ({ input, ctx }) => {


### PR DESCRIPTION
## Declaração de escopo
- [x] Baixo — sem impacto em dados ou fluxo principal
- [x] Nível 1 — Seguro

## F4.5 Integration Checkpoint
- [x] ALTER TABLE action_plans prazo ENUM +180_dias
- [x] PrazoActionPlan TypeScript atualizado L35
- [x] Zod schema atualizado L359

## Evidência de qualidade
```json
{
  "data_integrity": true,
  "regression": false,
  "rag_impact": false,
  "unexpected_behavior": false,
  "tests_passed": true,
  "typescript_errors": 0,
  "risk_level": "low"
}
```

## Verificação banco
```
ANTES: enum('30_dias','60_dias','90_dias')
DEPOIS: enum('30_dias','60_dias','90_dias','180_dias')
180_dias presente: SIM
```

## Arquivos alterados (escopo declarado)
- `drizzle/0077_add_180_dias_prazo.sql` — migration SQL
- `server/lib/db-queries-risks-v4.ts` L35 — PrazoActionPlan
- `server/routers/risks-v4.ts` L359 — Zod schema

Closes #579