### PR TITLE
fix(governance): HANDOFF reversão Z-14

### DIFF
--- a/docs/governance/PROMPT_HANDOFF_ORQUESTRADOR.md
+++ b/docs/governance/PROMPT_HANDOFF_ORQUESTRADOR.md
@@ -162,8 +162,10 @@ Isso significa:
 
   Opportunity: NUNCA gera plano de ação (INV-RD-05).
 
-  Tarefas: SEMPRE manuais.
-  buildTasks() não existe. Decisão Sprint Z-14.
+  Tarefas: carga inicial gerada via LLM
+  (generateTaskSuggestions, Sprint Z-17).
+  Advogado revisa/edita/exclui.
+  Reversão de Z-14 — autorização P.O. 16/04/2026.
 
   Breadcrumb: SEMPRE 4 nós.
   fonte › categoria › artigo › gap. Nunca NULL.
@@ -186,7 +188,7 @@ Isso significa:
 
 1 gap mapeado = 1 risco (nunca N riscos por gap)
 1 risco = N planos de ação (buildActionPlans catálogo)
-1 plano = N tarefas (sempre manuais)
+1 plano = N tarefas (carga inicial via LLM, Sprint Z-17)
 
 Oportunidade: entra na matriz, nunca gera plano.
 ```
@@ -226,7 +228,7 @@ Se você fizer qualquer uma destas ações, PARE:
 ❌ Ignorar o Gate 0 (banco + código real)
 ❌ Inventar campos de banco sem confirmar via Gate 0
 ❌ Usar risk_level em português no PR body
-❌ Implementar buildTasks() (não existe, não vai existir)
+❌ Implementar buildTasks() — substituído por generateTaskSuggestions (Sprint Z-17, Refs #659)
 ❌ Gerar plano para opportunity
 ❌ Usar risk_categories.label (campo real é .nome)
 ❌ Usar prazo como Date (é ENUM string: 30_dias etc)


### PR DESCRIPTION
risk_level: low · Refs #659

## Mudanças
Atualiza `docs/governance/PROMPT_HANDOFF_ORQUESTRADOR.md` com a reversão da decisão Z-14 sobre tarefas.

### 3 substituições aplicadas
1. **Contrato de Confiabilidade (linha 165–168):** `Tarefas: SEMPRE manuais` → `carga inicial gerada via LLM (generateTaskSuggestions, Sprint Z-17)`
2. **Cardinalidade (linha 191):** `1 plano = N tarefas (sempre manuais)` → `(carga inicial via LLM, Sprint Z-17)`
3. **Sinais de Alerta (linha 231):** `buildTasks() não existe, não vai existir` → `substituído por generateTaskSuggestions (Sprint Z-17, Refs #659)`

### Motivação
Reversão da decisão Sprint Z-14 — autorização P.O. Uires Tapajós em 16/04/2026.
Issue de implementação: #659