### PR TITLE
[HOTFIX] fix(audit): LIMIT TiDB — aba Histórico vazia

### DIFF
--- a/server/lib/db-queries-risks-v4.ts
+++ b/server/lib/db-queries-risks-v4.ts
@@ -606,12 +606,15 @@ export async function getProjectAuditLog(
   projectId: number,
   limit = 100
 ): Promise<AuditLogRow[]> {
+  // TiDB: LIMIT ? via mysql2 execute() lança ER_WRONG_ARGUMENTS
+  // Fix: interpolar safeLimit (já clamped 1-500 pelo zod no router)
+  const safeLimit = Math.max(1, Math.min(500, Math.floor(limit)));
   return query<AuditLogRow>(
     `SELECT * FROM audit_log
      WHERE project_id = ?
      ORDER BY created_at DESC
-     LIMIT ?`,
-    [projectId, limit]
+     LIMIT ${safeLimit}`,
+    [projectId]
   );
 }
 


### PR DESCRIPTION
## Causa raiz
TiDB/mysql2: LIMIT ? lança ER_WRONG_ARGUMENTS silenciosamente.
getProjectAuditLog retornava [] apesar de 10+ rows no banco.

## Fix
1 arquivo, 1 mudança: LIMIT ? → LIMIT ${safeLimit} (clamped 1-500)

## Nota
PR #687 do Manus tinha o mesmo fix mas com 72 arquivos. Este PR é limpo (1 arquivo).

risk_level: low

🤖 Generated with [Claude Code](https://claude.com/claude-code)