### PR TITLE
fix(engine): fallback PLANS por categoria [#611]

### DIFF
--- a/server/lib/action-plan-engine-v4.ts
+++ b/server/lib/action-plan-engine-v4.ts
@@ -13,6 +13,7 @@ export interface ActionPlanSuggestion {
 }
 
 export const PLANS: Record<string, ActionPlanSuggestion[]> = {
+  // ─── Por ruleId (prioridade máxima) ───
   "GAP-IS-001": [
     { titulo: "Implantar controle de apuração do IS", responsavel: "gestor_fiscal", prazo: "90_dias" },
     { titulo: "Contratar assessoria tributária IS", responsavel: "diretor", prazo: "30_dias" },
@@ -24,6 +25,20 @@ export const PLANS: Record<string, ActionPlanSuggestion[]> = {
     { titulo: "Parametrizar alíquota zero nos produtos elegíveis", responsavel: "gestor_fiscal", prazo: "60_dias" },
   ],
   "GAP-TR-001": [
+    { titulo: "Plano de transição ISS para IBS 2026 a 2032", responsavel: "juridico", prazo: "180_dias" },
+  ],
+  // ─── Por categoria (fallback hierárquico — #611) ───
+  "imposto_seletivo": [
+    { titulo: "Implantar controle de apuração do IS", responsavel: "gestor_fiscal", prazo: "90_dias" },
+    { titulo: "Contratar assessoria tributária IS", responsavel: "diretor", prazo: "30_dias" },
+  ],
+  "split_payment": [
+    { titulo: "Adequar sistema para split payment", responsavel: "ti", prazo: "90_dias" },
+  ],
+  "aliquota_zero": [
+    { titulo: "Parametrizar alíquota zero nos produtos elegíveis", responsavel: "gestor_fiscal", prazo: "60_dias" },
+  ],
+  "transicao_iss_ibs": [
     { titulo: "Plano de transição ISS para IBS 2026 a 2032", responsavel: "juridico", prazo: "180_dias" },
   ],
 };
@@ -50,7 +65,9 @@ export function buildActionPlans(risks: RiskV4[]): ActionPlanV4[] {
     // RN-AP-09: oportunidade NUNCA gera plano
     if (risk.severity === "oportunidade") continue;
 
-    const suggestions = PLANS[risk.ruleId] ?? [defaultSuggestion(risk)];
+    const suggestions = PLANS[risk.ruleId]
+      ?? PLANS[risk.categoria]
+      ?? [defaultSuggestion(risk)];
 
     for (const s of suggestions) {
       plans.push({

--- a/server/lib/risk-engine-v4.test.ts
+++ b/server/lib/risk-engine-v4.test.ts
@@ -249,14 +249,14 @@ describe("Bloco D — action plan engine", () => {
     expect(plans[0].prioridade).toBe("curto_prazo");
   });
 
-  it("D3: múltiplos riscos alta geram um plano por risco", () => {
+  it("D3: múltiplos riscos alta geram planos via fallback categoria", () => {
     const risks = [
-      classifyRisk(makeGap({ ruleId: "R-1", categoria: "split_payment" })),
-      classifyRisk(makeGap({ ruleId: "R-2", categoria: "confissao_automatica" })),
-      classifyRisk(makeGap({ ruleId: "R-3", categoria: "imposto_seletivo" })),
+      classifyRisk(makeGap({ ruleId: "R-1", categoria: "split_payment" })),       // 1 plan (PLANS["split_payment"])
+      classifyRisk(makeGap({ ruleId: "R-2", categoria: "confissao_automatica" })), // 1 plan (defaultSuggestion)
+      classifyRisk(makeGap({ ruleId: "R-3", categoria: "imposto_seletivo" })),     // 2 plans (PLANS["imposto_seletivo"])
     ];
     const plans = buildActionPlans(risks);
-    expect(plans).toHaveLength(3);
+    expect(plans).toHaveLength(4);
     plans.forEach(p => expect(p.prioridade).toBe("imediata"));
   });
 

--- a/server/routers/risks-v4.ts
+++ b/server/routers/risks-v4.ts
@@ -196,9 +196,10 @@ export const risksV4Router = router({
    * NÃO chama LLM — determinístico (decisão E-G Z-14).
    */
   getActionPlanSuggestion: protectedProcedure
-    .input(z.object({ ruleId: z.string(), riskTitulo: z.string().optional() }))
+    .input(z.object({ ruleId: z.string(), categoria: z.string().optional(), riskTitulo: z.string().optional() }))
     .query(({ input }) => {
-      const suggestions = PLANS[input.ruleId];
+      const suggestions = PLANS[input.ruleId]
+        ?? (input.categoria ? PLANS[input.categoria] : undefined);
       if (suggestions && suggestions.length > 0) {
         return suggestions[0];
       }


### PR DESCRIPTION
## Summary
- PLANS lookup: ruleId → categoria → defaultSuggestion
- 4 aliases de categoria adicionados ao catálogo PLANS
- getActionPlanSuggestion também usa fallback categoria

## Test plan
- [x] `pnpm vitest run server/lib/risk-engine-v4.test.ts` — 35/35
- [x] `tsc --noEmit` — 0 erros

Closes #611
risk_level: low

🤖 Generated with [Claude Code](https://claude.com/claude-code)