### PR TITLE
fix(layout): setShowTour → useEffect — causa raiz do crash ConsolidacaoV4

### DIFF
--- a/client/src/components/ComplianceLayout.tsx
+++ b/client/src/components/ComplianceLayout.tsx
@@ -18,7 +18,7 @@ import {
   Database,
   Upload,
 } from "lucide-react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link, useLocation } from "wouter";
 import { trpc } from "@/lib/trpc";
 import { ROLES } from "@shared/translations";
@@ -59,9 +59,12 @@ export default function ComplianceLayout({ children }: ComplianceLayoutProps) {
 
   // Disparar tour automaticamente no primeiro login
   // (shouldShowTour só é true quando isNew === true)
-  if (!tourLoading && shouldShowTour && !showTour) {
-    setShowTour(true);
-  }
+  // Fix: useEffect evita setState durante render — causa do crash ErrorBoundary
+  useEffect(() => {
+    if (!tourLoading && shouldShowTour && !showTour) {
+      setShowTour(true);
+    }
+  }, [tourLoading, shouldShowTour, showTour]);
 
   if (loading) {
     return (


### PR DESCRIPTION
## Causa raiz

`setShowTour(true)` era chamado diretamente no corpo do `ComplianceLayout` (fase de render), violando a regra do React de não chamar `setState` durante render.

React 18 Strict Mode executa o render 2x → loop infinito → `ErrorBoundary` captura → "Algo deu errado".

## Fix

Movido para `useEffect` com deps `[tourLoading, shouldShowTour, showTour]`.

## Evidência

- PR #682 (useMemo→useEffect) e PR #683 (Date render) corrigiram anti-patterns reais mas não eram a causa do crash.
- Este fix resolve o crash observado em `/projetos/930133/consolidacao-v4`.

```json
{"risk_level": "low", "scope": "client/src/components/ComplianceLayout.tsx", "lines_changed": 5}
```