### PR TITLE
feat(dashboard): RAG validation badge + fix L1107 bulkApprove

### DIFF
--- a/client/src/components/RiskDashboardV4.tsx
+++ b/client/src/components/RiskDashboardV4.tsx
@@ -81,6 +81,8 @@ interface RiskData {
   approved_by?: number | null;
   deleted_reason?: string | null;
   actionPlans?: { id: string; titulo: string; status: string }[];
+  rag_validated?: number;
+  rag_artigo_exato?: string | null;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -280,6 +282,24 @@ function RiskCard({ risk, canApprove, onDelete, onRestore, onApprove, onNewPlan,
             <Badge variant="secondary" className="text-xs">
               {URGENCIA_LABELS[risk.urgencia] ?? risk.urgencia}
             </Badge>
+            {risk.type !== "opportunity" && (
+              risk.rag_validated === 1 ? (
+                <span
+                  data-testid="rag-badge-validated"
+                  className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-50 text-green-700 border border-green-200"
+                  title={risk.rag_artigo_exato ?? ""}
+                >
+                  RAG ✓
+                </span>
+              ) : (
+                <span
+                  data-testid="rag-badge-pending"
+                  className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-gray-50 text-gray-500 border border-gray-200"
+                >
+                  Não validado
+                </span>
+              )
+            )}
           </div>
           <p className="mt-1.5 text-sm font-medium text-foreground line-clamp-2" data-testid="risk-title">{risk.titulo}</p>
           {/* Breadcrumb 4 nós */}
@@ -1104,7 +1124,7 @@ export function RiskDashboardV4({ projectId }: RiskDashboardV4Props) {
       <AlertDialog open={showBulkConfirm} onOpenChange={(open) => { if (!open) setShowBulkConfirm(false); }}>
         <AlertDialogContent data-testid="bulk-approve-confirm-modal">
           <AlertDialogHeader>
-            <AlertDialogTitle>Aprovar matriz de riscos os riscos pendentes</AlertDialogTitle>
+            <AlertDialogTitle>Aprovar matriz de riscos</AlertDialogTitle>
             <AlertDialogDescription>
               Você está aprovando {activeRisks.filter((r) => !r.approved_at).length} riscos de uma vez.
               Esta ação será registrada com data e hora no histórico de auditoria.

--- a/server/lib/db-queries-risks-v4.ts
+++ b/server/lib/db-queries-risks-v4.ts
@@ -77,6 +77,8 @@ export interface RiskV4Row {
   updated_by: number;
   created_at: Date;
   updated_at: Date;
+  rag_validated: number;
+  rag_artigo_exato: string | null;
 }
 
 export interface InsertRiskV4 {


### PR DESCRIPTION
## Declaração de escopo
- [x] Médio — UI + tipo TS, sem mudança de banco
- [x] Nível 2 — Requer revisão

## Summary
- #598: Fix texto malformado L1107 "riscos os riscos pendentes" → "Aprovar matriz de riscos"
- #600: RAG validation badge (verde RAG ✓ / cinza Não validado) no card de risco
- Tipo RiskV4Row + RiskData com rag_validated + rag_artigo_exato
- Oportunidades sem badge (INV-RD-05)

## F4.5 Integration Checkpoint
- [x] #598: L1107 `grep 'riscos os riscos'` = 0
- [x] #600: RiskV4Row com rag_validated + rag_artigo_exato
- [x] #600: RiskData com rag_validated + rag_artigo_exato
- [x] #600: badge verde/cinza no card (data-testid presentes)
- [x] #600: oportunidades sem badge

## Evidência de qualidade
```json
{
  "data_integrity": true,
  "regression": false,
  "rag_impact": false,
  "unexpected_behavior": false,
  "tests_passed": true,
  "typescript_errors": 0,
  "risk_level": "medium"
}
```

## Test plan
- [ ] Abrir dashboard com riscos rag_validated=1 → badge verde visível
- [ ] Hover no badge → tooltip com artigo exato
- [ ] Riscos rag_validated=0 → badge cinza "Não validado"
- [ ] Oportunidades → sem badge RAG
- [ ] Modal bulkApprove → título "Aprovar matriz de riscos" (sem duplicação)

Closes #598
Closes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)