### PR TITLE
fix(engine): observabilidade TaskGenerator + timeout 45s

### DIFF
--- a/server/lib/task-generator-v4.ts
+++ b/server/lib/task-generator-v4.ts
@@ -96,7 +96,7 @@ Gere as tarefas:`,
     {
       context: "TaskGenerator",
       temperature: 0.3,
-      timeoutMs: 15_000, // 15s por tentativa — pior caso 30s/plano (2 tentativas totais)
+      timeoutMs: 45_000, // 45s por tentativa — pior caso 90s/plano (2 tentativas totais)
       maxRetries: 2, // 2 tentativas totais (attempt 0 + attempt 1)
       enableCache: true, // system prompt fixo → cache GPT-4.1 reduz custo ~75%
     }

--- a/server/routers/risks-v4.ts
+++ b/server/routers/risks-v4.ts
@@ -251,11 +251,22 @@ export const risksV4Router = router({
             }
           })
         );
-        results
-          .filter((r) => r.status === "rejected")
-          .forEach((r) =>
-            console.warn("[TaskGenerator] falha:", (r as PromiseRejectedResult).reason)
-          );
+        for (const r of results) {
+          if (r.status === "rejected") {
+            const errMsg = r.reason instanceof Error ? r.reason.message : String(r.reason);
+            console.error("[TaskGenerator] falha:", errMsg);
+            await insertAuditLog({
+              project_id: projectId,
+              entity: "task",
+              entity_id: "llm_error",
+              action: "created",
+              user_id: ctx.user.id,
+              user_name: actor.user_name,
+              user_role: actor.user_role,
+              after_state: { error: errMsg, generated_by: "llm", step: "generateRisks" },
+            });
+          }
+        }
       }
 
       return {
@@ -959,11 +970,22 @@ export const risksV4Router = router({
             }
           })
         );
-        resultsBulk
-          .filter((r) => r.status === "rejected")
-          .forEach((r) =>
-            console.warn("[TaskGenerator:bulk] falha:", (r as PromiseRejectedResult).reason)
-          );
+        for (const r of resultsBulk) {
+          if (r.status === "rejected") {
+            const errMsg = r.reason instanceof Error ? r.reason.message : String(r.reason);
+            console.error("[TaskGenerator:bulk] falha:", errMsg);
+            await insertAuditLog({
+              project_id: projectId,
+              entity: "task",
+              entity_id: "llm_error",
+              action: "created",
+              user_id: ctx.user.id,
+              user_name: actor.user_name,
+              user_role: actor.user_role,
+              after_state: { error: errMsg, generated_by: "llm", step: "bulkGenerateActionPlans" },
+            });
+          }
+        }
       }
 
       return { generated: planIds.length, planIds, tasksGenerated: tasksGeneratedBulk };


### PR DESCRIPTION
## Escopo de fechamento
- Refs #659 → fix de observabilidade (não fecha issue nova)

## Summary
- Timeout LLM: 15s → 45s por tentativa
- console.warn → insertAuditLog com mensagem de erro
- Erros visíveis na aba Histórico (entity=task, entity_id=llm_error)
- Causa raiz: projeto 780192 com 8 planos e 0 tarefas — LLM falhou silenciosamente

## Test plan
- [x] tsc --noEmit — 0 erros
- [ ] Re-gerar riscos → se LLM falhar, audit_log mostra erro
- [ ] Se LLM funcionar → tarefas geradas normalmente

risk_level: medium

🤖 Generated with [Claude Code](https://claude.com/claude-code)