### PR TITLE
ci(governance): PRE-CLOSE-CHECKLIST + ORQ-17 hard-enforced

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -149,6 +149,23 @@ jobs:
           fi
           echo "OK: conteudo completo"
 
+  pre-close-checklist:
+    name: Pre-Close Checklist (ORQ-17)
+    runs-on: ubuntu-latest
+    if: |
+      !contains(github.event.pull_request.title, 'docs(') &&
+      !contains(github.event.pull_request.title, 'chore(')
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run PRE-CLOSE-CHECKLIST
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          chmod +x scripts/pre-close-check.sh
+          bash scripts/pre-close-check.sh
+
   procedure-check:
     name: Integration Checkpoint (WARN)
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,24 @@ Acoes com efeito cascata confirmado:
 
 "Gerar plano" nao e suficiente. Deve especificar: `status='rascunho'`, `prazo=ENUM`, `insertActionPlanV4WithAudit`.
 
+### REGRA-ORQ-17 — PRE-CLOSE-CHECKLIST (obrigatorio antes de fechar issue)
+
+Antes de mergear qualquer PR que contém `Closes #N`:
+executar `docs/governance/PRE-CLOSE-CHECKLIST.md` gates PC-1..PC-5.
+
+5 gates obrigatórios:
+  PC-1: PR toca os arquivos do Bloco 3 da issue?
+  PC-2: data-testid do Bloco 9 presentes no componente?
+  PC-3: critérios do Bloco 7 verificáveis no código?
+  PC-4: procedures do Bloco 5 chamadas pelo componente?
+  PC-5: tipo do PR compatível com tipo da issue?
+
+Se qualquer gate FALHA: remover `Closes #N` do PR body.
+PR de migration/docs NUNCA fecha issue de UI/frontend.
+
+Causa raiz: Sprint Z-16 — #614 fechada por PR #639 (migration)
+sem UI do modal implementada. 3/5 gates teriam bloqueado.
+
 ### REGRA-ORQ-15 — PR body template obrigatorio
 
 Todo PR DEVE conter no body os campos exatos do `.github/PULL_REQUEST_TEMPLATE.md`:

