### PR TITLE
[HOTFIX] fix(consolidacao): crash na página ConsolidacaoV4

### DIFF
--- a/client/src/pages/ConsolidacaoV4.tsx
+++ b/client/src/pages/ConsolidacaoV4.tsx
@@ -5,7 +5,7 @@
  * Leitura defensiva: data_fim ?? '—'
  */
 
-import { useMemo } from "react";
+import { useMemo, useEffect } from "react";
 import { useRoute, Link } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -117,13 +117,13 @@ export default function ConsolidacaoV4() {
     [allPlans]
   );
 
-  // Calculate score on mount
+  // Calculate score on mount — useEffect (não useMemo) para side effects
   const score = scoreMutation.data;
-  useMemo(() => {
+  useEffect(() => {
     if (projectId && !scoreMutation.data && !scoreMutation.isPending) {
       scoreMutation.mutate({ projectId });
     }
-  }, [projectId]);
+  }, [projectId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const nivel = score?.nivel ?? "baixo";
   const nivelColors = NIVEL_COLORS[nivel] ?? NIVEL_COLORS.baixo;


### PR DESCRIPTION
## Escopo
- Refs ConsolidacaoV4.tsx — crash "Algo deu errado" ao abrir /consolidacao-v4

## Causa raiz
`useMemo` com `scoreMutation.mutate()` (side effect) — anti-pattern React.
React 18 Strict Mode executa useMemo 2x → mutation dupla → crash.

## Fix
`useMemo` → `useEffect` (2 linhas)

## Test plan
- [x] tsc --noEmit — 0 erros
- [ ] Abrir /consolidacao-v4 → página carrega sem erro

risk_level: medium

🤖 Generated with [Claude Code](https://claude.com/claude-code)