### PR TITLE
feat(engine): geração automática tarefas LLM [#659]

### DIFF
--- a/server/lib/task-generator-v4.ts
+++ b/server/lib/task-generator-v4.ts
@@ -1,0 +1,106 @@
+// task-generator-v4.ts — Sprint Z-17 #659
+// Gera tarefas via LLM contextualizado para carga inicial dos planos.
+// Padrão: mesmo de ai-helpers.ts generateWithRetry.
+// LLM redige conteúdo contextualizado, engine persiste, advogado revisa.
+// Reversão Z-14: "tarefas manuais" → "carga inicial LLM + revisão humana"
+// Autorização P.O.: 16/04/2026
+
+import { z } from "zod";
+import { generateWithRetry } from "../ai-helpers";
+
+// ─── Types ─────────────────────────────────────────────────────────
+
+export interface TaskGeneratorInput {
+  risco: {
+    titulo: string;
+    categoria: string;
+    artigo: string | null; // null para Onda 1 (Solaris) e Onda 2 (IA Gen)
+    severidade: string;
+    source_priority: string; // cnae | ncm | nbs | solaris | iagen
+  };
+  plano: {
+    titulo: string;
+    responsavel: string;
+    prazo: string; // 30_dias | 60_dias | 90_dias | 180_dias
+  };
+  empresa: {
+    cnpj: string | null;
+    cnaes: string[];
+    porte: string | null; // mei | pequena | media | grande
+    regime_tributario: string | null;
+  };
+}
+
+// ─── Schema Zod para validar resposta do LLM ──────────────────────
+
+const TaskSuggestionSchema = z.object({
+  titulo: z.string().min(3).max(200),
+  descricao: z.string().max(500).default(""),
+  responsavel: z.string().min(1),
+});
+
+const TaskSuggestionsArraySchema = z.array(TaskSuggestionSchema).min(1).max(4);
+
+export type TaskSuggestion = z.infer<typeof TaskSuggestionSchema>;
+
+// ─── Geração via LLM ──────────────────────────────────────────────
+
+export async function generateTaskSuggestions(
+  input: TaskGeneratorInput
+): Promise<TaskSuggestion[]> {
+  const artigoCtx = input.risco.artigo
+    ? `Base legal: ${input.risco.artigo}`
+    : `Fonte: ${input.risco.source_priority} (sem artigo específico — questionário ${
+        input.risco.source_priority === "solaris" ? "SOLARIS" : "IA Gen"
+      })`;
+
+  const empresaCtx =
+    [
+      input.empresa.cnaes.length > 0
+        ? `CNAEs: ${input.empresa.cnaes.join(", ")}`
+        : null,
+      input.empresa.porte ? `Porte: ${input.empresa.porte}` : null,
+      input.empresa.regime_tributario
+        ? `Regime tributário: ${input.empresa.regime_tributario}`
+        : null,
+    ]
+      .filter(Boolean)
+      .join(" · ") || "Perfil da empresa não informado";
+
+  const messages: Array<{ role: "system" | "user"; content: string }> = [
+    {
+      role: "system",
+      content: `Você é um consultor tributário especializado na Reforma Tributária brasileira (LC 214/2025).
+Gere entre 2 e 4 tarefas concretas e executáveis para um plano de ação tributário.
+Cada tarefa deve ser uma ação atômica e indivisível.
+Considere o contexto específico da empresa.
+Retorne APENAS um JSON array com objetos { titulo, descricao, responsavel }.
+- titulo: ação concreta (max 80 chars)
+- descricao: detalhamento da ação (1-2 frases, max 500 chars)
+- responsavel: um de: gestor_fiscal | diretor | ti | juridico | advogado | contador`,
+    },
+    {
+      role: "user",
+      content: `Empresa: ${empresaCtx}
+Risco: "${input.risco.titulo}" (categoria: ${input.risco.categoria}, severidade: ${input.risco.severidade})
+${artigoCtx}
+Plano de ação: "${input.plano.titulo}" (responsável: ${input.plano.responsavel}, prazo: ${input.plano.prazo.replace("_", " ")})
+
+Gere as tarefas:`,
+    },
+  ];
+
+  const result = await generateWithRetry(
+    messages,
+    TaskSuggestionsArraySchema,
+    {
+      context: "TaskGenerator",
+      temperature: 0.3,
+      timeoutMs: 15_000, // 15s por tentativa — pior caso 30s/plano (2 tentativas totais)
+      maxRetries: 2, // 2 tentativas totais (attempt 0 + attempt 1)
+      enableCache: true, // system prompt fixo → cache GPT-4.1 reduz custo ~75%
+    }
+  );
+
+  return result.slice(0, 4);
+}

--- a/server/routers/risks-v4.ts
+++ b/server/routers/risks-v4.ts
@@ -16,6 +16,7 @@ import { router, protectedProcedure } from "../_core/trpc";
 import { computeRiskMatrix, buildActionPlans } from "../lib/risk-engine-v4";
 import { PLANS } from "../lib/action-plan-engine-v4";
 import { calculateComplianceScore } from "../lib/compliance-score-v4";
+import { generateTaskSuggestions } from "../lib/task-generator-v4";
 import type { ScoringDataSnapshot } from "../lib/compliance-score-v4";
 import { getProjectById, updateProject, safeParseJson } from "../db";
 import type { GapRule } from "../lib/risk-engine-v4";
@@ -166,9 +167,101 @@ export const risksV4Router = router({
         planIds.push(id);
       }
 
+      // ─── Sprint Z-17 #659: Gerar tarefas para cada plano via LLM ──────
+      const PRAZO_DAYS: Record<string, number> = {
+        "30_dias": 30, "60_dias": 60, "90_dias": 90, "180_dias": 180,
+      };
+      const CONCURRENCY = 3;
+      const empresaProfile = await getProjectById(projectId);
+      const empresa = {
+        cnpj: (empresaProfile?.companyProfile as any)?.cnpj ?? null,
+        cnaes: (Array.isArray(empresaProfile?.confirmedCnaes)
+          ? empresaProfile.confirmedCnaes.map((c: any) => c.code ?? c)
+          : []) as string[],
+        porte: empresaProfile?.companySize
+          ?? (empresaProfile?.companyProfile as any)?.companySize
+          ?? null,
+        regime_tributario: empresaProfile?.taxRegime
+          ?? (empresaProfile?.companyProfile as any)?.taxRegime
+          ?? null,
+      };
+      const today = new Date();
+      let tasksGenerated = 0;
+
+      for (let batch = 0; batch < planIds.length; batch += CONCURRENCY) {
+        const chunk = planIds.slice(batch, batch + CONCURRENCY);
+        const results = await Promise.allSettled(
+          chunk.map(async (planId, chunkIdx) => {
+            const globalIdx = batch + chunkIdx;
+            const plan = actionPlans[globalIdx];
+            const riskIdx = riskIds.findIndex(
+              (_id, idx) => risks[idx]?.rule_id === plan.riskRuleId
+            );
+            const risk = riskIdx >= 0 ? risks[riskIdx] : null;
+            if (!risk) return;
+
+            const prazoDias = PRAZO_DAYS[plan.prazo] ?? 60;
+            const dataFim = new Date(today);
+            dataFim.setDate(dataFim.getDate() + prazoDias);
+
+            const suggestions = await generateTaskSuggestions({
+              risco: {
+                titulo: risk.titulo,
+                categoria: risk.categoria,
+                artigo: risk.artigo || null,
+                severidade: risk.severidade,
+                source_priority: risk.source_priority,
+              },
+              plano: {
+                titulo: plan.titulo,
+                responsavel: plan.responsavel,
+                prazo: plan.prazo,
+              },
+              empresa,
+            });
+
+            for (let j = 0; j < suggestions.length; j++) {
+              const s = suggestions[j];
+              const taskId = await insertTaskV4({
+                project_id: projectId,
+                action_plan_id: planId,
+                titulo: s.titulo,
+                descricao: s.descricao || null,
+                responsavel: s.responsavel || plan.responsavel,
+                data_inicio: today,
+                data_fim: dataFim,
+                ordem: j,
+                created_by: ctx.user.id,
+              });
+              await insertAuditLog({
+                project_id: projectId,
+                entity: "task",
+                entity_id: taskId,
+                action: "created",
+                user_id: ctx.user.id,
+                user_name: actor.user_name,
+                user_role: actor.user_role,
+                after_state: {
+                  titulo: s.titulo,
+                  action_plan_id: planId,
+                  generated_by: "llm",
+                },
+              });
+              tasksGenerated++;
+            }
+          })
+        );
+        results
+          .filter((r) => r.status === "rejected")
+          .forEach((r) =>
+            console.warn("[TaskGenerator] falha:", (r as PromiseRejectedResult).reason)
+          );
+      }
+
       return {
         risksGenerated: riskIds.length,
         actionPlansGenerated: planIds.length,
+        tasksGenerated,
         riskIds,
         planIds,
         summary,
@@ -784,7 +877,96 @@ export const risksV4Router = router({
         planIds.push(id);
       }
 
-      return { generated: planIds.length, planIds };
+      // ─── Sprint Z-17 #659: Gerar tarefas para planos criados via LLM ──
+      const empresaProfileBulk = await getProjectById(projectId);
+      const empresaBulk = {
+        cnpj: (empresaProfileBulk?.companyProfile as any)?.cnpj ?? null,
+        cnaes: (Array.isArray(empresaProfileBulk?.confirmedCnaes)
+          ? empresaProfileBulk.confirmedCnaes.map((c: any) => c.code ?? c)
+          : []) as string[],
+        porte: empresaProfileBulk?.companySize
+          ?? (empresaProfileBulk?.companyProfile as any)?.companySize
+          ?? null,
+        regime_tributario: empresaProfileBulk?.taxRegime
+          ?? (empresaProfileBulk?.companyProfile as any)?.taxRegime
+          ?? null,
+      };
+      const todayBulk = new Date();
+      const PRAZO_DAYS_BULK: Record<string, number> = {
+        "30_dias": 30, "60_dias": 60, "90_dias": 90, "180_dias": 180,
+      };
+      let tasksGeneratedBulk = 0;
+
+      for (let batch = 0; batch < planIds.length; batch += 3) {
+        const chunk = planIds.slice(batch, batch + 3);
+        const resultsBulk = await Promise.allSettled(
+          chunk.map(async (planId, chunkIdx) => {
+            const globalIdx = batch + chunkIdx;
+            const plan = actionPlans[globalIdx];
+            const risk = risksWithoutPlans.find(
+              (r) => r.rule_id === plan.riskRuleId
+            );
+            if (!risk) return;
+
+            const prazoDias = PRAZO_DAYS_BULK[plan.prazo] ?? 60;
+            const dataFimBulk = new Date(todayBulk);
+            dataFimBulk.setDate(dataFimBulk.getDate() + prazoDias);
+
+            const suggestions = await generateTaskSuggestions({
+              risco: {
+                titulo: risk.titulo,
+                categoria: risk.categoria,
+                artigo: risk.artigo || null,
+                severidade: risk.severidade,
+                source_priority: risk.source_priority,
+              },
+              plano: {
+                titulo: plan.titulo,
+                responsavel: plan.responsavel,
+                prazo: plan.prazo,
+              },
+              empresa: empresaBulk,
+            });
+
+            for (let j = 0; j < suggestions.length; j++) {
+              const s = suggestions[j];
+              const taskId = await insertTaskV4({
+                project_id: projectId,
+                action_plan_id: planId,
+                titulo: s.titulo,
+                descricao: s.descricao || null,
+                responsavel: s.responsavel || plan.responsavel,
+                data_inicio: todayBulk,
+                data_fim: dataFimBulk,
+                ordem: j,
+                created_by: ctx.user.id,
+              });
+              await insertAuditLog({
+                project_id: projectId,
+                entity: "task",
+                entity_id: taskId,
+                action: "created",
+                user_id: ctx.user.id,
+                user_name: actor.user_name,
+                user_role: actor.user_role,
+                after_state: {
+                  titulo: s.titulo,
+                  action_plan_id: planId,
+                  generated_by: "llm",
+                },
+              });
+              tasksGeneratedBulk++;
+            }
+          })
+        );
+        resultsBulk
+          .filter((r) => r.status === "rejected")
+          .forEach((r) =>
+            console.warn("[TaskGenerator:bulk] falha:", (r as PromiseRejectedResult).reason)
+          );
+      }
+
+      return { generated: planIds.length, planIds, tasksGenerated: tasksGeneratedBulk };
     }),
 
   /**


### PR DESCRIPTION
## Escopo de fechamento
- Closes #659 → task-generator-v4.ts (novo) + generateRisks + bulkGenerateActionPlans modificados

## Summary
- Reversão decisão Z-14 — autorização P.O. 16/04/2026
- LLM gera 2-4 tarefas contextualizadas por plano como carga inicial
- generateWithRetry (não invokeLLM direto) com Zod validation
- Promise.allSettled chunks de 3 — LLM falha → plano sem tarefas (pipeline não bloqueia)
- audit_log com generated_by='llm' para rastreabilidade
- cnpj via companyProfile.cnpj (corrigido de campo direto do projeto)

## Test plan
- [x] tsc --noEmit — 0 erros
- [ ] generateRisks → planos com tarefas geradas
- [ ] bulkGenerateActionPlans → planos com tarefas geradas
- [ ] LLM falha → plano sem tarefas, pipeline não bloqueia
- [ ] audit_log entity=task action=created generated_by=llm
- [ ] Aba Histórico mostra entries de criação automática

Closes #659
risk_level: high

PC-1: OK — toca risks-v4.ts + task-generator-v4.ts (novo)
PC-2: N/A — backend puro, sem novos data-testid
PC-3: OK — 21 critérios binários verificáveis
PC-4: OK — generateWithRetry + insertTaskV4 chamados
PC-5: OK — feat(engine) fecha feat(engine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)