--- a/docs/governance/PRE-CLOSE-CHECKLIST.md
+++ b/docs/governance/PRE-CLOSE-CHECKLIST.md
@@ -1,0 +1,179 @@
+# PRE-CLOSE-CHECKLIST — Validação de Issue Antes do Fechamento
+
+> **Audiência:** Orquestrador (Claude) — executar ANTES de aceitar que um PR fecha uma issue.
+> **Causa raiz:** Sprint Z-16 — #614 fechada por PR #639 (migration) sem UI implementada.
+> **Regra:** Nenhuma issue é considerada CLOSED até passar nos 5 gates abaixo.
+
+---
+
+## Quando usar
+
+- Antes de mergear PR que contém `Closes #N` / `Fixes #N`
+- Antes de fechar issue manualmente
+- No checkpoint pós-merge (validação retroativa)
+
+---
+
+## Gate PC-1 — Escopo do PR vs Escopo da Issue
+
+```bash
+# O que a issue pede?
+gh issue view [N] --json title,body --jq '.title'
+
+# O que o PR entrega?
+gh pr view [PR] --json title,files --jq '{title, files: [.files[].path]}'
+```
+
+**Critério:** O PR toca os arquivos mencionados no Bloco 3 (Skeleton) da issue?
+
+| Pergunta | Esperado |
+|----------|----------|
+| Issue é frontend? PR toca `client/src/`? | SIM |
+| Issue é backend? PR toca `server/`? | SIM |
+| Issue é migration? PR toca `drizzle/`? | SIM |
+| PR toca APENAS docs/migrations mas issue pede UI? | **BLOQUEIO — PR não fecha a issue** |
+
+---
+
+## Gate PC-2 — data-testid implementados
+
+```bash
+# Extrair data-testid esperados da issue
+gh issue view [N] --json body --jq '.body' | grep -o 'data-testid="[^"]*"' | sort -u
+
+# Extrair data-testid presentes no componente
+grep -o 'data-testid="[^"]*"' [arquivo_componente] | sort -u
+
+# Gap
+comm -23 <(issue_testids) <(component_testids)
+```
+
+**Critério:** Todos os data-testid listados no Bloco 9 da issue estão no componente?
+
+| Gap | Ação |
+|-----|------|
+| 0 | PASS |
+| 1–3 | Avaliar se são opcionais (defer P.O.) |
+| > 3 | **BLOQUEIO — implementação incompleta** |
+
+---
+
+## Gate PC-3 — Critérios de Aceite (Bloco 7)
+
+```bash
+# Ler critérios de aceite da issue
+gh issue view [N] --json body --jq '.body' | sed -n '/Bloco 7/,/Bloco 8/p'
+```
+
+**Critério:** Cada checkbox do Bloco 7 pode ser verificado no código?
+
+Para cada critério:
+1. Identificar o arquivo/linha que implementa
+2. Se critério é `grep X = 0` → executar o grep
+3. Se critério é `tsc 0 erros` → já coberto no CI
+4. Se critério é comportamental → marcar como "E2E pendente"
+
+| Resultado | Ação |
+|-----------|------|
+| Todos verificáveis | PASS |
+| Algum sem evidência no código | **BLOQUEIO** |
+
+---
+
+## Gate PC-4 — Contrato API (Bloco 5)
+
+```bash
+# Procedures esperadas pela issue
+gh issue view [N] --json body --jq '.body' | grep -i "procedure\|trpc\.\|mutation\|query"
+
+# Procedures presentes no router
+grep -n "protectedProcedure" server/routers/risks-v4.ts | head -20
+```
+
+**Critério:** Toda procedure mencionada no Bloco 5 existe e é chamada pelo componente?
+
+```bash
+# ORQ-10: Integration checkpoint
+grep -n "trpc\." [componente] | head -20
+# Cruzar com procedures da issue
+```
+
+| Resultado | Ação |
+|-----------|------|
+| 100% procedures chamadas | PASS |
+| Procedure não chamada | **BLOQUEIO — F4.5 falha** |
+
+---
+
+## Gate PC-5 — Tipo de entrega vs Tipo de issue
+
+Classificar o PR:
+
+| Tipo PR | Exemplos | Pode fechar issue de frontend? | Pode fechar issue de engine? | Pode fechar issue de migration? |
+|---------|----------|-------------------------------|-----------------------------|---------------------------------|
+| `docs:` | Sprint Log, dicionários | NÃO | NÃO | NÃO |
+| `db:` / `migration:` | ALTER TABLE, schema | NÃO | NÃO | SIM |
+| `feat(engine):` | Score, PLANS | NÃO | SIM | NÃO |
+| `feat(dashboard):` | UI componente | SIM (se toca o componente) | NÃO | NÃO |
+| `feat(action-plan):` | UI componente | SIM (se toca o componente) | NÃO | NÃO |
+| `fix:` | Bug fix | Depende do escopo | Depende do escopo | NÃO |
+
+**Regra absoluta:** PR de migration/docs NUNCA fecha issue de UI/frontend.
+
+---
+
+## Comando rápido — validação em 1 minuto
+
+```bash
+# Substituir N pelo número da issue e PR pelo número do PR
+N=614; PR=639
+
+echo "=== PC-1: Escopo ==="
+ISSUE_TITLE=$(gh issue view $N --json title --jq '.title')
+PR_FILES=$(gh pr view $PR --json files --jq '[.files[].path] | join(", ")')
+echo "Issue: $ISSUE_TITLE"
+echo "PR files: $PR_FILES"
+
+echo "=== PC-2: data-testid ==="
+EXPECTED=$(gh issue view $N --json body --jq '.body' | grep -o 'data-testid="[^"]*"' | sort -u | wc -l)
+echo "data-testid esperados na issue: $EXPECTED"
+
+echo "=== PC-5: Tipo ==="
+PR_TITLE=$(gh pr view $PR --json title --jq '.title')
+echo "PR: $PR_TITLE"
+echo "Issue frontend? $(echo $ISSUE_TITLE | grep -qi 'feat\|modal\|componente\|badge\|redirect' && echo SIM || echo NAO)"
+echo "PR toca client/? $(echo $PR_FILES | grep -q 'client/' && echo SIM || echo NAO)"
+```
+
+---
+
+## Exemplo: #614 teria sido barrada
+
+```
+PC-1: Issue pede "modal editar tarefa" → PR #639 toca drizzle/ apenas → FALHA
+PC-2: Issue lista task-edit-modal, task-data-inicio-input → 0 no código → FALHA
+PC-5: PR é db:/migration → Issue é frontend → FALHA
+
+Resultado: 3/5 gates FALHAM → PR #639 NÃO fecha #614
+```
+
+---
+
+## Integração no fluxo do Orquestrador
+
+### Quando executar
+
+```
+F6 (implementação) → PR criado → F4.5 (integration checkpoint)
+  → **PRE-CLOSE-CHECKLIST** ← NOVO
+  → Merge → Issue fechada automaticamente
+```
+
+### Regra para CLAUDE.md
+
+```
+Antes de mergear qualquer PR com "Closes #N":
+executar PRE-CLOSE-CHECKLIST gates PC-1..PC-5.
+Se qualquer gate FALHA: remover "Closes #N" do PR body
+e reportar ao Orquestrador.
+```

