### PR TITLE
feat(consolidacao): integração botão PDF [#701]

### DIFF
--- a/client/src/pages/ConsolidacaoV4.tsx
+++ b/client/src/pages/ConsolidacaoV4.tsx
@@ -8,6 +8,7 @@
 import { useMemo, useEffect } from "react";
 import { useRoute, Link } from "wouter";
 import { trpc } from "@/lib/trpc";
+import { generateDiagnosticoPDF } from "@/lib/generateDiagnosticoPDF";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -450,7 +451,44 @@ export default function ConsolidacaoV4() {
             data-testid="btn-download-pdf"
             variant="outline"
             size="sm"
-            onClick={() => toast.info("PDF será implementado na issue #626")}
+            onClick={() => {
+              generateDiagnosticoPDF({
+                cnpj: undefined,
+                score: score?.score ?? 0,
+                nivel: score?.nivel ?? "baixo",
+                totalAlta: score?.total_alta ?? 0,
+                totalMedia: score?.total_media ?? 0,
+                risks: approvedRisks.map((r: any) => ({
+                  titulo: r.titulo,
+                  categoria: r.categoria,
+                  severidade: r.severidade,
+                  artigo: r.artigo || "",
+                  source_priority: r.source_priority,
+                  rag_validated: r.rag_validated,
+                })),
+                opportunities: opportunities.map((o: any) => ({
+                  titulo: o.titulo,
+                  categoria: o.categoria,
+                  artigo: o.artigo || "",
+                })),
+                plans: approvedPlans.map((p: any) => ({
+                  titulo: p.titulo,
+                  responsavel: p.responsavel,
+                  prazo: p.prazo,
+                  status: p.status,
+                  tasks: p.tasks?.map((t: any) => ({
+                    titulo: t.titulo,
+                    status: t.status,
+                    data_fim: t.data_fim
+                      ? (t.data_fim instanceof Date
+                          ? t.data_fim.toLocaleDateString("pt-BR")
+                          : String(t.data_fim).slice(0, 10))
+                      : null,
+                  })),
+                })),
+              });
+              toast.success("PDF gerado com sucesso");
+            }}
           >
             <Download className="h-3.5 w-3.5 mr-1.5" />
             Baixar diagnóstico (PDF)

--- a/tests/e2e/pdf-consolidacao.spec.ts
+++ b/tests/e2e/pdf-consolidacao.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * PDF Diagnóstico ConsolidacaoV4 E2E — Sprint Z-18 #701
+ * Valida que botão PDF gera download (não placeholder)
+ */
+import { test, expect } from "@playwright/test";
+import { loginViaTestEndpoint } from "./fixtures/auth";
+
+const PROJECT_ID = process.env.E2E_PROJECT_ID || "930001";
+
+test.describe("PDF Diagnóstico ConsolidacaoV4", () => {
+  test.beforeEach(async ({ page }) => {
+    let lastErr: Error | null = null;
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      try {
+        await loginViaTestEndpoint(page);
+        return;
+      } catch (err) {
+        lastErr = err as Error;
+        if (attempt < 3) await new Promise((r) => setTimeout(r, 3000 * attempt));
+      }
+    }
+    throw lastErr;
+  });
+
+  test("CT-01 — botão PDF visível na ConsolidacaoV4", async ({ page }) => {
+    test.setTimeout(60_000);
+    await page.goto(`/projetos/${PROJECT_ID}/consolidacao-v4`);
+    await page.waitForLoadState("networkidle");
+    await page.waitForTimeout(5000);
+
+    const btn = page.locator('[data-testid="btn-download-pdf"]');
+    await expect(btn).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("CT-02 — clicar PDF não mostra toast placeholder", async ({ page }) => {
+    test.setTimeout(60_000);
+    await page.goto(`/projetos/${PROJECT_ID}/consolidacao-v4`);
+    await page.waitForLoadState("networkidle");
+    await page.waitForTimeout(5000);
+
+    await page.click('[data-testid="btn-download-pdf"]');
+    await page.waitForTimeout(2000);
+
+    const bodyText = await page.textContent("body") ?? "";
+    expect(bodyText).not.toContain("PDF será implementado");
+  });
+
+  test("CT-03 — toast sucesso após clique no PDF", async ({ page }) => {
+    test.setTimeout(60_000);
+    await page.goto(`/projetos/${PROJECT_ID}/consolidacao-v4`);
+    await page.waitForLoadState("networkidle");
+    await page.waitForTimeout(5000);
+
+    await page.click('[data-testid="btn-download-pdf"]');
+
+    // Toast "PDF gerado com sucesso" deve aparecer
+    await expect(
+      page.locator('text="PDF gerado com sucesso"')
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("CT-04 — placeholder removido do código", async ({ page }) => {
+    test.setTimeout(30_000);
+    // Verificar via conteúdo da página (não do bundle)
+    await page.goto(`/projetos/${PROJECT_ID}/consolidacao-v4`);
+    await page.waitForLoadState("networkidle");
+    await page.waitForTimeout(3000);
+
+    const bodyText = await page.textContent("body") ?? "";
+    expect(bodyText).not.toContain("PDF será implementado");
+  });
+});


### PR DESCRIPTION
## Escopo de fechamento
- Closes #701 → ConsolidacaoV4.tsx (1 import + 1 onClick)

## Summary
- Remove toast placeholder "PDF será implementado"
- Conecta generateDiagnosticoPDF com dados da tela
- cnpj: undefined (Opção A aprovada)
- Suite E2E: 4 CTs pdf-consolidacao

## Test plan
- [x] tsc --noEmit — 0 erros
- [x] toast placeholder removido
- [x] generateDiagnosticoPDF importado + chamado
- [ ] E2E 4/4 PASS

Closes #701
risk_level: low

🤖 Generated with [Claude Code](https://claude.com/claude-code)