### PR TITLE
feat(engine): calculateComplianceScore v4 [#622]

### DIFF
--- a/server/lib/compliance-score-v4.test.ts
+++ b/server/lib/compliance-score-v4.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import {
+  calculateComplianceScore,
+  SEVERIDADE_SCORE_MAP,
+  CONFIDENCE_FLOOR,
+  MAX_PESO,
+} from "./compliance-score-v4";
+
+describe("compliance-score-v4", () => {
+  it("0 riscos → score=0, nivel=baixo", () => {
+    const result = calculateComplianceScore([]);
+    expect(result.score).toBe(0);
+    expect(result.nivel).toBe("baixo");
+    expect(result.total_riscos_aprovados).toBe(0);
+    expect(result.formula_version).toBe("v4.0");
+  });
+
+  it("riscos não aprovados são ignorados (RN-CV4-01)", () => {
+    const result = calculateComplianceScore([
+      { severidade: "alta", confidence: 1, type: "risk", approved_at: null },
+      { severidade: "media", confidence: 1, type: "risk", approved_at: null },
+    ]);
+    expect(result.score).toBe(0);
+    expect(result.total_riscos_aprovados).toBe(0);
+  });
+
+  it("oportunidades fora do denominador (RN-CV4-02)", () => {
+    const now = new Date();
+    const result = calculateComplianceScore([
+      { severidade: "alta", confidence: 1, type: "risk", approved_at: now },
+      { severidade: "oportunidade", confidence: 1, type: "opportunity", approved_at: now },
+    ]);
+    // 1 risco scorable: (7×1)/(1×9)×100 = 77.78 → 78
+    expect(result.score).toBe(78);
+    expect(result.nivel).toBe("critico");
+    expect(result.total_riscos_aprovados).toBe(2);
+    expect(result.total_alta).toBe(1);
+  });
+
+  it("confidence mínima 0.5 aplicada (RN-CV4-04)", () => {
+    const now = new Date();
+    const result = calculateComplianceScore([
+      { severidade: "alta", confidence: 0, type: "risk", approved_at: now },
+    ]);
+    // (7×0.5)/(1×9)×100 = 38.89 → 39
+    expect(result.score).toBe(39);
+    expect(result.nivel).toBe("medio");
+  });
+
+  it("nível critico >= 75", () => {
+    const now = new Date();
+    const result = calculateComplianceScore([
+      { severidade: "alta", confidence: 1, type: "risk", approved_at: now },
+      { severidade: "alta", confidence: 1, type: "risk", approved_at: now },
+    ]);
+    // (7+7)/(2×9)×100 = 77.78 → 78
+    expect(result.score).toBe(78);
+    expect(result.nivel).toBe("critico");
+  });
+
+  it("nível alto >= 50 < 75", () => {
+    const now = new Date();
+    const result = calculateComplianceScore([
+      { severidade: "alta", confidence: 1, type: "risk", approved_at: now },
+      { severidade: "media", confidence: 1, type: "risk", approved_at: now },
+    ]);
+    // (7+5)/(2×9)×100 = 66.67 → 67
+    expect(result.score).toBe(67);
+    expect(result.nivel).toBe("alto");
+  });
+
+  it("nível medio >= 25 < 50", () => {
+    const now = new Date();
+    const result = calculateComplianceScore([
+      { severidade: "media", confidence: 0.5, type: "risk", approved_at: now },
+    ]);
+    // (5×0.5)/(1×9)×100 = 27.78 → 28
+    expect(result.score).toBe(28);
+    expect(result.nivel).toBe("medio");
+  });
+
+  it("constantes exportadas corretamente", () => {
+    expect(SEVERIDADE_SCORE_MAP.alta).toBe(7);
+    expect(SEVERIDADE_SCORE_MAP.media).toBe(5);
+    expect(SEVERIDADE_SCORE_MAP.oportunidade).toBe(1);
+    expect(CONFIDENCE_FLOOR).toBe(0.5);
+    expect(MAX_PESO).toBe(9);
+  });
+
+  it("total_alta e total_media contam corretamente", () => {
+    const now = new Date();
+    const result = calculateComplianceScore([
+      { severidade: "alta", confidence: 1, type: "risk", approved_at: now },
+      { severidade: "alta", confidence: 1, type: "risk", approved_at: now },
+      { severidade: "media", confidence: 1, type: "risk", approved_at: now },
+    ]);
+    expect(result.total_alta).toBe(2);
+    expect(result.total_media).toBe(1);
+    expect(result.total_riscos_aprovados).toBe(3);
+  });
+});

--- a/server/lib/compliance-score-v4.ts
+++ b/server/lib/compliance-score-v4.ts
@@ -1,0 +1,96 @@
+// compliance-score-v4.ts — Score determinístico de compliance (Sprint Z-16 #622)
+// RN-CV4-01..07 + RN-CV4-10 + RN-CV4-14
+// Função pura: mesma entrada → mesma saída. NUNCA usa LLM.
+
+// ─── Constantes determinísticas ─────────────────────────────────────────────
+
+export const SEVERIDADE_SCORE_MAP: Record<string, number> = {
+  alta: 7,
+  media: 5,
+  oportunidade: 1,
+};
+
+export const CONFIDENCE_FLOOR = 0.5;
+export const MAX_PESO = 9;
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface ComplianceRiskScoreInput {
+  severidade: string;
+  confidence: number;
+  type: "risk" | "opportunity";
+  approved_at: Date | null;
+}
+
+export interface ComplianceScoreResult {
+  score: number;
+  nivel: "critico" | "alto" | "medio" | "baixo";
+  total_riscos_aprovados: number;
+  total_alta: number;
+  total_media: number;
+  formula_version: "v4.0";
+}
+
+export interface ScoringDataSnapshot {
+  score: number;
+  nivel: string;
+  total_riscos_aprovados: number;
+  total_alta: number;
+  total_media: number;
+  formula_version: string;
+  calculated_at: string;
+}
+
+// ─── Nível determinístico (RN-CV4-14) ───────────────────────────────────────
+
+function classifyNivel(score: number): "critico" | "alto" | "medio" | "baixo" {
+  if (score >= 75) return "critico";
+  if (score >= 50) return "alto";
+  if (score >= 25) return "medio";
+  return "baixo";
+}
+
+// ─── Fórmula principal ──────────────────────────────────────────────────────
+
+export function calculateComplianceScore(
+  risks: ComplianceRiskScoreInput[]
+): ComplianceScoreResult {
+  // RN-CV4-01: apenas riscos aprovados
+  const approved = risks.filter((r) => r.approved_at !== null);
+
+  // RN-CV4-02: oportunidades fora do denominador
+  const scorable = approved.filter((r) => r.type !== "opportunity");
+
+  if (scorable.length === 0) {
+    return {
+      score: 0,
+      nivel: "baixo",
+      total_riscos_aprovados: approved.length,
+      total_alta: 0,
+      total_media: 0,
+      formula_version: "v4.0",
+    };
+  }
+
+  // RN-CV4-04: confidence mínima 0.5
+  const weightedSum = scorable.reduce((acc, r) => {
+    const peso = SEVERIDADE_SCORE_MAP[r.severidade] ?? 0;
+    const conf = Math.max(r.confidence ?? 0, CONFIDENCE_FLOOR);
+    return acc + peso * conf;
+  }, 0);
+
+  // Fórmula: round(sum(peso × max(conf, 0.5)) / (n × 9) × 100)
+  const score = Math.round((weightedSum / (scorable.length * MAX_PESO)) * 100);
+
+  const total_alta = scorable.filter((r) => r.severidade === "alta").length;
+  const total_media = scorable.filter((r) => r.severidade === "media").length;
+
+  return {
+    score,
+    nivel: classifyNivel(score),
+    total_riscos_aprovados: approved.length,
+    total_alta,
+    total_media,
+    formula_version: "v4.0",
+  };
+}

--- a/server/routers/risks-v4.ts
+++ b/server/routers/risks-v4.ts
@@ -15,6 +15,9 @@ import { TRPCError } from "@trpc/server";
 import { router, protectedProcedure } from "../_core/trpc";
 import { computeRiskMatrix, buildActionPlans } from "../lib/risk-engine-v4";
 import { PLANS } from "../lib/action-plan-engine-v4";
+import { calculateComplianceScore } from "../lib/compliance-score-v4";
+import type { ScoringDataSnapshot } from "../lib/compliance-score-v4";
+import { getProjectById, updateProject, safeParseJson } from "../db";
 import type { GapRule } from "../lib/risk-engine-v4";
 import { generateRisksV4Pipeline } from "../lib/generate-risks-pipeline";
 // Sprint Z-10 PR #B — ACL Gap→Risk
@@ -761,5 +764,45 @@ export const risksV4Router = router({
     .query(async ({ input }) => {
       const entries = await getProjectAuditLog(input.projectId, input.limit);
       return { entries };
+    }),
+
+  /**
+   * 13. calculateAndSaveScore (Sprint Z-16 #622)
+   * Calcula score de compliance v4 deterministicamente e salva snapshot.
+   * RN-CV4-01..07 + RN-CV4-10 + RN-CV4-14
+   */
+  calculateAndSaveScore: protectedProcedure
+    .input(z.object({ projectId: z.number() }))
+    .mutation(async ({ input }) => {
+      const risks = await getRisksV4ByProject(input.projectId);
+
+      const result = calculateComplianceScore(
+        risks.map((r) => ({
+          severidade: r.severidade,
+          confidence: r.confidence,
+          type: r.type,
+          approved_at: r.approved_at,
+        }))
+      );
+
+      // RN-CV4-03 + RN-CV4-10: acrescentar snapshot, nunca deletar
+      const project = await getProjectById(input.projectId);
+      const existing = safeParseJson<{ snapshots?: ScoringDataSnapshot[] }>(
+        project?.scoringData,
+        {}
+      );
+      const snapshots = existing.snapshots ?? [];
+
+      const snapshot: ScoringDataSnapshot = {
+        ...result,
+        calculated_at: new Date().toISOString(),
+      };
+      snapshots.push(snapshot);
+
+      await updateProject(input.projectId, {
+        scoringData: { ...existing, ...result, snapshots },
+      });
+
+      return result;
     }),
 });


### PR DESCRIPTION
## Summary
- Score v4 determinístico: `sum(peso×max(conf,0.5))/(n×9)×100`
- Procedure `calculateAndSaveScore` salva snapshot em `projects.scoringData`
- Snapshots acumulados — nunca deleta histórico (RN-CV4-10)
- 9 testes unitários cobrindo edge cases

## Test plan
- [x] `pnpm vitest run server/lib/compliance-score-v4.test.ts` — 9/9
- [x] `pnpm vitest run server/lib/risk-engine-v4.test.ts` — 35/35
- [x] `tsc --noEmit` — 0 erros

Closes #622
risk_level: medium

🤖 Generated with [Claude Code](https://claude.com/claude-code)