### PR TITLE
chore: ignorar artefatos playwright do git [Sprint Z-18]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,7 @@ Fluxo_MVP_Compliance_Tributaria.png
 
 # Drizzle meta snapshots antigos (apenas os mais recentes sao necessarios)
 drizzle/meta/*_snapshot.json
+
+playwright-report/
+test-results/
+playwright-results.json


### PR DESCRIPTION
## Problema
Artefatos do Playwright (`playwright-report/`, `test-results/`, `playwright-results.json`) foram adicionados ao git staging e bloqueavam o `webdev_save_checkpoint`.

## Fix
- `git rm --cached` para remover do tracking
- Adicionado ao `.gitignore`

## Evidência
```json
{"pr": 699, "tipo": "chore", "risco": "baixo", "e2e": "N/A"}
```