### PR TITLE
[HOTFIX] fix(consolidacao): crash Date object em tarefas

### DIFF
--- a/client/src/pages/ConsolidacaoV4.tsx
+++ b/client/src/pages/ConsolidacaoV4.tsx
@@ -367,7 +367,11 @@ export default function ConsolidacaoV4() {
                         }`} />
                         <span className="truncate">{task.titulo}</span>
                         <span className="text-muted-foreground ml-auto shrink-0">
-                          {task.data_fim ?? "—"}
+                          {task.data_fim
+                            ? (task.data_fim instanceof Date
+                                ? task.data_fim.toLocaleDateString("pt-BR")
+                                : String(task.data_fim).slice(0, 10))
+                            : "—"}
                         </span>
                       </div>
                     ))}


### PR DESCRIPTION
## Causa raiz
task.data_fim é Date object (do banco). React crash: "Objects are not valid as a React child".

## Fix
Date → toLocaleDateString("pt-BR"), string → slice(0,10), null → "—"

risk_level: low

🤖 Generated with [Claude Code](https://claude.com/claude-code)