### PR TITLE
fix(action-plan): invalidar audit log cache + safeStr Date

### DIFF
--- a/client/src/pages/ActionPlanPage.tsx
+++ b/client/src/pages/ActionPlanPage.tsx
@@ -447,6 +447,7 @@ function ActionPlanCard({ plan, canApprove, onApprove, onDelete, onEdit }: Actio
   const deleteTaskMutation = trpc.risksV4.deleteTask.useMutation({
     onSuccess: () => {
       utils.risksV4.listRisks.invalidate({ projectId: plan.project_id });
+      utils.risksV4.getProjectAuditLog.invalidate({ projectId: plan.project_id });
       toast.success("Tarefa excluída");
     },
     onError: (err) => toast.error("Erro ao excluir tarefa", { description: err.message }),
@@ -460,6 +461,7 @@ function ActionPlanCard({ plan, canApprove, onApprove, onDelete, onEdit }: Actio
   const saveTaskEditMutation = trpc.risksV4.upsertTask.useMutation({
     onSuccess: () => {
       utils.risksV4.listRisks.invalidate({ projectId: plan.project_id });
+      utils.risksV4.getProjectAuditLog.invalidate({ projectId: plan.project_id });
       const wasCreate = taskModalMode === "create";
       closeTaskModal();
       toast.success(wasCreate ? "Tarefa criada" : "Tarefa atualizada");
@@ -833,6 +835,7 @@ export default function ActionPlanPage() {
   const approvePlanMutation = trpc.risksV4.approveActionPlan.useMutation({
     onSuccess: () => {
       utils.risksV4.listRisks.invalidate({ projectId });
+      utils.risksV4.getProjectAuditLog.invalidate({ projectId });
       toast.success("Plano aprovado com sucesso");
     },
     onError: (err) => toast.error("Erro ao aprovar plano", { description: err.message }),
@@ -875,6 +878,7 @@ export default function ActionPlanPage() {
   const deletePlanMutation = trpc.risksV4.deleteActionPlan.useMutation({
     onSuccess: () => {
       utils.risksV4.listRisks.invalidate({ projectId });
+      utils.risksV4.getProjectAuditLog.invalidate({ projectId });
       toast("Plano excluído", { description: "Movido para o histórico." });
     },
     onError: (err) => toast.error("Erro ao excluir plano", { description: err.message }),

--- a/client/src/pages/ConsolidacaoV4.tsx
+++ b/client/src/pages/ConsolidacaoV4.tsx
@@ -27,6 +27,16 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Converte qualquer valor para string segura para JSX (previne React error #31) */
+function safeStr(val: unknown): string {
+  if (val === null || val === undefined) return "—";
+  if (val instanceof Date) return val.toLocaleDateString("pt-BR");
+  if (typeof val === "object") return JSON.stringify(val);
+  return String(val);
+}
+
 // ─── Constants ──────────────────────────────────────────────────────────────
 
 const DISCLAIMER = `AVISO LEGAL: Este diagnóstico é uma ferramenta de apoio à decisão tributária elaborada com base nas informações fornecidas pela empresa. Os resultados apresentados — incluindo a identificação de riscos, oportunidades e planos de ação — NÃO constituem parecer jurídico. Toda classificação e recomendação deve ser validada por advogado tributarista ou contador habilitado antes de qualquer ação fiscal, contábil ou de compliance. A severidade dos riscos é determinística (baseada em tabelas normativas), mas a aplicabilidade ao caso concreto depende de análise humana qualificada. IA SOLARIS não se responsabiliza por decisões tomadas sem a devida validação profissional.`;
@@ -329,7 +339,7 @@ export default function ConsolidacaoV4() {
               {deletedRisks.map((r: any) => (
                 <div key={r.id} data-testid="risco-desconsiderado-row" className="flex items-center gap-2 text-xs text-muted-foreground border-b last:border-0 py-1.5">
                   <span className="truncate">{r.titulo}</span>
-                  <span className="ml-auto shrink-0 italic">{r.deleted_reason ?? "—"}</span>
+                  <span className="ml-auto shrink-0 italic">{safeStr(r.deleted_reason)}</span>
                 </div>
               ))}
             </CardContent>
@@ -367,11 +377,7 @@ export default function ConsolidacaoV4() {
                         }`} />
                         <span className="truncate">{task.titulo}</span>
                         <span className="text-muted-foreground ml-auto shrink-0">
-                          {task.data_fim
-                            ? (task.data_fim instanceof Date
-                                ? task.data_fim.toLocaleDateString("pt-BR")
-                                : String(task.data_fim).slice(0, 10))
-                            : "—"}
+                          {safeStr(task.data_fim)}
                         </span>
                       </div>
                     ))}


### PR DESCRIPTION
## Summary
- getProjectAuditLog.invalidate adicionado em 4 mutations
- safeStr helper para prevenir React error #31 (Date objects)
- Aba Histórico atualiza em tempo real após CRUD de tarefas/planos

## Test plan
- [x] tsc --noEmit — 0 erros
- [ ] Criar tarefa → aba Histórico mostra entry "created"
- [ ] Editar tarefa → aba Histórico mostra entry "updated"
- [ ] Excluir tarefa → aba Histórico mostra entry "deleted"

risk_level: low

🤖 Generated with [Claude Code](https://claude.com/claude-code)