### PR TITLE
feat(dashboard+action-plan): plans preview + AI suggestion

### DIFF
--- a/client/src/components/RiskDashboardV4.tsx
+++ b/client/src/components/RiskDashboardV4.tsx
@@ -80,7 +80,7 @@ interface RiskData {
   approved_at?: string | null;
   approved_by?: number | null;
   deleted_reason?: string | null;
-  actionPlans?: { id: string; titulo: string; status: string }[];
+  actionPlans?: { id: string; titulo: string; status: string; responsavel?: string }[];
   rag_validated?: number;
   rag_artigo_exato?: string | null;
 }
@@ -306,6 +306,17 @@ function RiskCard({ risk, canApprove, onDelete, onRestore, onApprove, onNewPlan,
           <div className="mt-1" data-testid="risk-legal-basis">
             <Breadcrumb4 breadcrumb={breadcrumb} />
           </div>
+          {/* Plans preview inline — #601 */}
+          {risk.type !== "opportunity" && (risk.actionPlans?.length ?? 0) > 0 && (
+            <div data-testid="plans-preview" className="mt-2 space-y-0.5">
+              {risk.actionPlans!.map((p, i) => (
+                <div data-testid="plan-preview-row" key={p.id ?? i} className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <span className={`inline-block h-2 w-2 rounded-full shrink-0 ${p.status === "aprovado" ? "bg-green-500" : p.status === "em_andamento" ? "bg-blue-500" : "bg-amber-400"}`} />
+                  <span className="line-clamp-1">{p.titulo}</span>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
 
         {/* Ações */}

--- a/client/src/pages/ActionPlanPage.tsx
+++ b/client/src/pages/ActionPlanPage.tsx
@@ -666,6 +666,28 @@ export default function ActionPlanPage() {
                   <Label htmlFor="ap-titulo">Título *</Label>
                   <Input id="ap-titulo" value={npTitulo} onChange={(e) => setNpTitulo(e.target.value)} placeholder="Min 5 caracteres" maxLength={500} />
                   {npTitulo.length > 0 && npTitulo.length < 5 && <p className="text-xs text-destructive mt-1">Título muito curto</p>}
+                  {!isEditMode && parentRisk && (
+                    <button
+                      data-testid="ai-suggestion-btn"
+                      type="button"
+                      className="mt-1 text-xs text-blue-600 hover:text-blue-800 hover:underline cursor-pointer bg-transparent border-none p-0"
+                      onClick={async () => {
+                        try {
+                          const suggestion = await utils.risksV4.getActionPlanSuggestion.fetch({
+                            ruleId: parentRisk.rule_id,
+                            riskTitulo: parentRisk.titulo,
+                          });
+                          if (suggestion) {
+                            setNpTitulo(suggestion.titulo);
+                            setNpResponsavel(suggestion.responsavel);
+                            setNpPrazo(suggestion.prazo);
+                          }
+                        } catch { /* fallback: campos ficam como estão */ }
+                      }}
+                    >
+                      Sugestão da IA ↗ — clique para usar
+                    </button>
+                  )}
                 </div>
                 <div className="grid grid-cols-2 gap-3">
                   <div>
@@ -680,6 +702,7 @@ export default function ActionPlanPage() {
                         <SelectItem value="30_dias">30 dias</SelectItem>
                         <SelectItem value="60_dias">60 dias</SelectItem>
                         <SelectItem value="90_dias">90 dias</SelectItem>
+                        <SelectItem value="180_dias">180 dias</SelectItem>
                       </SelectContent>
                     </Select>
                   </div>
@@ -698,7 +721,7 @@ export default function ActionPlanPage() {
                     riskId: editPlanTarget?.risk_id ?? riskIdParam!,
                     titulo: npTitulo,
                     responsavel: npResponsavel,
-                    prazo: npPrazo as "30_dias" | "60_dias" | "90_dias",
+                    prazo: npPrazo as "30_dias" | "60_dias" | "90_dias" | "180_dias",
                     descricao: npDescricao || undefined,
                     ...(editPlanTarget ? { planId: editPlanTarget.id } : {}),
                   })}

--- a/server/lib/action-plan-engine-v4.ts
+++ b/server/lib/action-plan-engine-v4.ts
@@ -6,13 +6,13 @@ import type { RiskV4, ActionPlanV4 } from "./risk-engine-v4";
 
 // ─── Catálogo canônico de planos por ruleId ─────────────────────────────────
 
-interface ActionPlanSuggestion {
+export interface ActionPlanSuggestion {
   titulo: string;
   responsavel: string;
   prazo: "30_dias" | "60_dias" | "90_dias" | "180_dias";
 }
 
-const PLANS: Record<string, ActionPlanSuggestion[]> = {
+export const PLANS: Record<string, ActionPlanSuggestion[]> = {
   "GAP-IS-001": [
     { titulo: "Implantar controle de apuração do IS", responsavel: "gestor_fiscal", prazo: "90_dias" },
     { titulo: "Contratar assessoria tributária IS", responsavel: "diretor", prazo: "30_dias" },

--- a/server/routers/risks-v4.ts
+++ b/server/routers/risks-v4.ts
@@ -14,6 +14,7 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import { router, protectedProcedure } from "../_core/trpc";
 import { computeRiskMatrix, buildActionPlans } from "../lib/risk-engine-v4";
+import { PLANS } from "../lib/action-plan-engine-v4";
 import type { GapRule } from "../lib/risk-engine-v4";
 import { generateRisksV4Pipeline } from "../lib/generate-risks-pipeline";
 // Sprint Z-10 PR #B — ACL Gap→Risk
@@ -187,6 +188,25 @@ export const risksV4Router = router({
       );
 
       return { risks: risksWithPlans };
+    }),
+
+  /**
+   * 2b. getActionPlanSuggestion
+   * Retorna sugestão do catálogo PLANS para um ruleId (#602).
+   * NÃO chama LLM — determinístico (decisão E-G Z-14).
+   */
+  getActionPlanSuggestion: protectedProcedure
+    .input(z.object({ ruleId: z.string(), riskTitulo: z.string().optional() }))
+    .query(({ input }) => {
+      const suggestions = PLANS[input.ruleId];
+      if (suggestions && suggestions.length > 0) {
+        return suggestions[0];
+      }
+      return {
+        titulo: `Avaliar e mitigar: ${input.riskTitulo ?? input.ruleId}`,
+        responsavel: "advogado",
+        prazo: "60_dias" as const,
+      };
     }),
 
   /**


### PR DESCRIPTION
## Declaração de escopo
- [x] Médio — UI + procedure tRPC, sem mudança de banco
- [x] Nível 2 — Requer revisão

## Summary
- #601: Plans preview inline no card de risco (dot status + título)
- #602: Sugestão da IA via catálogo PLANS (sem LLM) + procedure getActionPlanSuggestion
- 180_dias adicionado ao Select de prazo (RN_PLANOS_TAREFAS_V4)

## F4.5 Integration Checkpoint
- [x] #601: plans-preview data-testid presente
- [x] #601: plan-preview-row data-testid presente
- [x] #601: oportunidades sem preview (INV-RD-05)
- [x] #602: ai-suggestion-btn data-testid presente
- [x] #602: getActionPlanSuggestion procedure criada
- [x] #602: PLANS exportado do engine (server-only)
- [x] #602: 180_dias no Select prazo
- [x] CT-08 não quebrado (opportunity-card intacto)

## Evidência de qualidade
```json
{
  "data_integrity": true,
  "regression": false,
  "rag_impact": false,
  "unexpected_behavior": false,
  "tests_passed": true,
  "typescript_errors": 0,
  "risk_level": "medium"
}
```

## Test plan
- [ ] Dashboard → card risk → plans preview com dots corretos
- [ ] Dashboard → card opportunity → sem plans preview
- [ ] ActionPlanPage → Novo plano → "Sugestão da IA ↗" preenche campos
- [ ] ActionPlanPage → Novo plano → editar campos após sugestão
- [ ] ActionPlanPage → prazo 180_dias disponível
- [ ] CT-08 oportunidade sem plano não quebrado

Closes #601
Closes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)