### PR TITLE
db: tasks data_inicio/data_fim NOT NULL (Opção C)

### DIFF
--- a/docs/governance/DATA_DICTIONARY.md
+++ b/docs/governance/DATA_DICTIONARY.md
@@ -142,6 +142,8 @@ SELECT JSON_KEYS([campo_json]) FROM [tabela] WHERE [campo_json] IS NOT NULL LIMI
 | descricao | text | NULL |
 | responsavel | varchar(255) | NULL |
 | prazo | **DATE** | NULL — tasks usa date livre (diferente de action_plans!) |
+| **data_inicio** | **DATE NOT NULL** | Sprint Z-16 #614 — Opção C: MODIFY NOT NULL (sem DEFAULT) |
+| **data_fim** | **DATE NOT NULL** | Sprint Z-16 #614 — Opção C: MODIFY NOT NULL (sem DEFAULT) |
 | status | **ENUM('todo','doing','done','blocked','deleted')** | DEFAULT 'todo' — ⚠️ NAO e 'pendente' |
 | prioridade | enum('alta','media','baixa') | DEFAULT 'media' |
 | ordem | int | DEFAULT 0 |
@@ -152,7 +154,7 @@ SELECT JSON_KEYS([campo_json]) FROM [tabela] WHERE [campo_json] IS NOT NULL LIMI
 
 > **Atenção:** `tasks.prazo` é DATE (campo livre), diferente de `action_plans.prazo` que é ENUM.
 
-> **Verificado em Sprint Z-16 Gate 0 (2026-04-15):** O banco NAO tem `data_inicio` nem `data_fim` na tabela `tasks`. Colunas existentes: id, project_id, action_plan_id, titulo, descricao, responsavel, prazo, status, ordem, deleted_reason, created_by, created_at, updated_at.
+> **Atualizado em Sprint Z-16 Fase 2 (2026-04-16):** `data_inicio` e `data_fim` adicionados como DATE NOT NULL via ALTER TABLE MODIFY (Opção C aprovada pelo P.O.). Interfaces TypeScript `TaskRow` e `InsertTaskV4` atualizadas em `server/lib/db-queries-risks-v4.ts`. Defaults no código: `data_inicio = CURDATE()`, `data_fim = CURDATE() + 30 dias`.
 
 ---
 

--- a/server/lib/db-queries-risks-v4.ts
+++ b/server/lib/db-queries-risks-v4.ts
@@ -146,6 +146,8 @@ export interface TaskRow {
   descricao: string | null;
   responsavel: string;
   prazo: Date | null;
+  data_inicio: Date;    // Sprint Z-16 #614 — NOT NULL
+  data_fim: Date;       // Sprint Z-16 #614 — NOT NULL
   status: StatusTask;
   ordem: number;
   deleted_reason: string | null;
@@ -161,6 +163,8 @@ export interface InsertTaskV4 {
   descricao?: string | null;
   responsavel: string;
   prazo?: Date | null;
+  data_inicio: Date;    // Sprint Z-16 #614 — NOT NULL
+  data_fim: Date;       // Sprint Z-16 #614 — NOT NULL
   ordem?: number;
   created_by: number;
 }
@@ -463,8 +467,8 @@ export async function insertTaskV4(data: InsertTaskV4): Promise<string> {
   await query(
     `INSERT INTO tasks
       (id, project_id, action_plan_id, titulo, descricao, responsavel, prazo,
-       ordem, created_by)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       data_inicio, data_fim, ordem, created_by)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       id,
       data.project_id,
@@ -473,6 +477,8 @@ export async function insertTaskV4(data: InsertTaskV4): Promise<string> {
       data.descricao ?? null,
       data.responsavel,
       data.prazo ?? null,
+      data.data_inicio,
+      data.data_fim,
       data.ordem ?? 0,
       data.created_by,
     ]

--- a/server/routers/risks-v4.ts
+++ b/server/routers/risks-v4.ts
@@ -493,6 +493,8 @@ export const risksV4Router = router({
         descricao: z.string().optional(),
         responsavel: z.string().min(1),
         prazo: z.string().optional(),
+        dataInicio: z.string().optional(), // Sprint Z-16 #614 — ISO date string
+        dataFim: z.string().optional(),    // Sprint Z-16 #614 — ISO date string
         status: z.enum(["todo", "doing", "done", "blocked"]).optional(),
         ordem: z.number().optional(),
       })
@@ -518,6 +520,9 @@ export const risksV4Router = router({
       }
 
       // Insert
+      const today = new Date();
+      const in30Days = new Date(today);
+      in30Days.setDate(in30Days.getDate() + 30);
       const taskId = await insertTaskV4({
         project_id: input.projectId,
         action_plan_id: input.actionPlanId,
@@ -525,6 +530,8 @@ export const risksV4Router = router({
         descricao: input.descricao,
         responsavel: input.responsavel,
         prazo: input.prazo ? new Date(input.prazo) : undefined,
+        data_inicio: input.dataInicio ? new Date(input.dataInicio) : today,
+        data_fim: input.dataFim ? new Date(input.dataFim) : in30Days,
         ordem: input.ordem ?? 0,
         created_by: ctx.user.id,
       });


### PR DESCRIPTION
## Sprint Z-16 · Issue #614 — tasks.data_inicio + data_fim NOT NULL

### Tipo de mudança
- [x] db: migration (ALTER TABLE)
- [x] schema: atualização de tipos TypeScript
- [x] docs: DATA_DICTIONARY atualizado

### Evidência JSON
```json
{
  "show_columns": [
    {"Field": "data_inicio", "Type": "date", "Null": "NO", "Default": null},
    {"Field": "data_fim",    "Type": "date", "Null": "NO", "Default": null}
  ],
  "migration": "ALTER TABLE tasks MODIFY data_inicio DATE NOT NULL; ALTER TABLE tasks MODIFY data_fim DATE NOT NULL;",
  "opcao": "C",
  "risk_level": "medium",
  "tasks_count_antes": 0,
  "tsc": "0 erros",
  "testes": "1665 passed (falha b-z11-012 pré-existente)"
}
```

### Arquivos alterados (escopo declarado)
- `server/lib/db-queries-risks-v4.ts` — TaskRow + InsertTaskV4 + INSERT SQL
- `server/routers/risks-v4.ts` — upsertTask input schema + defaults
- `docs/governance/DATA_DICTIONARY.md` — tipos corrigidos

### Gate 7 Checklist
- [x] tsc: 0 erros
- [x] testes: 1665 passed (sem regressão)
- [x] sem DROP COLUMN
- [x] sem DIAGNOSTIC_READ_MODE=new
- [x] escopo declarado: 3 arquivos
- [x] SHOW COLUMNS verificado: Null=NO

Closes #614