--- a/scripts/pre-close-check.sh
+++ b/scripts/pre-close-check.sh
@@ -1,0 +1,224 @@
+#!/bin/bash
+# pre-close-check.sh — PRE-CLOSE-CHECKLIST automático (ORQ-17)
+# Valida que um PR realmente implementa o que a issue pede.
+# Uso: ./scripts/pre-close-check.sh
+# Requer: GH_TOKEN, PR_NUMBER, REPO como env vars
+
+set -euo pipefail
+
+REPO="${REPO:?REPO env var required}"
+PR_NUMBER="${PR_NUMBER:?PR_NUMBER env var required}"
+
+PASS=0
+FAIL=0
+WARN=0
+
+log_pass() { echo "✅ PC-$1: $2"; PASS=$((PASS + 1)); }
+log_fail() { echo "❌ PC-$1: $2"; FAIL=$((FAIL + 1)); }
+log_warn() { echo "⚠️  PC-$1: $2"; WARN=$((WARN + 1)); }
+log_skip() { echo "⏭️  PC-$1: $2"; }
+
+# ─── Resolve issue number ───────────────────────────────────────────────────
+
+ISSUE_NUMBER=$(gh pr view "$PR_NUMBER" \
+  --repo "$REPO" \
+  --json closingIssuesReferences \
+  --jq '.closingIssuesReferences[0].number' 2>/dev/null || echo "")
+
+if [ -z "$ISSUE_NUMBER" ] || [ "$ISSUE_NUMBER" = "null" ]; then
+  echo "SKIP: PR sem 'Closes #N' — checklist não se aplica"
+  exit 0
+fi
+
+echo "═══════════════════════════════════════════════════"
+echo "PRE-CLOSE-CHECKLIST — PR #$PR_NUMBER → Issue #$ISSUE_NUMBER"
+echo "═══════════════════════════════════════════════════"
+echo ""
+
+# ─── Resolve PR metadata ────────────────────────────────────────────────────
+
+PR_TITLE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json title --jq '.title')
+PR_FILES=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '[.files[].path] | join("\n")')
+
+ISSUE_TITLE=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json title --jq '.title')
+ISSUE_BODY=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json body --jq '.body')
+ISSUE_LABELS=$(gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json labels --jq '[.labels[].name] | join(",")')
+
+echo "PR: $PR_TITLE"
+echo "Issue: $ISSUE_TITLE"
+echo ""
+
+# ─── Skip conditions ────────────────────────────────────────────────────────
+
+# Skip for docs-only PRs closing docs issues
+if [[ "$PR_TITLE" == docs* ]] && [[ "$ISSUE_LABELS" != *"frontend"* ]] && [[ "$ISSUE_LABELS" != *"engine"* ]]; then
+  echo "SKIP: PR de docs fechando issue de docs — checklist não se aplica"
+  exit 0
+fi
+
+# Skip for hotfixes
+if [[ "$PR_TITLE" == *"[HOTFIX]"* ]]; then
+  echo "SKIP: HOTFIX — fast-track (ORQ-11)"
+  exit 0
+fi
+
+# ─── PC-1: Escopo do PR vs Escopo da Issue ───────────────────────────────────
+
+echo "── PC-1: Escopo PR vs Issue ──"
+
+IS_FRONTEND=false
+IS_ENGINE=false
+IS_MIGRATION=false
+
+[[ "$ISSUE_LABELS" == *"frontend"* ]] && IS_FRONTEND=true
+[[ "$ISSUE_LABELS" == *"engine"* ]] && IS_ENGINE=true
+echo "$ISSUE_BODY" | grep -qi "migration\|ALTER TABLE\|drizzle/" && IS_MIGRATION=true
+
+PC1_PASS=true
+
+if $IS_FRONTEND; then
+  if echo "$PR_FILES" | grep -q "^client/"; then
+    log_pass "1" "Issue frontend → PR toca client/"
+  else
+    log_fail "1" "Issue frontend mas PR NÃO toca client/ — implementação ausente"
+    PC1_PASS=false
+  fi
+elif $IS_ENGINE; then
+  if echo "$PR_FILES" | grep -q "^server/"; then
+    log_pass "1" "Issue engine → PR toca server/"
+  else
+    log_fail "1" "Issue engine mas PR NÃO toca server/ — implementação ausente"
+    PC1_PASS=false
+  fi
+else
+  log_skip "1" "Issue sem label frontend/engine — verificação manual"
+fi
+
+# ─── PC-2: data-testid ──────────────────────────────────────────────────────
+
+echo ""
+echo "── PC-2: data-testid ──"
+
+EXPECTED_TESTIDS=$(echo "$ISSUE_BODY" | grep -o 'data-testid="[^"]*"' | sort -u || true)
+EXPECTED_COUNT=$(echo "$EXPECTED_TESTIDS" | grep -c "data-testid" 2>/dev/null || echo "0")
+
+if [ "$EXPECTED_COUNT" -eq 0 ]; then
+  log_skip "2" "Issue não lista data-testid — verificação N/A"
+elif ! $IS_FRONTEND; then
+  log_skip "2" "Issue não é frontend — data-testid N/A"
+else
+  # Check which files the PR touches that are components
+  COMPONENT_FILES=$(echo "$PR_FILES" | grep -E "^client/src/" | grep -v "\.test\." || true)
+  if [ -z "$COMPONENT_FILES" ]; then
+    log_fail "2" "$EXPECTED_COUNT data-testid esperados mas PR não toca componentes"
+  else
+    FOUND=0
+    MISSING=""
+    while IFS= read -r tid; do
+      TID_VALUE=$(echo "$tid" | sed 's/data-testid="//;s/"//')
+      if echo "$COMPONENT_FILES" | xargs grep -q "data-testid=\"$TID_VALUE\"" 2>/dev/null; then
+        FOUND=$((FOUND + 1))
+      else
+        MISSING="$MISSING $TID_VALUE"
+      fi
+    done <<< "$EXPECTED_TESTIDS"
+
+    if [ "$FOUND" -eq "$EXPECTED_COUNT" ]; then
+      log_pass "2" "$FOUND/$EXPECTED_COUNT data-testid presentes"
+    elif [ "$FOUND" -gt 0 ]; then
+      log_warn "2" "$FOUND/$EXPECTED_COUNT data-testid presentes (faltam:$MISSING)"
+    else
+      log_fail "2" "0/$EXPECTED_COUNT data-testid presentes — implementação incompleta"
+    fi
+  fi
+fi
+
+# ─── PC-3: Critérios de Aceite (Bloco 7) ────────────────────────────────────
+
+echo ""
+echo "── PC-3: Critérios de Aceite ──"
+
+BLOCO7=$(echo "$ISSUE_BODY" | sed -n '/## Bloco 7/,/## Bloco 8/p' || true)
+CRITERIA_COUNT=$(echo "$BLOCO7" | grep -c "\- \[" 2>/dev/null || echo "0")
+
+if [ "$CRITERIA_COUNT" -eq 0 ]; then
+  log_skip "3" "Bloco 7 não encontrado ou sem checkboxes"
+else
+  # Check for tsc criterion
+  TSC_OK=false
+  echo "$BLOCO7" | grep -qi "tsc 0" && TSC_OK=true
+
+  if $TSC_OK; then
+    log_pass "3" "$CRITERIA_COUNT critérios no Bloco 7 (tsc coberto pelo CI)"
+  else
+    log_warn "3" "$CRITERIA_COUNT critérios no Bloco 7 — verificar manualmente"
+  fi
+fi
+
+# ─── PC-4: Contrato API ─────────────────────────────────────────────────────
+
+echo ""
+echo "── PC-4: Contrato API ──"
+
+PROCEDURES=$(echo "$ISSUE_BODY" | grep -oE "trpc\.[a-zA-Z0-9]+\.[a-zA-Z0-9]+" | sort -u || true)
+PROC_COUNT=$(echo "$PROCEDURES" | grep -c "trpc\." 2>/dev/null || echo "0")
+
+if [ "$PROC_COUNT" -eq 0 ]; then
+  log_skip "4" "Nenhuma procedure tRPC mencionada na issue"
+elif ! $IS_FRONTEND; then
+  log_skip "4" "Issue não é frontend — integration check N/A"
+else
+  COMPONENT_FILES=$(echo "$PR_FILES" | grep -E "^client/src/" | grep -v "\.test\." || true)
+  if [ -z "$COMPONENT_FILES" ]; then
+    log_warn "4" "$PROC_COUNT procedures esperadas mas PR não toca componentes"
+  else
+    log_warn "4" "$PROC_COUNT procedures mencionadas — verificar integração manualmente"
+  fi
+fi
+
+# ─── PC-5: Tipo PR vs Tipo Issue ────────────────────────────────────────────
+
+echo ""
+echo "── PC-5: Tipo PR vs Tipo Issue ──"
+
+PR_IS_DOCS=false
+PR_IS_DB=false
+PR_IS_FEAT_FE=false
+PR_IS_FEAT_BE=false
+
+[[ "$PR_TITLE" == docs* ]] && PR_IS_DOCS=true
+[[ "$PR_TITLE" == db:* ]] || [[ "$PR_TITLE" == *migration* ]] && PR_IS_DB=true
+echo "$PR_FILES" | grep -q "^client/" && PR_IS_FEAT_FE=true
+echo "$PR_FILES" | grep -q "^server/" && PR_IS_FEAT_BE=true
+
+if $IS_FRONTEND && $PR_IS_DB && ! $PR_IS_FEAT_FE; then
+  log_fail "5" "PR de migration/db fechando issue frontend SEM tocar client/ — BLOQUEADO"
+elif $IS_FRONTEND && $PR_IS_DOCS; then
+  log_fail "5" "PR de docs fechando issue frontend — BLOQUEADO"
+elif $IS_ENGINE && $PR_IS_DOCS; then
+  log_fail "5" "PR de docs fechando issue engine — BLOQUEADO"
+else
+  log_pass "5" "Tipo PR compatível com tipo issue"
+fi
+
+# ─── Resultado ───────────────────────────────────────────────────────────────
+
+echo ""
+echo "═══════════════════════════════════════════════════"
+echo "RESULTADO: $PASS pass · $FAIL fail · $WARN warn"
+echo "═══════════════════════════════════════════════════"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo ""
+  echo "::error::PRE-CLOSE-CHECKLIST FALHOU ($FAIL gate(s))"
+  echo "Remover 'Closes #$ISSUE_NUMBER' do PR body ou corrigir implementação."
+  exit 1
+fi
+
+if [ "$WARN" -gt 0 ]; then
+  echo ""
+  echo "::warning::PRE-CLOSE-CHECKLIST: $WARN aviso(s) — verificar manualmente"
+fi
+
+echo ""
+echo "PRE-CLOSE-CHECKLIST PASSED ✅"


### PR DESCRIPTION
## Summary
- `docs/governance/PRE-CLOSE-CHECKLIST.md` — documentação dos 5 gates
- `scripts/pre-close-check.sh` — script automático de validação
- `validate-pr.yml` — job `pre-close-checklist` no CI
- `CLAUDE.md` — REGRA-ORQ-17 adicionada

## Gates implementados

| Gate | Valida | Bloqueante |
|------|--------|------------|
| PC-1 | PR toca arquivos corretos (label frontend→client/, engine→server/) | SIM |
| PC-2 | data-testid do Bloco 9 presentes no componente | SIM (se 0 encontrados) |
| PC-3 | Critérios do Bloco 7 verificáveis | WARN |
| PC-4 | Procedures do Bloco 5 chamadas | WARN |
| PC-5 | Tipo PR compatível com tipo issue (migration nunca fecha frontend) | SIM |

## Fluxo
```
F6 → PR criado → CI (pre-close-checklist) → Merge → Close
```

## Test plan
- [x] Script valida PRs sem issue vinculada (skip gracioso)
- [x] Skip para docs-only e hotfix
- [x] PC-5 bloquearia PR #639 fechando #614

Closes #643
risk_level: medium

🤖 Generated with [Claude Code](https://claude.com/claude-code)