### PR TITLE
migration: 0087 tasks data_inicio + data_fim [#614]

### DIFF
--- a/drizzle/0087_tasks_data_inicio_fim.sql
+++ b/drizzle/0087_tasks_data_inicio_fim.sql
@@ -1,0 +1,11 @@
+-- Sprint Z-16 · Issue #614
+-- Adiciona data_inicio e data_fim na tabela tasks
+-- tasks.prazo (legado) permanece para compatibilidade
+
+ALTER TABLE tasks
+  ADD COLUMN data_inicio date NOT NULL
+    DEFAULT (CURDATE())
+    COMMENT 'Data de início da tarefa (Z-16)',
+  ADD COLUMN data_fim date NOT NULL
+    DEFAULT (DATE_ADD(CURDATE(), INTERVAL 30 DAY))
+    COMMENT 'Data de término previsto (Z-16)';


### PR DESCRIPTION
## Escopo
Migration de preview para adicionar campos de data nas tarefas.

## Arquivos alterados
- `drizzle/0087_tasks_data_inicio_fim.sql` — migration preview (NÃO executada)

## Evidência JSON
```json
{
  "gate": 7,
  "tipo": "migration-preview",
  "sprint": "Z-16-HOLD",
  "issue": "#614",
  "tabela": "tasks",
  "campos_adicionados": ["data_inicio DATE NOT NULL", "data_fim DATE NOT NULL"],
  "campos_preservados": ["prazo DATE (legado)"],
  "executado": false,
  "aguardando": "aprovacao_PO"
}
```

## Gate 7 checklist
- [x] migration preview — sem execução no banco
- [x] sem DROP COLUMN
- [x] tasks.prazo preservado (compatibilidade legado)
- [x] issue #614 referenciada
- [x] Sprint Z-16 HOLD respeitado

## ⚠️ IMPORTANTE
**Manus executa a migration SOMENTE após aprovação explícita do P.O.**
Não executar `pnpm db:push` sem autorização.