### PR TITLE
docs(governance): snapshot Matriz de Riscos v4 + inventário [Z-19]

### DIFF
--- a/docs/governance/MATRIZ_RISCOS_SNAPSHOT_2026-04-18.md
+++ b/docs/governance/MATRIZ_RISCOS_SNAPSHOT_2026-04-18.md
@@ -1414,7 +1414,215 @@ Antes da próxima iteração, o P.O. precisa decidir:
 
 ---
 
+## 25. Fluxos visuais (Mermaid)
+
+### 25.1 Fluxo E2E — do perfil ao PDF entregue ao cliente
+
+```mermaid
+flowchart TD
+    Start([Advogado acessa<br/>plataforma]) --> S1
+
+    subgraph PERF["Steps 1-3 · Perfil da Empresa"]
+        S1[Cadastro: CNPJ, CNAEs,<br/>regime, porte] --> S2[5 JSONs de perfil<br/>operationProfile, taxComplexity,<br/>financialProfile, governanceProfile]
+        S2 --> CPIE{{"CPIE v1/v2 analyze<br/>profileScore 0-100<br/>(Score A/B)"}}
+    end
+
+    CPIE --> QSTART
+
+    subgraph QUEST["Steps 1-3 · Questionários das 3 Ondas"]
+        QSTART[Ondas em paralelo/sequência] --> Q1[Onda 1 SOLARIS<br/>22 perguntas curadas<br/>classification_scope='risk_engine']
+        QSTART --> Q2[Onda 2 IA GEN<br/>perguntas dinâmicas<br/>temperature=0.1]
+        QSTART --> Q3[Onda 3 NCM/NBS/CNAE<br/>QC + QO + QCNAE]
+    end
+
+    Q1 --> GAPPIPE
+    Q2 --> GAPPIPE
+    Q3 --> GAPPIPE
+
+    subgraph GAP["Step 4 · Gap Engine + Briefing"]
+        GAPPIPE[analyzeGapsFromQuestionnaires<br/>+ analyzeGaps legado] --> GAPS[("project_gaps_v3")]
+        GAPS --> BR[generateBriefing<br/>LLM + RAG]
+        BR --> BRAPR{{Advogado<br/>aprova briefing?}}
+    end
+
+    BRAPR -->|Não| S2
+    BRAPR -->|Sim| GENR
+
+    subgraph MATRIZ["Step 5 · Matriz de Riscos (auto-gen)"]
+        GENR[generateRisksV4Pipeline<br/>automático no mount] --> PL[consolidateRisks → inferNormativeRisks → merge → enrichRiskWithRag]
+        PL --> RV4[("risks_v4<br/>status=active<br/>approved_at=NULL")]
+        RV4 --> RAPPR{{Advogado aprova<br/>ou exclui riscos}}
+        RAPPR -->|approveRisk| RAPR[approved_at=NOW]
+        RAPPR -->|deleteRisk<br/>motivo ≥ 10 chars| RDEL[status=deleted<br/>cascata planos+tarefas]
+    end
+
+    RAPR --> STEP6
+    RDEL -.-> STEP6
+
+    subgraph PLAN["Step 6 · Planos de Ação"]
+        STEP6[buildActionPlans<br/>RN-RISK-05: opportunity → sem plano] --> AP[("action_plans<br/>status=rascunho<br/>tarefas BLOQUEADAS")]
+        AP --> TGEN[Tarefas LLM<br/>concorrência=3<br/>falha não bloqueia]
+        TGEN --> TASKS[("tasks<br/>status=todo")]
+        TASKS --> PAPR{{Advogado<br/>aprova plano?}}
+        PAPR -->|Sim| PLIB[status=aprovado<br/>tarefas LIBERADAS]
+    end
+
+    PLIB --> STEP7
+
+    subgraph CONS["Step 7 · Consolidação"]
+        STEP7[ConsolidacaoV4<br/>useEffect no mount] --> CS[calculateComplianceScore<br/>Score D — determinístico]
+        CS --> SNAP[("projects.scoringData<br/>snapshots acumulados<br/>formula_version=v4.0")]
+        SNAP --> PDF[generateDiagnosticoPDF<br/>jsPDF + autoTable<br/>browser-side]
+    end
+
+    PDF --> END([Cliente recebe<br/>diagnostico-CNPJ-YYYY-MM-DD.pdf<br/>com disclaimer jurídico])
+
+    AUDIT[(audit_log<br/>entity/action/before/after/reason<br/>imutável)]
+    RAPR -.->|approved| AUDIT
+    RDEL -.->|deleted| AUDIT
+    PLIB -.->|approved| AUDIT
+    TGEN -.->|created| AUDIT
+
+    style CPIE fill:#fff3cd,stroke:#856404
+    style RV4 fill:#f8d7da,stroke:#721c24
+    style CS fill:#d4edda,stroke:#155724
+    style SNAP fill:#d4edda,stroke:#155724
+    style AUDIT fill:#e2e3e5,stroke:#383d41
+```
+
+**Leitura do fluxo:**
+
+- **Amarelo (CPIE):** score de perfil — débito ADR-0023, pode estar zerado em projetos v4.
+- **Vermelho (risks_v4):** entidade central — criada com `approved_at=NULL` e aprovada pelo advogado.
+- **Verde (Score D / snapshot):** fórmula determinística, persistido em `projects.scoringData`.
+- **Cinza (audit_log):** toda mutação gera entrada — imutável, base para auditoria fiscal.
+- **Decisões (losangos):** pontos de controle humano — 3 aprovações obrigatórias (briefing, cada risco, cada plano).
+
+---
+
+### 25.2 Origem dos dados → riscos (fluxo de rastreabilidade)
+
+```mermaid
+flowchart LR
+    subgraph ONDAS["3 Ondas de Origem"]
+        O1["Onda 1 — SOLARIS<br/>SOURCE_RANK=4<br/>confidence=1.0 fixo"]
+        O2["Onda 2 — IA GEN<br/>SOURCE_RANK=5<br/>confidence ~0.7"]
+        O3A["Onda 3A — RAG Normativo<br/>cnae=1 · ncm=2 · nbs=3"]
+        O3B["Onda 3B — Inferência Normativa<br/>aditiva, sem questionário"]
+    end
+
+    subgraph TABELAS["Tabelas de entrada"]
+        SA[("solaris_answers<br/>JOIN solaris_questions<br/>WHERE classification_scope='risk_engine'<br/>AND risk_category_code IS NOT NULL")]
+        IA[("iagen_answers<br/>WHERE risk_category_code IS NOT NULL")]
+        REQ[("regulatory_requirements_v3<br/>138 requisitos normativos")]
+        NPR[("normative_product_rules<br/>migration 0076")]
+        PROF[("projects:<br/>companyProfile · operationProfile<br/>+ NCMs + CNAEs")]
+    end
+
+    O1 --> SA
+    O2 --> IA
+    O3A --> REQ
+    O3B --> NPR
+    O3B --> PROF
+
+    subgraph ANALISE["Análise de Gaps"]
+        AGQ["analyzeGapsFromQuestionnaires<br/>Z-11<br/>classify pessimista:<br/>nao_atendido ganha"]
+        AGL["analyzeGaps legado<br/>Onda 3A"]
+    end
+
+    SA --> AGQ
+    IA --> AGQ
+    REQ --> AGL
+
+    subgraph ACL["ACL - Gap to Rule Mapper"]
+        ACLRULES["gap-to-rule-mapper<br/>status:<br/>• mapped (1 match) → gera<br/>• ambiguous (2+) → reviewQueue<br/>• unmapped (0) → descarta"]
+    end
+
+    AGQ --> PG
+    AGL --> PG
+    PG[("project_gaps_v3")]
+    PG --> ACLRULES
+
+    subgraph PIPELINE["generate-risks-pipeline.ts (Z-13.5)"]
+        PEX[extractProjectProfile]
+        CR["consolidateRisks<br/>agrupa por risk_key:<br/>categoria :: op :: multi|mono<br/>RN-RISK-04: 1 categoria = 1 risco"]
+        NI["inferNormativeRisks<br/>Onda 3B<br/>sem gap → risco direto"]
+        MG["mergeByRiskKey<br/>dedup — último vence"]
+        ERG["enrichAllWithRag<br/>timeout 3s"]
+    end
+
+    PROF --> PEX
+    ACLRULES --> CR
+    PEX --> CR
+    PEX --> NI
+    NPR --> NI
+    CR --> MG
+    NI --> MG
+    MG --> ERG
+
+    subgraph CATALOGOS["Catálogos (precedência)"]
+        RC[("risk_categories - DB<br/>10 rows<br/>N1: autoritativo")]
+        ST["SEVERITY_TABLE código<br/>N2: fallback<br/>10 categorias"]
+        TT["TITULO_TEMPLATES<br/>{op} := tipoOperacao ?? 'geral'"]
+        RAG_Q["RAG_QUERIES<br/>ragDocuments — 2515 chunks"]
+    end
+
+    RC -.severidade<br/>urgencia<br/>tipo<br/>artigo.-> CR
+    ST -.fallback.-> CR
+    TT -.titulo.-> CR
+    RAG_Q -.LIKE match.-> ERG
+
+    subgraph DESTINO["Persistência Final"]
+        RISKS[("risks_v4<br/>• breadcrumb: 4 nós<br/>• evidence: SOURCE_RANK ordenada<br/>• rag_validated: 1 se hit else 0<br/>• confidence: blend ou penalidade 0.75<br/>• status=active, approved_at=NULL<br/>• risk_key (dedup)")]
+    end
+
+    ERG --> RISKS
+
+    subgraph INVARIANTES["Invariantes garantidos"]
+        INV1["RN-RISK-01: artigo nunca NULL"]
+        INV2["RN-RISK-02: severidade nunca LLM"]
+        INV3["RN-RISK-04: 1 risco por categoria"]
+        INV5["RN-RISK-09: evidence ordenada SOURCE_RANK"]
+        DEC05["DEC-05: nunca repetir risco entre categorias"]
+    end
+
+    RISKS -.valida.-> INV1
+    RISKS -.valida.-> INV2
+    RISKS -.valida.-> INV3
+    RISKS -.valida.-> INV5
+    RISKS -.valida.-> DEC05
+
+    style O1 fill:#c3e6cb
+    style O2 fill:#fff3cd
+    style O3A fill:#bee5eb
+    style O3B fill:#bee5eb
+    style RC fill:#d1ecf1,stroke:#0c5460,stroke-width:3px
+    style RISKS fill:#f8d7da,stroke:#721c24,stroke-width:3px
+    style ACLRULES fill:#fce4ec
+```
+
+**Leitura do fluxo:**
+
+- **Verde (Onda 1 SOLARIS):** fonte humana curada pela equipe jurídica — maior confiança (1.0). SOURCE_RANK=4.
+- **Amarelo (Onda 2 IA GEN):** perguntas geradas dinamicamente pela IA — confidence variável (~0.7). SOURCE_RANK=5.
+- **Azul (Onda 3A/3B):** fontes normativas — menor rank = maior prioridade (cnae=1 é a mais confiável).
+- **Rosa (ACL):** gatekeeper — descarta gaps ambíguos/unmapped. Um gap só vira risco se tiver exatamente 1 match.
+- **Azul escuro (risk_categories):** autoritativo em runtime. Fallback SEVERITY_TABLE é só para casos de falha do DB.
+- **Vermelho (risks_v4):** destino final — todos os riscos carregam rastreabilidade completa até a fonte.
+- **Linhas tracejadas:** relações de validação/fornecimento de metadados (não fluxo de dados principal).
+
+**Rastreabilidade reversa (top → bottom):**
+
+Dado um `risks_v4.id`, é possível reconstruir a cadeia:
+1. `breadcrumb[0]` → fonte (cnae/ncm/nbs/solaris/iagen)
+2. `evidence[0].ruleId` → gap em `project_gaps_v3`
+3. `project_gaps_v3.source_type` → tabela original (`solaris_answers` / `iagen_answers` / `regulatory_requirements_v3`)
+4. JOIN com `risk_category_code` → pergunta que gerou a resposta
+5. `answer_value` → resposta do advogado/IA
+
+---
+
 *IA SOLARIS · Snapshot de Matriz de Riscos · 2026-04-18*
 *Documento imutável — novas versões geram novo arquivo datado*
-*Baseline + Inventário consolidado (24 seções · ~1400 linhas)*
+*Baseline + Inventário + Fluxos consolidados (25 seções · ~1600 linhas)*
 *Status: aguardando aprovação P.O. para liberar suite de testes*

--- a/docs/governance/MATRIZ_RISCOS_SNAPSHOT_2026-04-18.md
+++ b/docs/governance/MATRIZ_RISCOS_SNAPSHOT_2026-04-18.md
@@ -1,0 +1,1420 @@
+# MATRIZ DE RISCOS — SNAPSHOT DE EXPLORAÇÃO
+## IA SOLARIS · Compliance Tributário v2
+## Data: 2026-04-18 · HEAD: 3afc592 · Sprint: Z-19
+
+---
+
+## 0. Propósito
+
+Baseline consolidado do estado atual da matriz de riscos, antes de
+produzir a suite de testes de aferição "planejado x realizado".
+Este documento existe porque:
+- 3 fontes (DB, código, RN doc) divergem entre si
+- UAT Gate E (2026-04-11) registrou 21 bugs catalogados
+- O P.O. identificou suspeita de geração incorreta
+- Precisamos de uma foto para saber o que testar
+
+**Este documento é imutável após aprovação do P.O.** Mudanças geram
+um novo snapshot datado, preservando o histórico.
+
+---
+
+## 1. Fontes consultadas
+
+| # | Fonte | Tipo | Última modificação |
+|---|---|---|---|
+| 1 | `risk_categories` (DB TiDB) | Live | 2026-04-18 (query Manus) |
+| 2 | `server/lib/risk-engine-v4.ts` | Código | 2026-04-14 (Z-12) |
+| 3 | `server/lib/rag-risk-validator.ts` | Código | 2026-04-13 (Z-13.5) |
+| 4 | `server/lib/action-plan-engine-v4.ts` | Código | (Z-12) |
+| 5 | `server/routers/risks-v4.ts` | Código | 2026-04-17 |
+| 6 | `server/cpie.ts` / `server/cpie-v2.ts` | Código | pré-Z-07 |
+| 7 | `docs/governance/RN_GERACAO_RISCOS_V4.md` | Doc (repo) | — |
+| 8 | `docs/governance/RN_CONSOLIDACAO_V4.md` | Doc (repo) | Z-16 |
+| 9 | `0-MatrizRisco/MOCKUP - RISCO/UAT_GATE_E_FAIL_REPORT.md` | Doc externo | 2026-04-11 |
+| 10 | `docs/adr/ADR-0023-cpie-score-opcao-a-sprint-z07.md` | ADR | Z-07 |
+
+---
+
+## 2. Pipeline de geração de riscos (atual)
+
+```
+Step 1-3 (Perfil)
+  │
+  └─→ companyProfile + operationProfile + taxComplexity + financialProfile + governanceProfile
+  │    projects.profileCompleteness (CPIE) — 0-100
+  │
+Step 4 (Briefing)
+  │
+  └─→ generateBriefing (LLM + RAG)
+  │
+Step 5 (Matriz de Riscos)
+  │
+  ├─→ analyzeGapsFromQuestionnaires() [Z-11]
+  │     Lê: solaris_answers JOIN solaris_questions WHERE risk_category_code IS NOT NULL
+  │     Lê: iagen_answers WHERE risk_category_code IS NOT NULL
+  │     Agrupa: Map<risk_category_code, AnswerData[]>
+  │     Classifica pessimisticamente (nao_atendido ganha)
+  │
+  ├─→ analyzeGaps() [legado — Onda 3]
+  │     Lê: questionnaireAnswersV3 + regulatory_requirements_v3
+  │
+  ├─→ gap-to-rule-mapper (ACL)
+  │     Para cada gap:
+  │       mapped (1 match)     → gera risco
+  │       ambiguous (2+)       → reviewQueue
+  │       unmapped (0)         → descarta
+  │
+  ├─→ consolidateRisks() [risk-engine-v4.ts]
+  │     Agrupa por risk_key = {categoria}::op:{tipoOperacao}::geo:{mono|multi}
+  │     Para cada grupo:
+  │       Severity: risk_categories (DB) OR fallback SEVERITY_TABLE
+  │       Artigo:   risk_categories.artigo_base OR gap.artigo
+  │       Tipo:     risk_categories.tipo OR derivado (oportunidade→opportunity)
+  │       Breadcrumb: [bestSource, categoria, artigo, risk_key]
+  │       Confidence: ponderada por SOURCE_RANK
+  │       Titulo:   TITULO_TEMPLATES[categoria] com {op} substituído
+  │
+  ├─→ enrichRiskWithRag() [rag-risk-validator.ts]
+  │     Para cada risco: LIKE query em ragDocuments
+  │     Se match: rag_validated=1, rag_confidence=0.85, rag_artigo_exato
+  │     Se no match: rag_validated=0, confidence × 0.75 (penalidade)
+  │
+  └─→ INSERT risks_v4 (status='active', approved_at=NULL)
+
+Step 6 (Planos de Ação)
+  │
+  └─→ buildActionPlans(risk) [action-plan-engine-v4.ts]
+      RN-RISK-05: type='opportunity' → retorna []
+      type='risk': consulta catálogo PLANS[ruleId]
+
+Step 7 (ConsolidacaoV4)
+  │
+  └─→ calculateComplianceScore(risks aprovados)
+      score = sum(peso × max(conf, 0.5)) / (n × 9) × 100
+      Snapshot persistido em projects.scoringData
+```
+
+---
+
+## 3. Categorias oficiais (fonte: DB `risk_categories`)
+
+**Diagnóstico D8 (2026-04-18):** verificação definitiva do DB live via
+`SELECT * FROM risk_categories ORDER BY id DESC` retornou 10 rows
+com `created_at = 2026-04-10T05:22:44` — seed único, sem inserções
+posteriores. Última migration tocando a tabela: `0073_risk_categories_descricao.sql`
+(Sprint Z-12, PR #471). DB live **alinhado ao seed**.
+
+| # | codigo | nome | tipo | severidade | urgencia | artigo_base |
+|---|---|---|---|---|---|---|
+| 1 | imposto_seletivo | Imposto Seletivo | risk | alta | imediata | Art. 2 LC 214/2025 |
+| 2 | confissao_automatica | Confissão Automática | risk | alta | imediata | Art. 45 LC 214/2025 |
+| 3 | split_payment | Split Payment | risk | alta | imediata | Art. 9 LC 214/2025 |
+| 4 | inscricao_cadastral | Inscrição Cadastral IBS/CBS | risk | alta | imediata | Art. 213 LC 214/2025 |
+| 5 | regime_diferenciado | Regime Diferenciado | risk | media | curto_prazo | Art. 29 LC 214/2025 |
+| 6 | transicao_iss_ibs | Transição ISS para IBS | risk | media | medio_prazo | Arts. 6-12 LC 214/2025 |
+| 7 | obrigacao_acessoria | Obrigação Acessória | risk | media | curto_prazo | Art. 102 LC 214/2025 |
+| 8 | aliquota_zero | Alíquota Zero | opportunity | oportunidade | curto_prazo | Art. 14 LC 214/2025 |
+| 9 | aliquota_reduzida | Alíquota Reduzida | opportunity | oportunidade | curto_prazo | Art. 24 LC 214/2025 |
+| 10 | credito_presumido | Crédito Presumido | opportunity | oportunidade | curto_prazo | Art. 58 LC 214/2025 |
+
+**Observações:**
+- Total efetivo: **10 categorias ativas** (7 risk + 3 opportunity).
+- `tributacao_servicos` **NUNCA existiu no DB nem no código** — aparece apenas
+  no `RN_GERACAO_RISCOS_V4.md:92` como entrada órfã de exemplo/descartada.
+- Coluna `descricao` foi adicionada na migration 0073 (Z-12) mas não é usada no engine.
+- Engine lê via `getCategoryByCode()` com cache TTL 1h (Sprint Z-09).
+- FK: `risks_v4.categoria → risk_categories.codigo` (ON UPDATE CASCADE, ON DELETE RESTRICT — migration 0067).
+
+**Nota histórica sobre revisão:** uma query anterior do Manus (2026-04-18 manhã)
+retornou uma tabela com `tributacao_servicos` no lugar de `aliquota_reduzida`.
+A diagnóstica oficial posterior (mesma data, tarde) comprovou que foi erro de
+renderização/cópia do Manus — o DB live nunca teve `tributacao_servicos`.
+Esta tabela é a **autoritativa**.
+
+---
+
+## 4. Hierarquia de fontes (decisão técnica)
+
+```
+NÍVEL 1 — risk_categories (DB TiDB)
+  Fonte EFETIVA em runtime.
+  Engine lê via getCategoryByCode().
+  Atualização: migration + PR (ADR-0025).
+
+NÍVEL 2 — SEVERITY_TABLE + Categoria enum (código)
+  Fallback determinístico se DB falhar.
+  Fonte do TypeScript type safety.
+  Atualização: PR no repositório.
+
+NÍVEL 3 — RN_GERACAO_RISCOS_V4.md (doc)
+  Especificação de INTENÇÃO.
+  Não consultado em runtime.
+  Atualização: PR no repositório.
+```
+
+**Regra de precedência:** N1 > N2 > N3. Divergência entre níveis
+é bug de governança, mesmo que o runtime "funcione".
+
+---
+
+## 5. Divergências detectadas e decisões
+
+### Resumo
+
+| ID | Divergência | Severidade | Decisão |
+|---|---|---|---|
+| ~~D1~~ | ~~aliquota_reduzida ausente no DB~~ | — | **REMOVIDA** — diagnóstico comprovou DB tem a categoria (row 9) |
+| D2 | tributacao_servicos órfã no RN doc | Baixa | Remover do RN_GERACAO_RISCOS_V4.md:92 |
+| D3 | inscricao_cadastral severidade: RN doc diz "media", código+DB dizem "alta" | Média | Atualizar RN doc |
+| D4 | RN doc menciona categoria não-implementada (tributacao_servicos) | Baixa | Ver D2 |
+| D5 | Thresholds score: código 75/50/25 × RN doc 70/50/30 + bypass totalAlta | **Alta** | Decidir qual é o certo antes de expor na UI |
+| D6 | Timeline reforma: código 2033, RN doc 2032 | Baixa | RN doc está errada (LC 214/2025 Art. 349 confirma 2033) |
+| D7 | CATEGORIA_ARTIGOS frontend × seed banco | **Média** | Unificar — artigos canônicos vêm do DB |
+| ~~D8~~ | ~~Drift banco live × seed~~ | — | **FALSO POSITIVO** — SELECT inicial Manus foi errado; diagnóstico confirmou alinhamento |
+
+---
+
+### D2 — `tributacao_servicos`: órfã no RN doc (reclassificada)
+
+**Status atualizado após diagnóstico 2026-04-18 (tarde):**
+
+- DB live: **ausente** (nunca existiu — seed único 2026-04-10)
+- Código enum `Categoria`: ausente
+- `SEVERITY_TABLE`: ausente
+- `TITULO_TEMPLATES`: ausente
+- Frontend: sem referências
+- CSVs SOLARIS: nenhuma pergunta
+- **Produção 930001:** 0 riscos gerados
+- **Única ocorrência no repo:** `docs/governance/RN_GERACAO_RISCOS_V4.md:92`
+  (linha isolada dentro de bloco de exemplo da `SEVERITY_TABLE`)
+
+**Diagnóstico:** categoria planejada/descartada durante Sprint Z-07
+que ficou como comentário órfão no documento de RN. **Nunca foi
+implementada.** Não há migration fantasma, não há drift de banco.
+
+**Decisão P.O. (revisada):** **NÃO** aplicar Opção C (fusão com
+`transicao_iss_ibs`) — basta **remover a linha 92 do RN doc** como
+revisão documental. Prioridade **baixa**, junto com D3/D4.
+
+---
+
+### D3 — `inscricao_cadastral`: severidade
+
+- DB: alta/imediata
+- Código: alta/imediata
+- RN doc: **media**/imediata
+
+**Diagnóstico:** RN doc desatualizada. DB e código concordam.
+
+**Decisão:** atualizar RN doc para alta/imediata (pós-snapshot).
+
+---
+
+### D4 — RN doc com categorias não implementadas
+
+Consolidada em D2. `aliquota_reduzida` já existe em DB + código
+(confirmado no diagnóstico). `tributacao_servicos` é órfã a remover
+do RN doc linha 92.
+
+---
+
+### D5 — Thresholds do Compliance Score
+
+| Nível | Código `compliance-score-v4.ts:46-51` | RN_CONSOLIDACAO_V4 §3 |
+|---|---|---|
+| critico | `score >= 75` | `score >= 70` **OU `totalAlta >= 2`** |
+| alto | `score >= 50` | `score >= 50` **OU `totalAlta >= 1`** |
+| medio | `score >= 25` | `score >= 30` |
+| baixo | `score < 25` | `score < 30` |
+
+**Divergência dupla:**
+(a) limiares numéricos (75 vs 70, 25 vs 30)
+(b) código **NÃO** tem bypass por `totalAlta` — RN tem
+
+**Impacto:** projeto com 4 riscos alta + confidence=1.0:
+- Código: score = 68.25 → "alto"
+- RN: `totalAlta=4 ≥ 2` → "critico" (bypass)
+
+**Decisão:** pendente P.O. Recomendação técnica: seguir RN doc
+(bypass por totalAlta preserva sensibilidade a exposição alta em
+projetos pequenos). Exige 1 PR em `compliance-score-v4.ts`.
+
+---
+
+### D6 — Timeline da reforma: 2032 vs 2033
+
+- `ConsolidacaoV4.tsx §17.5` (código): marcos `2026 / 2027 / 2029 / 2033`
+- `RN_CONSOLIDACAO_V4.md §4.9` (doc): marcos `[2026] [2027-2028] [2029] [2032]`
+
+**Fato histórico:** LC 214/2025 Art. 349 + ADCT Art. 125 estabelecem
+extinção do PIS/COFINS e ISS/ICMS em **2033**. Código está correto.
+
+**Decisão:** atualizar RN doc de 2032 → 2033 (pós-snapshot).
+
+---
+
+### D7 — CATEGORIA_ARTIGOS frontend × seed banco
+
+Identificada pelo inventário Manus §3. Frontend (`RiskDashboardV4.tsx`)
+mantém mapa hardcoded `CATEGORIA_ARTIGOS` com artigos diferentes do
+seed do banco:
+
+| Categoria | Seed (banco) | Frontend hardcoded |
+|---|---|---|
+| split_payment | Art. 9 | Art. 29 |
+| inscricao_cadastral | Art. 213 | Art. 21 |
+| regime_diferenciado | Art. 29 | Art. 258 |
+| obrigacao_acessoria | Art. 102 | Art. 88 |
+| aliquota_zero | Art. 14 | Art. 125 |
+| aliquota_reduzida | Art. 24 | Art. 120 |
+| credito_presumido | Art. 58 | Art. 185 |
+
+**Impacto jurídico:** o advogado pode ver 2 artigos diferentes para o
+mesmo risco dependendo do componente que está consultando. Artigo é
+**base legal** do parecer — divergência pode induzir erro.
+
+**Manus qualificou como "só fallback de exibição"** — imprecisão:
+embora o artigo canônico persista no banco, o mapa frontend pode
+substituir em alguns componentes da UI. Precisa auditoria.
+
+**Decisão:** remover `CATEGORIA_ARTIGOS` do frontend. Consumir sempre
+`risk_categories.artigo_base` via tRPC. Prioridade **média**
+(pós-snapshot).
+
+---
+
+### D8 — FALSO POSITIVO (descartada)
+
+**Hipótese inicial:** drift entre seed e live DB.
+**Diagnóstico posterior:** SELECT inicial Manus foi errado;
+DB live alinhado ao seed desde 2026-04-10.
+**Status:** descartada. Nenhuma ação técnica necessária.
+
+---
+
+## 6. CPIE — desambiguação e mapeamento dos 4 scores
+
+O termo "CPIE" tem 3 significados históricos diferentes no repositório.
+Esta seção desambigua e define qual é o "score na Matriz" que o P.O.
+quer ver atualizando conforme aprovações.
+
+### 6.1 Os 4 scores existentes — tabela definitiva
+
+| # | Nome | Arquivo | Propósito | Reage a riscos aprovados? | Determinístico? |
+|---|---|---|---|---|---|
+| A | CPIE v1 (Profile) | `server/cpie.ts` | Qualidade do perfil (5 dims) | Não | Parcialmente (LLM para perguntas) |
+| B | CPIE v2 (Profile + IA) | `server/cpie-v2.ts` | v1 + Arbitragem IA | Não | Parcialmente |
+| C | CPIE-B (scoringEngine) | `server/routers/scoringEngine.ts` | Gaps 40% + Riscos 35% + Ações 25% | Sim — mas lê tabelas v3 legadas | Sim |
+| D | **Compliance Score v4** | `server/lib/compliance-score-v4.ts` | `sum(peso × max(conf, 0.5)) / (n × 9) × 100` | **Sim — lê `risks_v4.approved_at`** | **Sim** |
+
+**O que o P.O. quer na Matriz de Riscos:** o **score D (Compliance Score v4)**.
+Esse sim muda conforme aprovações, é determinístico, e já está implementado.
+Apenas **não está sendo exibido no RiskDashboardV4** — só é chamado no Step 7
+(ConsolidacaoV4), uma única ocorrência em `server/routers/risks-v4.ts:1175`.
+
+### 6.2 Score D (Compliance Score v4) — detalhamento
+
+**Arquivo:** `server/lib/compliance-score-v4.ts`
+**Determinismo:** 100% — mesma entrada, mesma saída. Zero LLM.
+**RN:** RN-CV4-01..07, RN-CV4-10, RN-CV4-14
+
+**Constantes:**
+```typescript
+SEVERIDADE_SCORE_MAP = { alta: 7, media: 5, oportunidade: 1 }
+CONFIDENCE_FLOOR     = 0.5
+MAX_PESO             = 9
+```
+
+**Filtros aplicados:**
+1. RN-CV4-01: `approved_at IS NOT NULL` (riscos aprovados)
+2. RN-CV4-02: `type !== 'opportunity'` (oportunidades fora)
+
+**Fórmula:**
+```
+fator_confianca = max(risk.confidence, 0.5)
+pontos_risco    = SEVERIDADE_SCORE_MAP[severidade] × fator_confianca
+score           = ROUND(SUM(pontos_risco) / (n × 9) × 100)
+```
+
+**Classificação de nível (código `compliance-score-v4.ts:46-51`):**
+```
+score >= 75 → critico
+score >= 50 → alto
+score >= 25 → medio
+score <  25 → baixo
+```
+
+### 6.3 ⚠️ Divergência adicional — D5
+
+A RN_CONSOLIDACAO_V4.md usa thresholds diferentes do código:
+
+| Nível | Código `compliance-score-v4.ts` | RN_CONSOLIDACAO_V4 |
+|---|---|---|
+| critico | `score >= 75` | `score >= 70` **OU `totalAlta >= 2`** |
+| alto | `score >= 50` | `score >= 50` **OU `totalAlta >= 1`** |
+| medio | `score >= 25` | `score >= 30` |
+| baixo | `score < 25` | `score < 30` |
+
+**Diagnóstico:** código e RN divergem em dois pontos:
+(a) limiares numéricos (75 vs 70, 25 vs 30)
+(b) código **NÃO** tem bypass por `totalAlta` — RN tem.
+
+**Impacto no 930001 (hipótese):** projeto tem 4 riscos alta. Se todos
+fossem aprovados com confidence=1.0:
+- Pelo código: score = (4×7×1.0 + 3×5×1.0) / (7×9) × 100 = 43/63 × 100 = 68.25 → **alto**
+- Pela RN: `totalAlta=4 ≥ 2` → **critico** (bypass)
+
+Resultado potencialmente muito diferente. Precisa de decisão P.O.
+(guardado para pós-snapshot junto com D3/D4).
+
+### 6.4 Onde o Score D é calculado e usado hoje
+
+```
+CHAMADA: calculateComplianceScore() invocada em:
+  server/routers/risks-v4.ts:1175  (procedure getConsolidacaoV4)
+
+USADO POR:
+  - ConsolidacaoV4.tsx (Step 7) — exibe score + snapshot
+
+NÃO USADO POR:
+  - RiskDashboardV4.tsx (Step 5 / Matriz) ← LACUNA IDENTIFICADA
+  - ActionPlanPage.tsx (Step 6 / Planos)  ← LACUNA
+  - Dashboard do projeto (visão geral)     ← LACUNA
+
+PERSISTÊNCIA:
+  projects.scoringData (JSON) — snapshots[], score_atual, nivel_atual
+  Gravado em cada visita à ConsolidacaoV4.
+```
+
+### 6.5 Regra de integração DEC-01 (revisada) — Compliance Score na Matriz
+
+Para atender ao P.O. ("preciso dele na matriz, pois conforme os riscos
+aprovados, o nível de compliance pode aumentar ou diminuir"):
+
+```
+RiskDashboardV4 deve exibir um componente:
+
+  ┌──────────────────────────────────────────────────┐
+  │ SCORE DE COMPLIANCE: 43/100 · Nível: MÉDIO       │
+  │ ─────────────────────────────────────────────    │
+  │ Calculado sobre: 3 riscos aprovados              │
+  │ [alta: 1] [media: 2] · 7 pendentes · 3 opor.     │
+  │                                                  │
+  │ O score sobe conforme você aprova/exclui riscos. │
+  │ Ver detalhe auditável na Consolidação.           │
+  └──────────────────────────────────────────────────┘
+
+Reatividade:
+  - Recalcula a cada approveRisk / deleteRisk
+  - Usa mesma procedure: calculateComplianceScore(risks)
+  - Invalida cache ao montar (consistente com Step 7)
+
+NÃO é o CPIE v1/v2 (score A/B — qualidade do perfil).
+É o Compliance Score v4 (score D — exposição tributária aprovada).
+
+Semântica visível ao advogado:
+  - "SCORE DE COMPLIANCE" (label do card)
+  - Não usar a sigla "CPIE" na UI (confunde com score A/B)
+  - O termo CPIE fica como nome técnico interno
+```
+
+### 6.6 E o score A/B (CPIE Profile) — ainda tem lugar?
+
+Sim, mas secundário:
+- **Dashboard do projeto (Step 1-3):** KPI "Qualidade do Perfil"
+- **Header da Matriz:** chip pequeno "Perfil 75/100" — só aviso se < 50
+- **Nunca** se confunde com o Score de Compliance principal
+
+### 6.7 Status de débito técnico (ADR-0023)
+
+```
+ADR-0023 (2026-04-09):
+  "Score CPIE-B continua lendo tabelas legadas (v3) até PR #E.
+   Projetos novos com engine v4 terão CPIE-B zerado até PR #E."
+
+Confirmação no 930001:
+  profileCompleteness = 0
+  profileConfidence = 0
+
+O que funciona hoje:
+  ✅ Score D (Compliance Score v4) — calculado corretamente
+     sobre risks_v4, mas só exibido no Step 7.
+  ❌ Score C (CPIE-B scoringEngine) — zerado para projetos v4.
+  ❓ Score A/B (CPIE Profile) — precisa verificar se leitura
+     de companyProfile funciona apesar de CPIE-B zerado.
+
+PR #E pendente reconcilia Score C com engine v4.
+Mesmo sem PR #E, podemos avançar com Score D na Matriz
+(implementação nova, independente de reconciliação).
+```
+
+---
+
+## 7. Fórmula do score de compliance (fonte: RN_CONSOLIDACAO_V4)
+
+```typescript
+// Constantes
+SEVERIDADE_SCORE_MAP = { alta: 7, media: 5, oportunidade: 1 }
+MAX_PESO            = 9
+CONFIDENCE_FLOOR    = 0.5
+
+// Filtros
+riscos_elegiveis = WHERE type='risk'
+                     AND status='active'
+                     AND approved_at IS NOT NULL
+
+// Cálculo por risco
+fator_confianca = max(risk.confidence, 0.5)
+pontos_risco    = SEVERIDADE_SCORE_MAP[severidade] × fator_confianca
+
+// Score total
+n                = COUNT(riscos_elegiveis)
+soma_pontos      = SUM(pontos_risco)
+score            = ROUND(soma_pontos / (n × 9) × 100)
+
+// Níveis
+score >= 70 OU totalAlta >= 2  → critico
+score >= 50 OU totalAlta >= 1  → alto
+score >= 30                    → medio
+score <  30                    → baixo
+```
+
+**Regras:**
+- Oportunidades **FORA** do numerador E denominador.
+- `rag_confidence` **não entra** (só alerta visual).
+- Snapshot salvo em `projects.scoringData.snapshots[]` a cada visita.
+- `formula_version: 'v4.0'` registrada para auditoria futura.
+
+---
+
+## 8. Gate 7 — 4 provas de qualidade
+
+Fonte: `docs/governance/GOVERNANCA-E2E-IA-SOLARIS.md:385-388`
+
+| Prova | Regra | Falha se |
+|---|---|---|
+| P1 — Quantidade | 10 ≤ total ≤ 40 | total = 0 ou total > 60 |
+| P2 — Inferência normativa | `aliquota_zero` + `credito_presumido` presentes | aba Oportunidades vazia |
+| P3 — Títulos jurídicos | Sem `"[categoria]"` e sem `"geral"` | qualquer título com colchetes ou "geral" |
+| P4 — RAG validation | ≥ 50% riscos com `rag_validated=1` | 0% validados |
+
+---
+
+## 9. Estado do projeto de referência 930001
+
+Fonte: queries Manus 2026-04-18.
+
+### 9.1 Perfil
+
+| Campo | Valor |
+|---|---|
+| id | 930001 |
+| profileCompleteness | **0** (CPIE zerado — ADR-0023) |
+| profileConfidence | **0** |
+| companyProfile.annualRevenueRange | 4800000-78000000 |
+| companyProfile.cnpj | 00.394.460/0058-87 |
+| companyProfile.companySize | media |
+| companyProfile.companyType | ltda |
+| companyProfile.isEconomicGroup | false |
+| companyProfile.taxCentralization | centralized |
+| companyProfile.taxRegime | lucro_real |
+
+### 9.2 Distribuição de riscos
+
+```
+Total de riscos: 10
+Total de grupos: 10 (1 risco por categoria — suspeito)
+```
+
+| categoria | severidade | total |
+|---|---|---|
+| aliquota_reduzida | oportunidade | 1 |
+| aliquota_zero | oportunidade | 1 |
+| confissao_automatica | alta | 1 |
+| credito_presumido | oportunidade | 1 |
+| imposto_seletivo | alta | 1 |
+| inscricao_cadastral | alta | 1 |
+| obrigacao_acessoria | media | 1 |
+| regime_diferenciado | media | 1 |
+| split_payment | alta | 1 |
+| transicao_iss_ibs | media | 1 |
+
+**Distribuição:** 4× alta · 3× media · 3× oportunidade · 0× critica · 0× baixa.
+
+### 9.3 Observações sobre a distribuição
+
+1. **Um risco por categoria — POR DESIGN** (decisão P.O. 2026-04-18):
+   > "não posso repetir riscos, por isso, é um risco por categoria,
+   >  caso contrário poderia ter o mesmo risco em várias categorias"
+
+   Implicação técnica: `consolidateRisks()` agrupa por
+   `risk_key = {categoria}::op:{tipoOperacao}::geo:{mono|multi}`.
+   Se múltiplos gaps de uma mesma categoria coincidem em
+   `tipoOperacao` + `multiestadual`, são fundidos em 1 risco —
+   é isso que gera a distribuição 1:1 observada.
+
+   **Regra do P.O.:** nunca repetir categoria. 930001 com
+   `tipoOperacao='comercio'` uniforme produz exatamente 10 riscos
+   para 10 categorias ativas (excluindo `tributacao_servicos` órfã).
+
+   **Atenção:** se um projeto futuro tiver `multiestadual` alternado
+   entre gaps de mesma categoria, `risk_key` gera 2 grupos distintos
+   e a regra "1 por categoria" é violada. Ver `risk-engine-v4.ts:238-242`.
+   **Ação P3:** testar se o engine garante unicidade por CATEGORIA
+   (não só por risk_key) — pode precisar ajuste.
+
+2. **`aliquota_reduzida` gerada corretamente via DB** (D1 descartada).
+   Diagnóstico 2026-04-18 confirmou que a categoria existe em
+   `risk_categories` (row 9, Art. 24). O risco veio do caminho oficial
+   `getCategoryByCode()`, não de fallback. Funcionamento esperado.
+
+3. **`tributacao_servicos` não gerada** — correto. Nunca foi
+   implementada; só aparece no RN doc como órfã (D2 reclassificada).
+
+4. **`inscricao_cadastral` como alta** — DB e código alinhados.
+   RN doc desatualizada (D3).
+
+### 9.4 Gate 7 — aferição COMPLETA
+
+Dados confirmados pelo Manus em 2026-04-18:
+
+| Prova | Status | Evidência |
+|---|---|---|
+| P1 — Quantidade | **PASS** | 10 riscos (borda inferior do intervalo 10-40) |
+| P2 — Inferência normativa | **PASS** | `aliquota_zero` + `credito_presumido` presentes |
+| P3 — Títulos jurídicos | **PASS** | 10 títulos com templates canônicos — nenhum com `[categoria]` ou palavra isolada "geral" (todos têm "comercio" no lugar de {op}) |
+| P4 — RAG validation | **PASS** | **100% (10/10) `rag_validated=1`** — excelente |
+
+**Resultado: 4/4 PASS.** Projeto 930001 passa todas as provas Gate 7.
+
+**Títulos observados (P3):**
+```
+1.  Risco de incidência do Imposto Seletivo nas operações de comercio
+2.  Risco de irregularidade cadastral no IBS/CBS nas operações de comercio
+3.  Oportunidade de aproveitamento de crédito presumido nas operações de comercio
+4.  Risco de enquadramento incorreto em regime diferenciado nas operações de comercio
+5.  Risco de inconsistência na transição ISS/IBS nas operações de comercio
+6.  Oportunidade de alíquota reduzida nas operações de comercio
+7.  Risco de não conformidade com Split Payment nas operações de comercio
+8.  Oportunidade de alíquota zero sobre produtos elegíveis nas operações de comercio
+9.  Risco de confissão automática de débitos nas operações de comercio
+10. Risco de descumprimento de obrigações acessórias nas operações de comercio
+```
+
+Todos seguem `TITULO_TEMPLATES[categoria]` com `{op}='comercio'`.
+Nenhum caiu no fallback `"Risco: ${categoria} nas operações de {op}"`.
+
+### 9.5 Verificações complementares ainda pendentes (não-Gate 7)
+
+| # | Check | Query pendente |
+|---|---|---|
+| V1 | Breadcrumb 4 nós | `SELECT breadcrumb FROM risks_v4 WHERE project_id=930001` — contar `JSON_LENGTH(breadcrumb)=4` |
+| V2 | Ordenação `SEVERITY_ORDER` respeitada | `SELECT severidade, COUNT(*) FROM risks_v4 WHERE project_id=930001 ORDER BY id` → verificar sequência |
+| V3 | Invariante RN-RISK-05 (oportunidade → sem plano) | `SELECT COUNT(*) FROM action_plans ap JOIN risks_v4 r ON ap.risk_id=r.id WHERE r.type='opportunity' AND r.project_id=930001` → deve ser 0 |
+| V4 | Consistência `type ⇔ severidade` | `SELECT type, severidade, COUNT(*) FROM risks_v4 WHERE project_id=930001 GROUP BY type, severidade` |
+| V5 | **Unicidade por categoria** (regra P.O.) | `SELECT categoria, COUNT(*) FROM risks_v4 WHERE project_id=930001 GROUP BY categoria HAVING COUNT(*) > 1` — deve retornar 0 linhas |
+| V6 | Compliance Score atual (se riscos aprovados) | `SELECT scoringData FROM projects WHERE id=930001` + calcular hipotético |
+
+---
+
+## 10. Status dos 21 bugs UAT Gate E (2026-04-11)
+
+Fonte: `0-MatrizRisco/MOCKUP - RISCO/UAT_GATE_E_FAIL_REPORT.md`.
+
+Status "presume-fechado" com base em sprints Z-13 a Z-18.
+Requer **auditoria de código** para confirmar cada item.
+
+### 10.1 RiskDashboardV4 (B-01 a B-13)
+
+| # | Bug | Presunção | Verificar em |
+|---|---|---|---|
+| B-01 | Geração automática pós-briefing | FECHADO (Z-14) | `routers-fluxo-v3.ts` + frontend |
+| B-02 | Botões do card (Editar/Excluir/Aprovar) | FECHADO (Z-15) | `RiskDashboardV4.tsx` |
+| B-03 | Estado approved vs pending | FECHADO (Z-15) | `RiskDashboardV4.tsx` |
+| B-04 | Modal de aprovação de risco | FECHADO (Z-15) | `RiskDashboardV4.tsx` |
+| B-05 | Modal de exclusão (soft delete) | FECHADO (Z-15) | `RiskDashboardV4.tsx` |
+| B-06 | Summary bar 4 cards | VERIFICAR | `RiskDashboardV4.tsx` |
+| B-07 | Banner de aprovação pendente | VERIFICAR | `RiskDashboardV4.tsx` |
+| B-08 | Agrupamento por categoria | VERIFICAR | `RiskDashboardV4.tsx` |
+| B-09 | Painel evidências por SOURCE_RANK | VERIFICAR | `RiskDashboardV4.tsx` |
+| B-10 | Aba Oportunidades (teal, sem "+ Plano") | VERIFICAR | `RiskDashboardV4.tsx` |
+| B-11 | Aba Histórico (restore + audit_log) | VERIFICAR | `RiskDashboardV4.tsx` |
+| B-12 | Chips dinâmicos de categoria | VERIFICAR | `RiskDashboardV4.tsx` |
+| B-13 | Breadcrumb clicável (nó 3 modal, nó 4 tooltip) | VERIFICAR | `RiskDashboardV4.tsx` |
+
+### 10.2 ActionPlanPage (B-14 a B-21)
+
+| # | Bug | Presunção | Verificar em |
+|---|---|---|---|
+| B-14 | Integração ao fluxo (não tela vazia) | FECHADO (Z-14) | `ActionPlanPage.tsx` |
+| B-15 | Banner rastreabilidade sticky | FECHADO (Z-12) | `ActionPlanPage.tsx:941` (TraceabilityBanner) |
+| B-16 | Estado rascunho (opacity 40%) | FECHADO (Z-12) | `ActionPlanPage.tsx` |
+| B-17 | Botão aprovar plano | FECHADO (Z-14) | `ActionPlanPage.tsx` |
+| B-18 | Progresso barra X/N | VERIFICAR | `ActionPlanPage.tsx` |
+| B-19 | Status inline tarefa | VERIFICAR | `ActionPlanPage.tsx` |
+| B-20 | Modal editar plano | FECHADO (Z-16 #614) | `ActionPlanPage.tsx` |
+| B-21 | Modal editar tarefa | FECHADO (Z-16 #614) | `ActionPlanPage.tsx` |
+
+**Total presumido-fechado:** 9/21
+**Total a verificar:** 12/21
+
+---
+
+## 11. Pendências técnicas e de produto (pós-snapshot)
+
+Lista ordenada por prioridade. Nenhum item foi executado neste snapshot.
+
+### P0 — Bloqueadores do snapshot (aprovação P.O.)
+
+- **P0.1** — Decisão Q3: `aliquota_reduzida` remover do código OU adicionar ao DB (pendente).
+- **P0.2** — Concluir auditoria dos 12 bugs UAT Gate E "a verificar".
+
+### P1 — Alinhamento pós-snapshot
+
+- **P1.1** — PR de governança: atualizar RN_GERACAO_RISCOS_V4 (D3, D4, D2).
+- **P1.2** — Migration: DELETE `tributacao_servicos` de `risk_categories` (decisão C).
+- **P1.3** — Código: remover referências a `tributacao_servicos` em docs (D4).
+- **P1.4** — Decidir e aplicar resolução D1 (`aliquota_reduzida`).
+
+### P2 — Débitos técnicos conhecidos
+
+- **P2.1** — PR #E: reconciliar CPIE com engine v4 (ADR-0023). Elimina `profileCompleteness=0` em projetos novos.
+- **P2.2** — Verificar por que `consolidateRisks` produziu 1 risco por grupo no 930001 (esperado: múltiplos gaps consolidados por `risk_key`).
+- **P2.3** — Completar queries Gate 7 P3/P4 (títulos e `rag_validated`).
+
+### P3 — Suite de testes (camadas propostas)
+
+- **P3.1** — Camada 1: unit tests do engine (`risk-engine-v4.afericao.test.ts`).
+- **P3.2** — Camada 2: script `scripts/audit-risk-matrix.mjs` (aferição real no 930001).
+- **P3.3** — Camada 3: E2E Playwright da matriz (regression guard).
+- **P3.4** — `scripts/categoria-drift-check.mjs` (DB × código × RN).
+
+---
+
+## 12. Referências cruzadas
+
+- `docs/adr/ADR-0022-hot-swap-risk-engine-v4.md` — engine v4 ativo
+- `docs/adr/ADR-0023-cpie-score-opcao-a-sprint-z07.md` — débito CPIE
+- `docs/adr/ADR-0025-risk-categories-configurable-rag-sensor.md` — risk_categories configurável
+- `docs/governance/RN_GERACAO_RISCOS_V4.md` — spec geração (desatualizada nos pontos D2, D3, D4)
+- `docs/governance/RN_CONSOLIDACAO_V4.md` — score de compliance Step 7
+- `docs/governance/RN_PLANOS_TAREFAS_V4.md` — planos e tarefas
+- `docs/governance/GOVERNANCA-E2E-IA-SOLARIS.md` — Gate 7 P1-P4
+- `server/lib/risk-engine-v4.ts` — engine determinístico
+- `server/lib/rag-risk-validator.ts` — enrichment RAG
+- `server/cpie-v2.ts` — CPIE v2
+
+---
+
+## 13. Rastreabilidade risco → gap → onda (NOVO)
+
+> Inserido para atender pedido P.O. 2026-04-18:
+> "identificar a fonte dos riscos, e a fonte da fonte, ou seja,
+>  quero saber se temos os gaps identificados nas 3 ondas,
+>  se essas são as fontes para gerar riscos, e a regra ou fórmula
+>  para gerar risco. Nosso compromisso é 98% ou superior de
+>  confiabilidade, este trabalho é essencial antes da liberação
+>  para os advogados testarem."
+
+### 13.1 As 3 ondas de origem — com schemas confirmados
+
+```
+╔══════════════════════════════════════════════════════════════════════╗
+║ ONDA 1 — SOLARIS (Questionário jurídico curado pela equipe)          ║
+╠══════════════════════════════════════════════════════════════════════╣
+║ Tabela:      solaris_answers JOIN solaris_questions                  ║
+║ Chave:       solaris_questions.risk_category_code                    ║
+║ Qualif:      classification_scope = 'risk_engine' AND ativo = 1      ║
+║ Fonte:       'solaris' — SOURCE_RANK = 4                             ║
+║ Confidence:  1.0 (fixo — resposta humana)                            ║
+║ Gap gerado:  compliance_status ∈ {nao_atendido, parcial}             ║
+║ Pipeline:    analyze-gaps-questionnaires.ts                          ║
+║ Migration:   0068_solaris_questions_risk_category.sql                ║
+╚══════════════════════════════════════════════════════════════════════╝
+
+╔══════════════════════════════════════════════════════════════════════╗
+║ ONDA 2 — IA GEN (Questionário personalizado pela IA)                 ║
+╠══════════════════════════════════════════════════════════════════════╣
+║ Tabela:      iagen_answers                                           ║
+║ Chave:       iagen_answers.risk_category_code                        ║
+║ Qualif:      risk_category_code IS NOT NULL                          ║
+║ Fonte:       'iagen' — SOURCE_RANK = 5                               ║
+║ Confidence:  ia.confidence_score (default 0.7)                       ║
+║ Gap gerado:  compliance_status ∈ {nao_atendido, parcial}             ║
+║ Pipeline:    analyze-gaps-questionnaires.ts (mesma função)           ║
+║ Migration:   0069_iagen_answers_risk_category.sql                    ║
+╚══════════════════════════════════════════════════════════════════════╝
+
+╔══════════════════════════════════════════════════════════════════════╗
+║ ONDA 3A — RAG NORMATIVO (compliance contra regulatory_requirements)  ║
+╠══════════════════════════════════════════════════════════════════════╣
+║ Tabela:      regulatory_requirements_v3 (138 requisitos)             ║
+║ Chave:       req.code (REQ-APU-001, REQ-IS-003, etc.)                ║
+║ Fonte:       'cnae' (1), 'ncm' (2), 'nbs' (3)                        ║
+║ Confidence:  variável conforme match                                 ║
+║ Gap gerado:  analyzeGaps() → project_gaps_v3                         ║
+║ Pipeline:    routers/gapEngine.ts (LEGADO)                           ║
+╚══════════════════════════════════════════════════════════════════════╝
+
+╔══════════════════════════════════════════════════════════════════════╗
+║ ONDA 3B — INFERÊNCIA NORMATIVA POR PERFIL (aditiva)                  ║
+╠══════════════════════════════════════════════════════════════════════╣
+║ Tabela:      normative_product_rules (migration 0076)                ║
+║ Chave:       match por NCM + regime tributário                       ║
+║ Fonte:       'ncm' (SOURCE_RANK 2)                                   ║
+║ Gap gerado:  não gera gap — gera risco DIRETO (sem questionário)     ║
+║ Pipeline:    server/lib/normative-inference.ts                       ║
+║ Observação:  independente dos questionários — mesmo sem Ondas 1+2    ║
+║              uma empresa com CNAE X + NCM Y pode ter risco gerado    ║
+╚══════════════════════════════════════════════════════════════════════╝
+```
+
+### 13.2 Pipeline completo — gap → risco (código real)
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ 1. COLETA DE RESPOSTAS                                              │
+│    solaris_answers (Onda 1) + iagen_answers (Onda 2)                │
+└─────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│ 2. analyzeGapsFromQuestionnaires() — Z-11                           │
+│    server/lib/analyze-gaps-questionnaires.ts:170                    │
+│                                                                     │
+│    SELECT answer_value, risk_category_code, fonte, confidence       │
+│    FROM solaris_answers JOIN solaris_questions                      │
+│         WHERE classification_scope='risk_engine' AND ativo=1        │
+│    UNION ALL                                                        │
+│    FROM iagen_answers WHERE risk_category_code IS NOT NULL          │
+│                                                                     │
+│    Classificação pessimista por categoria (DEC-Z11-ARCH-02):        │
+│      qualquer resposta 'nao_atendido' → categoria 'nao_atendido'    │
+│      se todas 'atendido' → sem gap                                  │
+│      se todas 'nao_aplicavel' → sem gap                             │
+│                                                                     │
+│    INSERT project_gaps_v3 (categoria=nao_atendido ou parcial)       │
+└─────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│ 3. analyzeGaps() — LEGADO Onda 3A                                   │
+│    server/routers/gapEngine.ts                                      │
+│                                                                     │
+│    Para cada CNAE confirmado:                                       │
+│      match regulatory_requirements_v3                               │
+│      compara com respostas do questionário                          │
+│    INSERT project_gaps_v3 (ondas 3)                                 │
+└─────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│ 4. generateRisksV4Pipeline() — Z-13.5                               │
+│    server/lib/generate-risks-pipeline.ts                            │
+│                                                                     │
+│    a) extractProjectProfile(projectId)                              │
+│       → ProjectProfile {cnaes, taxRegime, tipoOperacao, ...}        │
+│                                                                     │
+│    b) consolidateRisks(projectId, gaps, context, actorId)           │
+│       → agrupa gaps por risk_key = {cat}::op:{op}::geo:{mono|multi} │
+│       → 1 grupo = 1 risco (consolidação por chave)                  │
+│       → severidade via getCategoryByCode(DB) ou SEVERITY_TABLE      │
+│       → artigo via risk_categories.artigo_base ou gap.artigo        │
+│       → breadcrumb = [bestSource, categoria, artigo, risk_key]      │
+│       → titulo via TITULO_TEMPLATES[categoria] com {op} substituído │
+│       → confidence = weighted avg por 1/SOURCE_RANK                 │
+│                                                                     │
+│    c) inferNormativeRisks(projectId, profile)                       │
+│       → lê normative_product_rules × profile.productNcms            │
+│       → gera riscos ADICIONAIS sem passar por gaps                  │
+│                                                                     │
+│    d) mergeByRiskKey([consolidated, inferred])                      │
+│       → último vence em colisão                                     │
+│                                                                     │
+│    e) enrichAllWithRag(merged, 3000ms timeout)                      │
+│       → para cada risco: LIKE query em ragDocuments                 │
+│       → se hit: rag_validated=1, rag_confidence=0.85                │
+│       → se miss: rag_validated=0, confidence × 0.75 (penalidade)    │
+│                                                                     │
+│    f) summary { total, alta, media, oportunidades, rag_validated }  │
+└─────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│ 5. INSERT INTO risks_v4                                             │
+│    approved_at = NULL, approved_by = NULL, status = 'active'        │
+│    (tabela server/lib/db-queries-risks-v4.ts)                       │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### 13.3 Fórmula de geração — RESUMO DETERMINÍSTICO
+
+**Severidade do risco:**
+```
+severidade = DB.risk_categories[categoria].severidade
+             OR SEVERITY_TABLE[categoria].severity
+             OR 'media' (último fallback — deveria nunca acontecer)
+```
+
+**Urgência do risco:**
+```
+urgencia = DB.risk_categories[categoria].urgencia
+           OR SEVERITY_TABLE[categoria].urgency
+           OR 'curto_prazo' (último fallback)
+```
+
+**Tipo do risco:**
+```
+type = DB.risk_categories[categoria].tipo
+       OR (severidade === 'oportunidade' ? 'opportunity' : 'risk')
+```
+
+**Artigo:**
+```
+artigo = DB.risk_categories[categoria].artigo_base
+         OR gap.artigo (primeiro gap do grupo)
+         (NUNCA inventado por LLM — RN-RISK-01)
+```
+
+**Título:**
+```
+titulo = TITULO_TEMPLATES[categoria].replace('{op}', ctx.tipoOperacao ?? 'geral')
+         OR `Risco: ${categoria} nas operações de {op}` (fallback)
+```
+
+**Confidence:**
+```
+confidence_por_gap = 1 / SOURCE_RANK[gap.fonte]
+confidence_risco   = Σ(confidence_gap × evidence.confidence) / Σ(confidence_gap)
+                     (média ponderada por 1/SOURCE_RANK)
+
+se RAG hit:  confidence × 0.8 + 0.85 × 0.2 (blend)
+se RAG miss: confidence × 0.75            (penalidade)
+```
+
+**Breadcrumb (4 nós, sempre):**
+```
+[0] fonte  = gap com menor SOURCE_RANK do grupo
+[1] categoria
+[2] artigo = risk_categories.artigo_base OU gap.artigo
+[3] risk_key ou rule_id
+```
+
+**Score de compliance do projeto (agregado, para o RiskDashboardV4):**
+```
+filtro: risks_v4 WHERE project_id = ? AND status = 'active'
+                   AND approved_at IS NOT NULL
+                   AND type = 'risk'
+
+fator_confianca = max(risk.confidence, 0.5)
+pontos_risco    = {alta: 7, media: 5, oportunidade: 1}[severidade] × fator_confianca
+score_projeto   = ROUND(Σ pontos_risco / (n × 9) × 100)
+
+nivel (código): >=75 critico / >=50 alto / >=25 medio / <25 baixo
+(ver D5 — divergência com RN)
+```
+
+### 13.4 Verificação no 930001 — rastreabilidade
+
+Para fechar a auditoria de rastreabilidade, queries necessárias
+(pedido Manus):
+
+```sql
+-- Q1: Quantos gaps por projeto, separados por onda
+SELECT source_type AS onda, COUNT(*) total
+FROM project_gaps_v3
+WHERE project_id = 930001
+GROUP BY source_type;
+
+-- Q2: Rastreabilidade risco → gap (via rule_id ou evidence JSON)
+SELECT r.id, r.categoria, r.rule_id, r.source_priority,
+       JSON_LENGTH(JSON_EXTRACT(r.evidence, '$.gaps')) n_gaps_evidence
+FROM risks_v4 r
+WHERE r.project_id = 930001
+ORDER BY r.categoria;
+
+-- Q3: Existem riscos sem gap de origem? (violação RN-RISK-06)
+SELECT r.id, r.categoria, r.rule_id
+FROM risks_v4 r
+WHERE r.project_id = 930001
+  AND (r.rule_id IS NULL OR r.rule_id = '');
+
+-- Q4: Respostas SOLARIS com risk_category_code (Onda 1)
+SELECT sq.risk_category_code, COUNT(*) respostas
+FROM solaris_answers sa
+JOIN solaris_questions sq ON sq.id = sa.question_id
+WHERE sa.project_id = 930001
+  AND sq.risk_category_code IS NOT NULL
+GROUP BY sq.risk_category_code;
+
+-- Q5: Respostas IA GEN com risk_category_code (Onda 2)
+SELECT risk_category_code, COUNT(*) respostas
+FROM iagen_answers
+WHERE project_id = 930001
+  AND risk_category_code IS NOT NULL
+GROUP BY risk_category_code;
+
+-- Q6: Riscos da inferência normativa (Onda 3B) vs gaps (Ondas 1+2+3A)
+SELECT CASE
+         WHEN r.rule_id LIKE 'infer_%' THEN 'inferido'
+         ELSE 'gap'
+       END AS origem,
+       COUNT(*) total
+FROM risks_v4 r
+WHERE r.project_id = 930001
+GROUP BY origem;
+```
+
+Sem essas queries, não sabemos:
+- quantos gaps saíram de cada onda
+- se todos os 10 riscos estão rastreáveis a gaps
+- se `aliquota_reduzida` veio de Onda 1, 2 ou 3
+- se algum risco veio só de `inferNormativeRisks` (sem gap)
+
+### 13.5 Meta de 98% de confiabilidade — o que aferir
+
+Para fechar o compromisso antes da liberação para advogados:
+
+| Critério | Como medir | Status 930001 |
+|---|---|---|
+| 1. Todo risco tem origem | `rule_id IS NOT NULL` em 100% | Pendente Q3 |
+| 2. Toda categoria veio de ≥1 onda | Q4 + Q5 cobrem 10 categorias | Pendente |
+| 3. Severidade determinística | DB.risk_categories não modificado em runtime | OK (função pura) |
+| 4. Artigo rastreável ao RAG | rag_validated = 1 em ≥50% | **100% PASS** |
+| 5. Breadcrumb 4 nós | `JSON_LENGTH(breadcrumb) = 4` em 100% | Pendente V1 |
+| 6. Sem planos para oportunidade | RN-RISK-05 | Pendente V3 |
+| 7. Unicidade por categoria | Uma linha por codigo por projeto | Pendente V5 |
+| 8. Score visível ao advogado | Score D aparece no RiskDashboardV4 | **FALHA** (só Step 7) |
+| 9. Fonte primária explícita | Breadcrumb[0] = fonte de menor SOURCE_RANK | Pendente V1 |
+| 10. Nenhuma categoria órfã gerando | `tributacao_servicos` não aparece | PASS (já confirmado) |
+
+**Nota:** Critérios 1-7 e 9-10 são **propriedades do engine**.
+Critério 8 é **propriedade de UI** (lacuna identificada em 6.4).
+Precisa ser atacado antes da liberação.
+
+---
+
+## 14. Decisões registradas nesta iteração
+
+| # | Decisão | Por | Data |
+|---|---|---|---|
+| DEC-01 | Score **D (Compliance Score v4)** deve ser exibido no RiskDashboardV4, atualizando com aprovações/exclusões de riscos. Score A/B (CPIE Profile) permanece secundário (chip/aviso). NÃO usar sigla "CPIE" na UI principal. | P.O. | 2026-04-18 |
+| DEC-02 | `tributacao_servicos`: remover linha 92 do RN_GERACAO_RISCOS_V4.md (reclassificada como órfã no doc — nunca foi implementada, Opção C original não se aplica) | P.O. | 2026-04-18 |
+| DEC-03 | Alinhamento RN × código × DB (D3, D5, D6) fica para PR pós-snapshot | P.O. | 2026-04-18 |
+| DEC-04 | `aliquota_reduzida` — confirmada presente em DB (row 9) e código; sem ação necessária (D1 descartada) | diagnóstico | 2026-04-18 |
+| DEC-05 | "1 risco por categoria" é regra de produto inviolável — não pode haver o mesmo risco em 2 categorias, nem 2 riscos da mesma categoria | P.O. | 2026-04-18 |
+| DEC-06 | Meta de 98% de confiabilidade antes de liberar para advogados — 10 critérios auditáveis listados em §13.5 | P.O. | 2026-04-18 |
+| DEC-07 | Snapshot + inventário consolidados em 1 arquivo único (Opção A) | P.O. | 2026-04-18 |
+| DEC-08 | D7 (CATEGORIA_ARTIGOS frontend) elevada para prioridade média — advogado não pode ver 2 artigos diferentes | P.O. | 2026-04-18 |
+| DEC-09 | D8 (drift DB) descartada — era falso positivo da query Manus inicial | diagnóstico | 2026-04-18 |
+
+---
+
+## 15. Schemas detalhados (integrado do inventário Manus)
+
+### 15.1 Tabela `risks_v4`
+
+Migration principal: `drizzle/0064_risks_v4.sql` (Z-07). Campos adicionados
+em migrations posteriores (`0075_risks_v4_rag_fields.sql`, Z-13.5).
+
+| Coluna | Tipo | Constraint | Descrição |
+|---|---|---|---|
+| id | VARCHAR(36) | PK | UUID v4 gerado pelo servidor |
+| project_id | INT | NOT NULL | FK → projects.id |
+| rule_id | VARCHAR(255) | NOT NULL | Chave da regra de origem (GAP-IS-001 ou risk_key) |
+| type | ENUM('risk','opportunity') | NOT NULL | — |
+| categoria | VARCHAR(100) | NOT NULL, FK → risk_categories.codigo | 0066/0067 |
+| titulo | VARCHAR(500) | NOT NULL | Determinístico |
+| descricao | TEXT | NULL | Pode ser LLM |
+| artigo | VARCHAR(255) | NOT NULL | RN-RISK-01 — nunca NULL |
+| severidade | ENUM('alta','media','oportunidade') | NOT NULL | RN-RISK-02 — nunca LLM |
+| urgencia | ENUM('imediata','curto_prazo','medio_prazo') | NOT NULL | Determinística |
+| evidence | JSON | NOT NULL | Array ordenado por SOURCE_RANK |
+| breadcrumb | JSON | NOT NULL | 4 nós: [fonte, categoria, artigo, ruleId] |
+| source_priority | ENUM('cnae','ncm','nbs','solaris','iagen') | NOT NULL | Fonte menor SOURCE_RANK |
+| confidence | DECIMAL(5,4) | NOT NULL DEFAULT 1.0 | 0.0–1.0 |
+| status | ENUM('active','deleted') | NOT NULL DEFAULT 'active' | Soft delete |
+| approved_by | INT | NULL | — |
+| approved_at | TIMESTAMP | NULL | NULL = pendente |
+| deleted_reason | TEXT | NULL | Obrigatório quando status='deleted' |
+| created_by, updated_by | INT | NOT NULL | — |
+| created_at | TIMESTAMP | NOT NULL DEFAULT NOW() | — |
+| updated_at | TIMESTAMP | NOT NULL DEFAULT NOW() ON UPDATE | — |
+
+Campos RAG (Z-13.5):
+| Coluna | Tipo | Descrição |
+|---|---|---|
+| risk_key | VARCHAR(255) NULL | `{cat}::op:{op}::geo:{mono\|multi}` |
+| operational_context | JSON NULL | Contexto operacional (CNAEs, regime...) |
+| evidence_count | INT NOT NULL DEFAULT 0 | Gaps consolidados neste risco |
+| rag_validated | TINYINT(1) NOT NULL DEFAULT 0 | 1 = validado |
+| rag_confidence | DECIMAL(3,2) NOT NULL DEFAULT 0 | 0.00–1.00 |
+| rag_artigo_exato | VARCHAR(255) NULL | Artigo encontrado no corpus |
+| rag_paragrafo, rag_inciso | VARCHAR(100) NULL | — |
+| rag_trecho_legal | TEXT NULL | Primeiros 500 chars |
+| rag_query | VARCHAR(500) NULL | Query LIKE usada |
+| rag_validation_note | TEXT NULL | Nota de validação |
+
+**Índices:** project_id, status, rule_id.
+
+### 15.2 Tabelas `action_plans` e `tasks` + `audit_log`
+
+**`action_plans`:** prazo ENUM `30_dias|60_dias|90_dias|180_dias`
+(`180_dias` adicionado em `0077_add_180_dias_prazo.sql`). Status ENUM
+`rascunho|aprovado|em_andamento|concluido|deleted` (default `rascunho`).
+
+**`tasks`:** status ENUM `todo|doing|done|blocked|deleted`. Campos
+`data_inicio, data_fim` DATE NULL (migration `0087_tasks_data_inicio_fim.sql`).
+
+**`audit_log`:** entity ENUM `risk|action_plan|task`; action ENUM
+`created|updated|deleted|restored|approved`; `created_at` **imutável**
+(sem `ON UPDATE`). `before_state` obrigatório em `deleted`.
+`reason.length >= 10` em deletes.
+
+---
+
+## 16. Procedures tRPC — risks-v4 router (19 procedures)
+
+Arquivo: `server/routers/risks-v4.ts`
+
+| # | Procedure | Tipo | Sprint | Descrição |
+|---|---|---|---|---|
+| 1 | `generateRisks` | mutation | Z-07 | Pipeline completo: gaps → consolidação → RAG → persist |
+| 2 | `listRisks` | query | Z-07 | Lista riscos ativos com planos/tarefas aninhados |
+| 3 | `getActionPlanSuggestion` | query | Z-07 | Sugestão de plano via LLM |
+| 4 | `deleteRisk` | mutation | Z-07 | Soft delete com cascata |
+| 5 | `restoreRisk` | mutation | Z-07 | Restore (90 dias) |
+| 6 | `approveRisk` | mutation | Z-07 | `approved_at=NOW()` |
+| 7 | `bulkApprove` | mutation | Z-14 #533 | Aprova todos pendentes |
+| 8 | `upsertActionPlan` | mutation | Z-07 | Cria/edita plano |
+| 9 | `deleteActionPlan` | mutation | Z-07 | Soft delete com cascata |
+| 10 | `restoreActionPlan` | mutation | Z-07 | Restore |
+| 11 | `approveActionPlan` | mutation | Z-07 | Aprova + dispara `persistCpieScore` (fire-and-forget) |
+| 12 | `upsertTask` | mutation | Z-07 | Cria/edita tarefa |
+| 13 | `deleteTask` | mutation | Z-07 | Soft delete |
+| 14 | `mapGapsToRules` | mutation | Z-10 | ACL gap → rule |
+| 15 | `generateRisksFromGaps` | mutation | Z-10 | Versão sem LLM de tarefas |
+| 16 | `getAuditLog` | query | Z-07 | Audit log do projeto |
+| 17 | `bulkGenerateActionPlans` | mutation | Z-14 | Planos para todos aprovados |
+| 18 | `getProjectAuditLog` | query | Z-14 | Audit log completo |
+| 19 | `calculateAndSaveScore` | mutation | Z-16 #622 | Score v4 + snapshot |
+
+**Regras implícitas:**
+- `generateRisks` usa concorrência 3 para LLM de tarefas
+- Falhas de tarefa → audit_log (`after_state.error`), sem interromper fluxo
+- `approveActionPlan` não aguarda `persistCpieScore` (assíncrono)
+
+---
+
+## 17. Regras de Negócio — consolidado
+
+### 17.1 RN-RISK (geração)
+
+| Código | Regra | Arquivo |
+|---|---|---|
+| RN-RISK-01 | artigo nunca NULL — vem de GapRule.artigo ou risk_categories.artigo_base | risk-engine-v4.ts |
+| RN-RISK-02 | severidade nunca LLM — sempre de SEVERITY_TABLE ou risk_categories | risk-engine-v4.ts |
+| RN-RISK-03 | categoria nunca LLM — vem de risk_category_code do gap | db-queries-risks-v4.ts |
+| RN-RISK-04 | 1 gap → 1 risco por categoria (N gaps de mesma categoria consolidam) | risk-engine-v4.ts |
+| RN-RISK-05 | type='opportunity' → buildActionPlans retorna [] | action-plan-engine-v4.ts |
+| RN-RISK-06 | ruleId nunca NULL | db-queries-risks-v4.ts |
+| RN-RISK-07 | approved_at=NULL ao criar | 0064 migration |
+| RN-RISK-08 | status='active' ao criar | 0064 DEFAULT |
+| RN-RISK-09 | evidence[] ordenada por SOURCE_RANK crescente | sortBySourceRank |
+| RN-RISK-10 | confidence = ponderada (0.0-1.0) | calcWeightedConfidence |
+
+### 17.2 RN-AP (planos de ação)
+
+| Código | Regra |
+|---|---|
+| RN-AP-01 | risk_id nunca NULL (FK obrigatória) |
+| RN-AP-02 | status inicial = 'rascunho' |
+| RN-AP-03 | titulo.length >= 5 |
+| RN-AP-04 | responsavel obrigatório |
+| RN-AP-05 | prazo ENUM 30/60/90/180_dias |
+| RN-AP-06 | Soft delete (nunca DELETE físico) |
+| RN-AP-07 | Excluir plano → cascata soft delete tarefas |
+| RN-AP-08 | audit_log em toda mutação |
+| RN-AP-09 | type='opportunity' → botão "+ Plano" não renderizado |
+
+**Catálogo canônico de responsáveis:**
+`gestor_fiscal · diretor · ti · juridico · advogado`
+
+### 17.3 RN-TASK (tarefas)
+
+| Código | Regra |
+|---|---|
+| RN-TASK-01 | actionPlanId nunca NULL |
+| RN-TASK-02 | status inicial = 'todo' |
+| RN-TASK-03 | BLOQUEADA (opacity 40%) quando plan.status='rascunho' |
+| RN-TASK-04 | LIBERADA quando plan.status='aprovado' |
+| RN-TASK-05 | Soft delete |
+| RN-TASK-06 | Excluir plano → cascata tarefas |
+| RN-TASK-07 | audit_log em toda mutação |
+| RN-TASK-08 | Progresso = COUNT(done)/COUNT(*) |
+
+**Máquina de estados:**
+```
+todo ↔ doing ↔ done (toggle)
+doing → blocked → todo
+```
+`titulo.length >= 3` (vs >= 5 em planos).
+
+### 17.4 RN-CV4 (score de compliance) — consolidado
+
+Ver §6.2 (Score D) e §7 (fórmula). Pontos críticos:
+- RN-CV4-01: apenas aprovados
+- RN-CV4-02: oportunidades fora do denominador
+- RN-CV4-03: snapshot acumulado (nunca deletado)
+- RN-CV4-04: confidence floor = 0.5
+- RN-CV4-10: `formula_version` registrada em cada snapshot
+- RN-CV4-14: **thresholds divergem entre código e RN (D5)**
+
+---
+
+## 18. Engine — constantes determinísticas (arquivo: `server/lib/risk-engine-v4.ts`)
+
+### 18.1 SEVERITY_TABLE (fallback hardcoded)
+
+```typescript
+imposto_seletivo:     { severity: "alta",         urgency: "imediata"    }
+confissao_automatica: { severity: "alta",         urgency: "imediata"    }
+split_payment:        { severity: "alta",         urgency: "imediata"    }
+inscricao_cadastral:  { severity: "alta",         urgency: "imediata"    }
+regime_diferenciado:  { severity: "media",        urgency: "curto_prazo" }
+transicao_iss_ibs:    { severity: "media",        urgency: "medio_prazo" }
+obrigacao_acessoria:  { severity: "media",        urgency: "curto_prazo" }
+aliquota_zero:        { severity: "oportunidade", urgency: "curto_prazo" }
+aliquota_reduzida:    { severity: "oportunidade", urgency: "curto_prazo" }
+credito_presumido:    { severity: "oportunidade", urgency: "curto_prazo" }
+```
+
+Precedência: DB risk_categories > SEVERITY_TABLE > default `media/curto_prazo`.
+
+### 18.2 SOURCE_RANK
+
+`cnae=1 · ncm=2 · nbs=3 · solaris=4 · iagen=5` — menor = maior prioridade.
+
+### 18.3 TITULO_TEMPLATES
+
+Ver §9.4 (10 títulos já confirmados em 930001). `{op}` substituído por
+`context.tipoOperacao ?? "geral"`.
+
+### 18.4 Inferência Normativa — CNAES hardcoded (`normative-inference.ts`)
+
+```typescript
+CNAES_ALIMENTAR   = { "4639-7/01", "4632-0/01", "4631-1/00", "4634-6/01", "4635-4/01" }
+CNAES_ATACADISTA  = CNAES_ALIMENTAR ∪ { "4637-1/07", "4633-8/01", "4636-2/02" }
+```
+**Regra implícita:** CNAE alimentar é subconjunto de atacadista —
+projeto com CNAE 4639-7/01 recebe 2 riscos inferidos (credito_presumido + regime_diferenciado).
+
+### 18.5 RAG_QUERIES (`rag-risk-validator.ts`)
+
+```
+split_payment        → "split payment"        (~20 hits)
+confissao_automatica → "apuração do IBS"       (~10 hits)
+aliquota_zero        → "cesta básica"          (~5 hits)
+credito_presumido    → "crédito presumido"     (~32 hits)
+obrigacao_acessoria  → "obrigação acessória"   (~7 hits)
+inscricao_cadastral  → "sujeito passivo"       (~74 hits — PROXY)
+transicao_iss_ibs    → "prestação de serviços" (~34 hits — PROXY)
+imposto_seletivo     → "imposto seletivo"      (~54 hits)
+regime_diferenciado  → "regime diferenciado"   (~3 hits)
+aliquota_reduzida    → "alíquota reduzida"     (~8 hits)
+```
+
+**Atenção:** `inscricao_cadastral` e `transicao_iss_ibs` usam proxies —
+o `rag_artigo_exato` retornado pode não ser o mais relevante para essas
+categorias.
+
+### 18.6 Enrichment RAG — fórmula de confidence
+
+**Com hit:**
+- `rag_validated = 1`
+- `rag_confidence = 0.85` (fixo)
+- `confidence_final = confidence_base × 0.8 + 0.85 × 0.2` (blend)
+
+**Sem hit (ou timeout 3s):**
+- `rag_validated = 0`
+- `confidence_final = confidence_base × 0.75` (penalidade 25%)
+- `rag_validation_note = "Base legal não localizada no corpus RAG"`
+
+**Invariante:** risco nunca é bloqueado por falha de RAG.
+
+---
+
+## 19. Frontend — UX atual
+
+### 19.1 RiskDashboardV4 (`client/src/components/RiskDashboardV4.tsx`, 1272 linhas)
+
+- **Abas:** Riscos · Oportunidades · Histórico (`data-testid="history-tab"`)
+- **Filtros:** severidade (todos/alta/media/oportunidade) + categoria (10 categorias)
+- **Summary Bar** (`data-testid="summary-bar"`): `summary-count-alta | summary-count-media | summary-count-oportunidade`
+- **Botão "Ver Planos de Ação"** (`btn-ver-planos`) — Z-17 #668:
+  - Habilitado se pelo menos 1 risco aprovado
+  - Desabilitado se nenhum aprovado
+  - Oculto se 0 riscos
+- **Breadcrumb4** cores: fonte=azul · categoria=roxo · artigo=verde · ruleId=cinza
+- **RAG Badge:** `rag-badge-validated` (rag_validated=1) ou `rag-badge-pending` (=0)
+- **Aprovação:** botão `approve-risk-button` + `bulk-approve-button`
+
+### 19.2 ActionPlanPage (`client/src/pages/ActionPlanPage.tsx`, 1216 linhas)
+
+- **Traceability Banner** (`traceability-banner`): 5 chips `[fonte › cat › art › ruleId › risco]`
+- **Lock tarefas:** `isLocked = plan.status === 'rascunho'` → `pointer-events:none, opacity:40%`
+- **Ordenação tarefas:** overdue → todo → doing → blocked → done → deleted; dentro de cada grupo por `data_fim` crescente
+- **Overdue:** `task.data_fim < today` AND status ≠ done/deleted
+- **Botão "Ver Consolidação"** (`btn-ver-consolidacao`) — Sprint Z-19 #712 (PR #714 aberto)
+- **Botão "Exportar PDF"** (`btn-exportar-pdf-planos`) — gera via jsPDF no browser
+
+### 19.3 ConsolidacaoV4 (`client/src/pages/ConsolidacaoV4.tsx`)
+
+- **KPIs:** `kpi-score · kpi-alta · kpi-media`
+- **Compliance Score Card:** chama `trpc.risksV4.calculateAndSaveScore` no mount
+- **Disclaimer** (`disclaimer-box`) obrigatório no topo
+- **Timeline Reforma:** marcos `2026 / 2027 / 2029 / 2033` (hardcoded — D6)
+
+### 19.4 Artefatos produzidos no fluxo E2E
+
+| # | Artefato | Tabela/Campo | Gerado por | Destinatário |
+|---|---|---|---|---|
+| 1 | Respostas questionários | solaris_answers, iagen_answers | Usuário | Sistema |
+| 2 | Gaps de compliance | project_gaps_v3 | Gap Engine | Sistema |
+| 3 | Briefing aprovado | projects.briefingData | LLM + RAG | Advogado |
+| 4 | Matriz de Riscos | risks_v4 | Pipeline v4 (determinístico) | Advogado |
+| 5 | Planos + Tarefas | action_plans + tasks | LLM + manual | Advogado |
+| 6 | Score de Compliance | projects.scoringData | calculateComplianceScore | Sistema |
+| 7 | PDF Diagnóstico | arquivo local | jsPDF (browser) | Cliente final |
+| 8 | Audit Log | audit_log | Toda mutação | Auditoria fiscal |
+
+---
+
+## 20. Cascata de Soft Delete
+
+```
+Excluir RISCO (deleteRisk):
+  risks_v4.status='deleted', deleted_reason=reason
+  → action_plans WHERE risk_id=? → status='deleted'
+  → tasks WHERE action_plan_id IN (...) → status='deleted'
+  audit_log: entity='risk', action='deleted', before_state, reason
+
+Excluir PLANO (deleteActionPlan):
+  action_plans.status='deleted'
+  → tasks WHERE action_plan_id=? → status='deleted'
+  audit_log: entity='action_plan', action='deleted'
+
+Excluir TAREFA (deleteTask):
+  tasks.status='deleted' (nível folha, sem cascata)
+  audit_log: entity='task', action='deleted'
+
+Restaurar RISCO (restoreRisk):
+  risks_v4.status='active'
+  → action_plans: status restaurado
+  → tasks: status restaurado
+  (RI-07: sem granularidade — restaura TODOS os filhos)
+```
+
+---
+
+## 21. Testes existentes + lacunas
+
+### 21.1 Unit (Vitest)
+
+| Arquivo | Blocos | Casos |
+|---|---|---|
+| `server/lib/risk-engine-v4.test.ts` | A-F | 16 (classifyRisk, breadcrumb, sortBySourceRank, computeRiskMatrix, getRiskCategories, consolidateRisks) |
+| `server/lib/rag-risk-validator.test.ts` | T-04 | 3 (import, tipos, penalidade) |
+| `server/routers/scoringEngine.test.ts` | T-B8-01..10 | 10 (CPIE-B, dimensões, maturidade) |
+
+### 21.2 E2E (Playwright)
+
+| Arquivo | Casos | Cobertura |
+|---|---|---|
+| `tests/e2e/z14-risk-action-plan.spec.ts` | CT-01..09 | Dashboard, cards, aprovação, oportunidade sem plano |
+| `tests/e2e/z17-pipeline-completo.spec.ts` | CT-01..20 | Pipeline E2E: questionários → riscos → planos → tarefas |
+| `tests/e2e/action-plan-ui-refinements.spec.ts` | CT-01..16 | Sprint Z-19 (PR #714) |
+| `tests/e2e/pdf-consolidacao.spec.ts` | — | PDF |
+
+### 21.3 Lacunas (candidatas a testes da suite "planejado × realizado")
+
+- Sem unit para `normative-inference.ts`
+- Sem unit para `generate-risks-pipeline.ts`
+- Sem unit para `compliance-score-v4.ts`
+- Sem E2E para `ConsolidacaoV4.tsx`
+- Sem teste de cascata soft delete (risco → planos → tarefas)
+
+---
+
+## 22. Regras Implícitas Detectadas (12 RIs — do inventário Manus)
+
+| ID | Regra | Arquivo | Impacto |
+|---|---|---|---|
+| RI-01 | `CATEGORIA_ARTIGOS` frontend diverge do seed | RiskDashboardV4.tsx | **Médio — D7** |
+| RI-02 | Cache de categorias TTL 1h — delay de propagação | risk-engine-v4.ts | Baixo |
+| RI-03 | `risk_key` não inclui project_id — único só por projeto | risk-engine-v4.ts | Baixo |
+| RI-04 | Score só calcula ao visitar ConsolidacaoV4 | ConsolidacaoV4.tsx | **Médio — lacuna UI** |
+| RI-05 | Score CPIE-B (v3) e Score v4 coexistem sem sync | scoringEngine.ts vs compliance-score-v4.ts | Médio |
+| RI-06 | `MAX_PESO=9` → score 100% matematicamente impossível (cap ~77.8%) | compliance-score-v4.ts | Confirmar intenção com P.O. |
+| RI-07 | Restore de risco restaura TODOS os filhos (sem granularidade) | risks-v4.ts | Baixo |
+| RI-08 | CNAES_ALIMENTAR ⊂ CNAES_ATACADISTA — projeto alimentar recebe 2 inferências | normative-inference.ts | Intencional não documentado |
+| RI-09 | `inscricao_cadastral` e `transicao_iss_ibs` usam proxies RAG | rag-risk-validator.ts | Baixo (artigo pode não ser melhor match) |
+| RI-10 | Falha LLM de tarefa não interrompe fluxo — só audit_log | risks-v4.ts | Risco: plano sem tarefas silencioso |
+| RI-11 | Prazo `180_dias` adicionado depois (0077) — código legado pode quebrar | 0077_add_180_dias | Auditar uso legado |
+| RI-12 | Título "nas operações de geral" quando tipoOperacao=null | risk-engine-v4.ts | Violação Gate 7 P3 se ocorrer |
+
+---
+
+## 23. Pendências consolidadas (ordenadas por prioridade)
+
+### P0 — Bloqueadores antes da liberação para advogados
+
+- **P0.1** Expor Compliance Score v4 no RiskDashboardV4 (DEC-01)
+- **P0.2** Resolver D5 (thresholds código × RN) — decisão P.O. sobre bypass totalAlta
+- **P0.3** Concluir auditoria dos 12 bugs UAT Gate E "a verificar" (§10)
+- **P0.4** Executar queries Q1-Q6 de rastreabilidade (§13.4) no 930001
+
+### P1 — Alinhamento pós-snapshot (PR de governança)
+
+- **P1.1** Remover `tributacao_servicos` do RN_GERACAO_RISCOS_V4.md:92 (D2)
+- **P1.2** Atualizar `inscricao_cadastral` para "alta" no RN_GERACAO_RISCOS (D3)
+- **P1.3** Atualizar timeline 2032 → 2033 no RN_CONSOLIDACAO_V4 §4.9 (D6)
+- **P1.4** Remover `CATEGORIA_ARTIGOS` hardcoded do frontend (D7)
+- **P1.5** PR de thresholds código conforme decisão P.O. (D5)
+
+### P2 — Débitos técnicos conhecidos
+
+- **P2.1** PR #E — reconciliar CPIE-B (scoringEngine) com engine v4 (ADR-0023)
+- **P2.2** Verificar unicidade por categoria (§9.5 V5) em projetos com `multiestadual` alternado
+- **P2.3** `PENDENCIA_RAG_EXPANSAO_NCM_NBS.md` (Manus §23 P-05)
+
+### P3 — Suite de testes (4 camadas)
+
+- **P3.1** Unit: `risk-engine-v4.afericao.test.ts`
+- **P3.2** Unit: `compliance-score-v4.test.ts` (ausente)
+- **P3.3** Unit: `normative-inference.test.ts` (ausente)
+- **P3.4** Integration: `generate-risks-pipeline.integration.test.ts`
+- **P3.5** Script: `scripts/audit-risk-matrix.mjs` (aferição real)
+- **P3.6** Script: `scripts/categoria-drift-check.mjs` (DB × código × RN)
+- **P3.7** E2E: `risk-matrix-audit.spec.ts`
+- **P3.8** E2E: `consolidacao-v4.spec.ts` (ausente)
+- **P3.9** E2E: cascata soft delete
+
+---
+
+## 24. Sinalização de pendências abertas para P.O.
+
+Antes da próxima iteração, o P.O. precisa decidir:
+
+1. **D5 — thresholds de score**: seguir RN (70/50/30 + bypass totalAlta) ou código (75/50/25 sem bypass)?
+2. **RI-06 — cap ~77.8%**: design intencional ou bug?
+3. **Aprovar P0.1-P0.4** para iniciar suite de testes
+4. **Ordem de P1**: fazer 1 PR consolidado (5 docs) ou PRs separados?
+
+---
+
+*IA SOLARIS · Snapshot de Matriz de Riscos · 2026-04-18*
+*Documento imutável — novas versões geram novo arquivo datado*
+*Baseline + Inventário consolidado (24 seções · ~1400 linhas)*
+*Status: aguardando aprovação P.O. para liberar suite de testes*

--- a/docs/specs/SPEC-TESTE-MATRIZ-RISCOS-v1.md
+++ b/docs/specs/SPEC-TESTE-MATRIZ-RISCOS-v1.md
@@ -1,0 +1,642 @@
+# SPEC — Suite de Testes: Matriz de Riscos v4
+
+## IA SOLARIS · Compliance Tributário v2
+## Versão 1.0 · 2026-04-18 · Audiência: P.O. · Orquestrador · Claude Code · Manus
+## Baseline: `docs/governance/MATRIZ_RISCOS_SNAPSHOT_2026-04-18.md` (1628 linhas)
+
+---
+
+## Contexto
+
+A Matriz de Riscos v4 é o artefato central de compliance do produto
+IA SOLARIS. A meta declarada pelo P.O. (DEC-06 do snapshot) é **98%
+de confiabilidade jurídica antes da liberação para advogados**.
+
+Esta spec define uma suite de testes **em 4 baterias iterativas**,
+com correções entre cada bateria, seguida de teste manual com caso
+real fornecido pelos advogados.
+
+**Princípio da suite:**
+- Manus roda testes **em background**
+- Manus alimenta o relatório de progresso **durante** a execução
+  (não após) — P.O. acompanha em tempo real
+- Cada bateria produz achados → correções → próxima bateria
+- Sem pressa: trabalho minucioso, 98% é o piso
+
+---
+
+## Bloco 1 — Fluxo declarado (ORQ-13)
+
+**Step:** N/A — trilha de qualidade paralela ao fluxo de produto
+**Upstream:** Snapshot aprovado (`MATRIZ_RISCOS_SNAPSHOT_2026-04-18.md`)
+  + baseline do projeto 930001 documentada em §9 do snapshot
+**Downstream:** Liberação para UAT com advogados (teste manual P.O.
+  com caso real) → GO/NO-GO para produção
+
+**Integrações obrigatórias (triggers automáticos):**
+- TiDB Cloud (`DATABASE_URL`) — leitura de `risks_v4`, `risk_categories`,
+  `project_gaps_v3`, `solaris_answers`, `iagen_answers`, `audit_log`
+- Corpus RAG (`ragDocuments`) — validação de `rag_validated`
+- audit_log — testes NÃO devem gerar lixo de auditoria em produção
+  (usar projeto dedicado de testes destrutivos)
+
+---
+
+## Bloco 2 — UX Spec
+
+**ISENÇÃO ORQ-16:** esta é spec de **teste**, não de UI. Não há
+componente frontend a validar contra mockup. O único artefato
+visual é o **relatório de progresso** (`progress.md`), cujo
+formato é definido no Bloco 5.
+
+Nenhum `data-testid` novo introduzido (Bloco 9 consolida os
+existentes que serão cobertos pelos testes E2E).
+
+---
+
+## Bloco 3 — Skeleton (arquivos a criar ou modificar)
+
+### 3.1 Arquivos NOVOS (9)
+
+| # | Arquivo | Propósito |
+|---|---|---|
+| 1 | `server/lib/risk-engine-v4.afericao.test.ts` | Unit — complementa `risk-engine-v4.test.ts` com 10 critérios do snapshot §13.5 |
+| 2 | `server/lib/compliance-score-v4.test.ts` | Unit — atualmente AUSENTE, testa fórmula + thresholds |
+| 3 | `server/lib/normative-inference.test.ts` | Unit — atualmente AUSENTE, testa CNAES_ALIMENTAR/ATACADISTA + regras NCM |
+| 4 | `server/lib/generate-risks-pipeline.integration.test.ts` | Integração — pipeline completo com DB real |
+| 5 | `scripts/audit-risk-matrix.mjs` | Aferição evidence-based do projeto 930001 |
+| 6 | `scripts/categoria-drift-check.mjs` | Drift-check DB × código × RN |
+| 7 | `tests/e2e/risk-matrix-audit.spec.ts` | E2E — cobertura dos 21 bugs UAT Gate E |
+| 8 | `tests/e2e/consolidacao-v4.spec.ts` | E2E — ausente, cobre fluxo Step 7 |
+| 9 | `tests/e2e/soft-delete-cascade.spec.ts` | E2E — cascata risco → planos → tarefas |
+
+### 3.2 Arquivos MODIFICADOS (3)
+
+| # | Arquivo | Mudança |
+|---|---|---|
+| 10 | `package.json` | Adicionar scripts: `test:battery-1`, `test:battery-2`, `test:battery-3`, `test:battery-4`, `test:battery-full`, `test:afericao`, `test:drift` |
+| 11 | `vitest.config.ts` | Custom reporter para alimentar `progress.md` em tempo real |
+| 12 | `.gitignore` | Adicionar `reports/` (relatórios locais não commitados) |
+
+### 3.3 Arquivos de governança (2)
+
+| # | Arquivo | Propósito |
+|---|---|---|
+| 13 | `docs/governance/TEST_PROGRESS_TEMPLATE.md` | Template do `progress.md` |
+| 14 | `docs/governance/CASO_REAL_UAT_CHECKLIST.md` | Checklist para teste manual pós-bateria 4 |
+
+### 3.4 Estrutura de diretórios criada
+
+```
+reports/                          (novo, .gitignored)
+├── battery-1/
+│   ├── progress.md               (alimentado em tempo real)
+│   ├── final.md                  (commitado ao final da bateria)
+│   ├── unit-coverage.json
+│   ├── integration-evidence.json
+│   ├── afericao-930001.md
+│   └── e2e-screenshots/
+├── battery-2/ ...
+├── battery-3/ ...
+└── battery-4/ ...
+
+scripts/
+├── audit-risk-matrix.mjs         (novo)
+├── categoria-drift-check.mjs     (novo)
+└── run-battery.mjs               (orquestrador shell — novo)
+```
+
+---
+
+## Bloco 4 — Schema
+
+**Nenhuma mudança de banco.** Todos os testes leem estado atual.
+
+**Tabelas lidas (read-only):**
+- `risks_v4` · `risk_categories` · `project_gaps_v3`
+- `solaris_answers` · `solaris_questions`
+- `iagen_answers`
+- `regulatory_requirements_v3`
+- `ragDocuments`
+- `action_plans` · `tasks` · `audit_log`
+- `projects` (para `scoringData` e `profileCompleteness`)
+
+**Projeto de referência:** `930001` (leitura)
+**Projeto de testes destrutivos:** a definir pelo Orquestrador
+  (criar via `trpc.createProject` com `test_` no nome)
+
+---
+
+## Bloco 5 — Contrato de saída
+
+### 5.1 Formato do `progress.md` (alimentado em tempo real pelo Manus)
+
+```markdown
+# Bateria N — Progresso em tempo real
+
+**Iniciada em:** 2026-04-XX HH:MM:SS
+**Branch:** test/z20-bateria-N
+**Executor:** Manus (background task)
+**Status:** running | passed_partial | failed | completed
+
+## 1. Unit tests (engine puro)
+
+| Teste | Status | Timestamp | Evidência |
+|---|---|---|---|
+| engine.SEVERITY_TABLE.10_categorias | ✅ PASS | 14:23:01 | — |
+| engine.SOURCE_RANK.ordem | ✅ PASS | 14:23:02 | — |
+| engine.classifyRisk.inscricao_cadastral_alta | ⏳ RUNNING | 14:23:03 | — |
+| engine.classifyRisk.tributacao_servicos_ausente | ❌ FAIL | 14:23:04 | TypeError: enum mismatch |
+| ... | | | |
+
+**Subtotal Unit:** X PASS · Y FAIL · Z PENDING
+
+## 2. Integration tests (DB + pipeline)
+...
+
+## 3. Aferição 930001 (10 critérios §13.5 snapshot)
+
+| # | Critério | Status | Evidência |
+|---|---|---|---|
+| 1 | Todo risco tem origem (rule_id NOT NULL) | ✅ PASS | 10/10 |
+| 2 | Toda categoria veio de ≥1 onda | ⏳ RUNNING | — |
+| ... | | | |
+
+## 4. Regression E2E (21 bugs UAT Gate E)
+
+| Bug | CT | Status | Screenshot |
+|---|---|---|---|
+| B-01 | Geração automática pós-briefing | ✅ PASS | — |
+| B-06 | Summary bar 4 cards | ❌ FAIL | battery-1/e2e-screenshots/B-06-fail.png |
+| ... | | | |
+
+## 5. Drift check (categoria-drift-check.mjs)
+
+| Diff | Fonte A | Fonte B | Diff detectado |
+|---|---|---|---|
+| DB × código | 10 rows DB | 10 entries SEVERITY_TABLE | (listar divergências) |
+| RN × código | 11 menções | 10 entries | `tributacao_servicos` órfã |
+| ... | | | |
+
+## Resumo
+
+- **Total:** X PASS · Y FAIL · Z PENDING
+- **Gaps encontrados:** N
+- **Pronto para próxima bateria:** SIM / NÃO
+- **Recomendação:** (texto automático baseado nos thresholds do Bloco 7)
+
+---
+*Atualizado automaticamente a cada teste. Última linha adicionada em: TIMESTAMP*
+```
+
+### 5.2 Formato do `final.md` (commitado ao final da bateria)
+
+Mesmo conteúdo do `progress.md` final, mais:
+- Diff entre baterias (o que melhorou, o que regrediu)
+- Lista priorizada de correções recomendadas
+- Estimativa de esforço por correção
+
+### 5.3 Tempo real — regra de alimentação
+
+**Manus DEVE:**
+1. Escrever cada resultado de teste **dentro de 2 segundos** da conclusão
+2. Nunca buffer em memória sem flush — um crash não pode perder progresso
+3. Usar append, não rewrite — escrever nova linha ao final
+4. Commitar `progress.md` a cada 10 testes OU a cada 5 minutos (o que vier primeiro)
+5. Ao final: renomear `progress.md` → `progress-final.md` e criar `final.md` curado
+
+**P.O. DEVE conseguir:**
+- Abrir `reports/battery-N/progress.md` a qualquer momento e ver estado corrente
+- Ver timestamp da última atualização (ao final do arquivo)
+- Não esperar bateria terminar para começar a discussão sobre correções
+
+---
+
+## Bloco 6 — Estado atual (comandos a executar antes)
+
+```bash
+# Confirma branch e HEAD
+git fetch origin && git log origin/main --oneline -1
+
+# Confirma que snapshot foi mergeado (pré-requisito)
+ls docs/governance/MATRIZ_RISCOS_SNAPSHOT_2026-04-18.md
+
+# Confirma arquivos de teste já existentes (para não duplicar)
+ls server/lib/risk-engine-v4.test.ts
+ls server/lib/rag-risk-validator.test.ts
+ls server/routers/scoringEngine.test.ts
+ls tests/e2e/z14-risk-action-plan.spec.ts
+ls tests/e2e/z17-pipeline-completo.spec.ts
+
+# Confirma pendências documentadas
+grep -n "ausente" docs/governance/MATRIZ_RISCOS_SNAPSHOT_2026-04-18.md | head -5
+
+# DB connection sanity
+echo "SELECT COUNT(*) FROM risks_v4 WHERE project_id=930001;" | # execute via Manus
+```
+
+**Esperado:**
+- HEAD em `main` contendo o snapshot mergeado
+- 3 testes unit existem (risk-engine-v4, rag-risk-validator, scoringEngine)
+- 4 testes E2E existem (z14, z17, action-plan-ui-refinements, hub-hotswap)
+- Pendências §21.3 confirmam: compliance-score-v4, normative-inference, consolidacao-v4, soft-delete → **ausentes**
+
+---
+
+## Bloco 7 — Critérios de aceite (por bateria)
+
+### Bateria 1 — Baseline (primeira passada)
+
+**Objetivo:** fotografar o estado real vs esperado. Vai falhar muito —
+esse é o ponto.
+
+**Gates:**
+- [ ] G1.1: Todos os 9 arquivos novos compilam sem erro
+- [ ] G1.2: Unit tests executam (pass/fail registrado para todos)
+- [ ] G1.3: Integration tests executam com DATABASE_URL válido
+- [ ] G1.4: Aferição 930001 produz 10 linhas (mesmo que todas FAIL)
+- [ ] G1.5: E2E executa 21 CTs (mesmo que falhem)
+- [ ] G1.6: `progress.md` alimentado em tempo real (evidência: diff
+  entre 2 leituras com intervalo de 1 min mostra linhas adicionadas)
+- [ ] G1.7: `final.md` gerado e commitado
+
+**Mínimo aceitável para avançar:**
+- ≥ 50% dos unit tests PASS
+- ≥ 30% dos integration tests PASS
+- ≥ 5/10 critérios de aferição PASS
+- ≥ 10/21 bugs UAT verificados (mesmo que 5 permaneçam abertos)
+
+**Ação se gates falharem:**
+- Se G1.1 FAIL: correções de sintaxe/imports antes de qualquer bateria
+- Se G1.6 FAIL: reescrever reporter do vitest — tempo real é inegociável
+
+---
+
+### Bateria 2 — Pós-primeiras correções
+
+**Pré-condição:** Orquestrador despachou correções dos gaps da Bateria 1.
+
+**Gates:**
+- [ ] G2.1: Todos os gaps prioritários (P0) da Bateria 1 corrigidos
+- [ ] G2.2: ≥ 80% unit tests PASS
+- [ ] G2.3: ≥ 70% integration tests PASS
+- [ ] G2.4: ≥ 8/10 critérios de aferição PASS
+- [ ] G2.5: ≥ 17/21 bugs UAT verificados como resolvidos
+- [ ] G2.6: Drift check: zero divergências críticas entre DB × código
+- [ ] G2.7: `progress.md` mostra que todos os testes rodaram
+
+**Mínimo aceitável para avançar:**
+- Todos acima simultaneamente
+
+---
+
+### Bateria 3 — Estabilização
+
+**Pré-condição:** Orquestrador despachou correções da Bateria 2.
+
+**Gates:**
+- [ ] G3.1: 100% unit tests PASS
+- [ ] G3.2: 100% integration tests PASS
+- [ ] G3.3: 10/10 critérios de aferição PASS
+- [ ] G3.4: 21/21 bugs UAT verificados
+- [ ] G3.5: Zero flaky tests em 3 execuções consecutivas (critério
+  anti-intermitência)
+- [ ] G3.6: Drift check: zero divergências (DB × código × RN
+  alinhados após PRs de governança P1)
+- [ ] G3.7: Compliance Score visível no RiskDashboardV4 (DEC-01)
+
+---
+
+### Bateria 4 — Validação final
+
+**Pré-condição:** Bateria 3 aprovada.
+
+**Gates:**
+- [ ] G4.1: Tudo da Bateria 3 mantém-se PASS
+- [ ] G4.2: 1 projeto real (fornecido pelo advogado) processado
+  end-to-end sem erros
+- [ ] G4.3: Relatório entregue ao P.O. com:
+  - Tempo total de processamento por etapa
+  - Cobertura das 10 categorias no projeto real
+  - Rag_validated ≥ 50% no projeto real
+  - Breadcrumb 4 nós em 100% dos riscos
+- [ ] G4.4: P.O. aprova explicitamente a passagem para teste manual
+
+---
+
+### Pós-Bateria 4 — Teste manual P.O.
+
+Executado pelo próprio P.O. com caso real dos advogados. Fora do
+escopo da suite automatizada. Checklist em
+`docs/governance/CASO_REAL_UAT_CHECKLIST.md`.
+
+---
+
+## Bloco 8 — Armadilhas conhecidas
+
+1. **LIMIT ? em queries TiDB falha silenciosamente.**
+   Usar `LIMIT ${Math.max(1, Math.min(500, n))}` — interpolação
+   com clamp. Regra documentada em `.claude/rules/database.md`.
+
+2. **DATABASE_URL ausente = testes silenciosamente passam com mock vazio.**
+   O runner deve abortar explicitamente se `DATABASE_URL` não estiver
+   setada ao rodar integration/aferição. Nunca fallback para vazio.
+
+3. **930001 é projeto compartilhado — NÃO MUTAR.**
+   Apenas SELECTs. Para testes destrutivos (deleteRisk,
+   deleteActionPlan): criar projeto novo com prefixo `test_bateria_N_`.
+
+4. **Vitest reporter customizado pode quebrar em testes paralelos.**
+   Usar lock de arquivo ao fazer append ao `progress.md`
+   (`proper-lockfile` ou equivalente).
+
+5. **RAG timeout de 3s em testes de integração é flaky.**
+   Aumentar para 10s em testes; nunca remover o timeout (viola
+   contrato do pipeline).
+
+6. **Score D tem fórmula diferente entre código e RN (D5 do snapshot).**
+   Teste deve verificar a fórmula do **código** (é o runtime), mas
+   reportar a divergência com a RN no relatório — decisão P.O.
+   antes de alinhar (já registrada como pendência P1.5).
+
+7. **Projetos com perfil incompleto geram título "nas operações de geral"**
+   (RI-12 do snapshot). Gate 7 P3 falha se ocorrer. Teste deve
+   cobrir esse caso com projeto cujo perfil tem `tipoOperacao=NULL`.
+
+8. **Cascade de soft delete pode deixar audit_log órfão.**
+   Verificar em E2E de cascata que `audit_log.before_state` contém
+   o estado pré-delete completo, não apenas referências.
+
+9. **Manus não pode travar se 1 teste falhar — deve continuar.**
+   Qualquer teste com erro vira `FAIL` no relatório, não aborta a bateria.
+
+10. **audit_log é permanente — não limpar entre baterias.**
+    O teste de produção fica poluído se limpar. Usar projeto de
+    testes dedicado.
+
+---
+
+## Bloco 9 — data-testid (cobertura E2E)
+
+### Existentes (verificar com grep — já implementados)
+
+```
+# RiskDashboardV4
+summary-bar · summary-count-alta · summary-count-media · summary-count-oportunidade
+btn-ver-planos · approve-risk-button · bulk-approve-button
+rag-badge-validated · rag-badge-pending · history-tab
+
+# ActionPlanPage
+traceability-banner · new-plan-button · plan-title-input
+plan-responsavel-select · plan-prazo-select
+task-edit-modal · task-delete-modal · task-overdue-indicator
+btn-ver-consolidacao · btn-ver-consolidacao-top · btn-exportar-pdf-planos
+history-tab · audit-log
+
+# ConsolidacaoV4
+compliance-score-card · kpi-score · kpi-alta · kpi-media
+kpi-riscos-aprovados · kpi-planos · kpi-tarefas
+tabela-riscos-aprovados · risk-row · secao-oportunidades
+disclaimer-box · btn-download-pdf
+```
+
+### Novos necessários para os E2E desta spec
+
+```
+# risk-matrix-audit.spec.ts — aferição visual
+audit-summary-total · audit-summary-by-severity · audit-summary-by-category
+
+# soft-delete-cascade.spec.ts
+deleted-risk-card · restored-risk-card
+cascade-indicator-plans · cascade-indicator-tasks
+
+# consolidacao-v4.spec.ts (se não existirem)
+secao-riscos-desconsiderados · risco-desconsiderado-row
+secao-planos · plano-row · plano-tarefas-lista
+timeline-reforma · proximo-passo-box
+```
+
+**Gap gerenciado:** se algum `data-testid` novo não existir no
+componente, a suite deve falhar com mensagem clara citando a linha
+faltante — Claude Code corrige via PR antes de avançar.
+
+---
+
+## ADR — Decisões arquiteturais
+
+### ADR-TST-01 — 4 baterias iterativas em vez de 1 execução única
+
+**Contexto:** A meta de 98% de confiabilidade é difícil de atingir em
+uma única passada. Os 12 bugs hotfix do Z-17 e os 21 bugs UAT Gate E
+demonstram que a primeira execução sempre revela gaps não previstos.
+
+**Decisão:** 4 baterias com correções entre cada. Cada bateria tem
+thresholds progressivamente mais exigentes (50% → 80% → 100% →
+caso real).
+
+**Alternativas rejeitadas:**
+- (a) 1 execução única: maximiza pressão para perfeição na primeira
+  vez — gera atalhos perigosos.
+- (b) 2 baterias: pouco espaço para amadurecer correções finas.
+- (c) 5+ baterias: diminishing returns; fadiga do P.O.
+
+**Consequências:** tempo total maior (estimado 2-4 sprints), mas
+qualidade final mais alta. Cada bateria produz um commit datado
+que serve como histórico de evolução da qualidade.
+
+---
+
+### ADR-TST-02 — Aferição evidence-based complementa pass/fail
+
+**Contexto:** Testes tradicionais retornam PASS/FAIL. Para os 10
+critérios de confiabilidade do §13.5 do snapshot, isso é insuficiente
+— o P.O. precisa ver **porquê** passou ou falhou.
+
+**Decisão:** Criar script `scripts/audit-risk-matrix.mjs` que,
+além de PASS/FAIL, imprime:
+- Planejado (o que a regra diz)
+- Realizado (o que o DB/código mostra)
+- Delta (diferença quantitativa se aplicável)
+
+**Alternativas rejeitadas:**
+- Só pass/fail: obriga P.O. a debuggar para entender o motivo.
+- Screenshot: não funciona para dados tabulares.
+
+**Consequências:** aferição demora mais para rodar (~30s por critério),
+mas permite ação imediata do Orquestrador ao ler o relatório.
+
+---
+
+### ADR-TST-03 — Relatório alimentado em tempo real
+
+**Contexto:** P.O. explicitou: "Manus deve alimentar o relatório
+durante os testes, não depois." Padrão atual de Vitest/Playwright
+é bufferizado — só escreve ao final.
+
+**Decisão:** Custom reporter do Vitest que:
+1. Implementa `onTestFinished` hook
+2. Faz append ao `progress.md` com lock de arquivo
+3. Flush imediato (sem bufferização)
+
+Para Playwright E2E: wrapper shell script que captura output
+linha a linha e escreve em progress.md.
+
+**Alternativas rejeitadas:**
+- Polling do log por P.O.: funciona mas incentiva bufferização pelo runner.
+- Dashboard web: overengineering para 4 baterias.
+
+**Consequências:** reporter customizado adiciona complexidade.
+Risk de quebra em testes muito paralelos. Mitigação: lock de arquivo
++ testes serializados na aferição (Vitest `--no-file-parallelism`).
+
+---
+
+## Contrato (Bloco 5 API)
+
+**Nenhuma nova procedure tRPC.** Testes consomem procedures existentes:
+
+| Procedure | Uso |
+|---|---|
+| `trpc.risksV4.listRisks` | Aferição + E2E |
+| `trpc.risksV4.getProjectAuditLog` | E2E de audit_log |
+| `trpc.risksV4.approveRisk` | E2E de aprovação |
+| `trpc.risksV4.deleteRisk` | E2E de soft delete |
+| `trpc.risksV4.calculateAndSaveScore` | E2E ConsolidacaoV4 |
+| `trpc.risksV4.generateRisks` | Integration test do pipeline |
+
+**Outputs da spec:**
+- `reports/battery-N/progress.md` (tempo real)
+- `reports/battery-N/final.md` (ao final)
+- `reports/battery-N/afericao-930001.md` (ao rodar aferição)
+- `reports/battery-N/e2e-screenshots/*.png` (falhas Playwright)
+
+---
+
+## Fluxo E2E (da suite de testes, não do produto)
+
+```
+1. P.O. aprova esta spec
+   ↓
+2. Orquestrador cria issue #N com spec
+   Atribui labels: spec-bloco9, spec-adr, spec-contrato, spec-e2e, spec-aprovada
+   Cria milestone "Sprint Z-20 — Suite de Testes"
+   ↓
+3. Orquestrador despacha Claude Code (F6 implementação)
+   Claude Code cria branch test/z20-suite-matriz-riscos
+   Claude Code implementa os 14 arquivos (9 novos + 3 modificados + 2 governance)
+   Claude Code commita e abre PR
+   ↓
+4. Orquestrador despacha Manus (bateria 1 — background)
+   Manus executa: pnpm test:battery-1 em background
+   Manus alimenta reports/battery-1/progress.md em tempo real
+   Manus commita snapshots do progress.md a cada 10 testes
+   Manus avisa Orquestrador quando progress.md atinge "status: completed"
+   ↓
+5. P.O. lê reports/battery-1/final.md
+   P.O. identifica gaps prioritários (lista rebaixada por severidade)
+   P.O. retorna ao Orquestrador: "corrigir X, Y, Z"
+   ↓
+6. Orquestrador despacha Claude Code (F6 correções Bateria 1)
+   Claude Code aplica fixes
+   Claude Code commita incremento
+   ↓
+7. Orquestrador despacha Manus (Bateria 2)
+   Repete passo 4 em reports/battery-2/
+   ↓
+8. P.O. + Orquestrador repetem ciclo até Bateria 4 PASS
+   ↓
+9. P.O. executa teste manual com caso real do advogado
+   Usa docs/governance/CASO_REAL_UAT_CHECKLIST.md
+   ↓
+10. P.O. aprova GO/NO-GO para UAT externa com advogados
+```
+
+---
+
+## O que NÃO entra nesta spec (explícito)
+
+1. **Mudanças de lógica de negócio** — suite apenas AFERE.
+   Correções detectadas geram issues separadas.
+
+2. **Testes de performance/load** — escopo Z-21+.
+
+3. **Testes de segurança** — escopo separado (pentest).
+
+4. **Fixação dos 12 bugs UAT Gate E "a verificar" do snapshot §10.2** —
+   apenas VERIFICA se estão fechados. Correções viram PRs separados.
+
+5. **PR #E (reconciliação CPIE-B v4)** — débito ADR-0023 permanece.
+   Suite registra impacto mas não resolve.
+
+6. **Frontend novo** — nenhum componente UI criado. Score v4
+   visível na matriz (DEC-01) é escopo de spec separada Z-20+.
+
+---
+
+## Condição de merge — ESPECIAL Z-20 (suite de testes)
+
+Fluxo de aceite em 6 etapas (mais rigoroso que o padrão):
+
+```
+ETAPA 1 — Implementação dos 14 arquivos (Claude Code)
+ETAPA 2 — Bateria 1 executada pelo Manus em background
+          + progress.md alimentado em tempo real (validado por P.O.)
+ETAPA 3 — Correções Bateria 1 + Bateria 2
+ETAPA 4 — Correções Bateria 2 + Bateria 3 (100% PASS)
+ETAPA 5 — Bateria 4 com caso real do advogado
+ETAPA 6 — Aprovação explícita P.O. após teste manual
+
+Merge da PR da spec só acontece em ETAPA 6.
+Cada bateria intermediária é commitada mas PR permanece OPEN.
+```
+
+**Nunca mergear antes da aprovação explícita P.O. após ETAPA 6.**
+Mesmo com todos os gates PASS.
+
+---
+
+## Pendências bloqueadoras (antes da aprovação da spec)
+
+O Orquestrador precisa validar com o P.O. antes de abrir issue:
+
+1. **D5 do snapshot (thresholds score):** seguir RN (70/50/30 + bypass
+   totalAlta) ou código (75/50/25 sem bypass)? A Bateria 3 não
+   pode passar em 10/10 critérios sem essa decisão.
+
+2. **RI-06 (cap ~77.8% do score):** design intencional ou bug?
+   Se bug, corrigir antes da Bateria 3. Se intencional, documentar
+   na RN como "cap determinístico" antes da Bateria 3.
+
+3. **PR #E (CPIE-B):** será feito ANTES ou DEPOIS da suite?
+   Se antes: critério 8 do §13.5 pode passar.
+   Se depois: critério 8 entra como débito aceito no caso real UAT.
+
+4. **Caso real do advogado:** definir projeto de UAT + perfil +
+   questionários antes da ETAPA 5. Ideal: advogado fornece 2026-04-XX.
+
+5. **Projeto de testes destrutivos:** ID a ser definido pelo
+   Orquestrador + criado no DB antes da Bateria 1.
+
+---
+
+## Referências
+
+- `docs/governance/MATRIZ_RISCOS_SNAPSHOT_2026-04-18.md` — baseline (§13.5, §21, §23)
+- `docs/governance/RN_GERACAO_RISCOS_V4.md` — regras RN-RISK
+- `docs/governance/RN_PLANOS_TAREFAS_V4.md` — regras RN-AP, RN-TASK
+- `docs/governance/RN_CONSOLIDACAO_V4.md` — regras RN-CV4 (score D)
+- `docs/governance/GOVERNANCA-E2E-IA-SOLARIS.md` — Gate 7 P1-P4
+- `docs/adr/ADR-0022-hot-swap-risk-engine-v4.md` — engine v4 ativo
+- `docs/adr/ADR-0023-cpie-score-opcao-a-sprint-z07.md` — débito CPIE-B
+- `docs/adr/ADR-0025-risk-categories-configurable-rag-sensor.md` — risk_categories configurável
+- `server/lib/risk-engine-v4.ts` — fonte do engine
+- `server/lib/compliance-score-v4.ts` — Score D
+- `server/lib/rag-risk-validator.ts` — enrichment RAG
+- `server/lib/generate-risks-pipeline.ts` — pipeline Z-13.5
+- `server/routers/risks-v4.ts` — 19 procedures tRPC
+
+---
+
+*IA SOLARIS · Spec de Suite de Testes · Matriz de Riscos v4*
+*Versão 1.0 · 2026-04-18 · Pendente aprovação P.O. + Orquestrador*
+*Após aprovação: submeter como issue com 5 labels spec-* + 4 blocos obrigatórios*

--- a/docs/specs/SPEC-TESTE-MATRIZ-RISCOS-v1.md
+++ b/docs/specs/SPEC-TESTE-MATRIZ-RISCOS-v1.md
@@ -1,8 +1,9 @@
 # SPEC — Suite de Testes: Matriz de Riscos v4
 
 ## IA SOLARIS · Compliance Tributário v2
-## Versão 1.0 · 2026-04-18 · Audiência: P.O. · Orquestrador · Claude Code · Manus
+## Versão 1.1 · 2026-04-18 · Audiência: P.O. · Orquestrador · Claude Code · Manus
 ## Baseline: `docs/governance/MATRIZ_RISCOS_SNAPSHOT_2026-04-18.md` (1628 linhas)
+## Changelog v1.0 → v1.1: aplicadas C1-C7 + decisões P1-P5 (crítica Manus 2026-04-18)
 
 ---
 
@@ -44,13 +45,20 @@ real fornecido pelos advogados.
 
 ## Bloco 2 — UX Spec
 
-**ISENÇÃO ORQ-16:** esta é spec de **teste**, não de UI. Não há
-componente frontend a validar contra mockup. O único artefato
-visual é o **relatório de progresso** (`progress.md`), cujo
-formato é definido no Bloco 5.
+**ISENÇÃO ORQ-16 (explicitada por bateria — C5):**
 
-Nenhum `data-testid` novo introduzido (Bloco 9 consolida os
-existentes que serão cobertos pelos testes E2E).
+- **B1-B3:** isenção aplica — sem componentes UI novos. Suite usa
+  `data-testid` existentes (listados em Bloco 9). Nenhum mockup
+  necessário.
+- **B4:** testa UI existente via Playwright (fluxo completo com caso
+  real do advogado) — sem criar componentes novos. Isenção
+  mantida: nenhum mockup de UI novo é requerido em nenhuma bateria.
+
+O único artefato visual produzido pela spec é o **relatório de
+progresso** (`progress.md`), cujo formato é definido no Bloco 5.
+
+Novos `data-testid` para E2E listados no Bloco 9 são para elementos
+já existentes no código — confirmar via grep antes da implementação.
 
 ---
 
@@ -85,7 +93,39 @@ existentes que serão cobertos pelos testes E2E).
 | 13 | `docs/governance/TEST_PROGRESS_TEMPLATE.md` | Template do `progress.md` |
 | 14 | `docs/governance/CASO_REAL_UAT_CHECKLIST.md` | Checklist para teste manual pós-bateria 4 |
 
-### 3.4 Estrutura de diretórios criada
+### 3.4 Projeto de testes destrutivos (C6 + P5)
+
+Criado pelo Manus via `trpc.createProject` **antes de G1.1** (pré-requisito
+da Bateria 1). Perfil padronizado — paralelo estrutural ao 930001:
+
+```
+name:               "test_z20_destructive"
+cnpj:               "00.000.000/0001-99"   (fake válido)
+companyType:        ltda
+companySize:        media
+taxRegime:          lucro_real
+annualRevenueRange: 4800000-78000000
+confirmedCnaes:     ["4639-7/01"]           (atacadista alimentar)
+operationProfile.tipoOperacao:  comercio
+operationProfile.tipoCliente:   b2b
+operationProfile.multiestadual: false
+```
+
+**Por que esse perfil:**
+- Mesmo perfil do 930001 permite comparação determinística de outputs
+- CNAE 4639-7/01 aciona `CNAES_ALIMENTAR` **e** `CNAES_ATACADISTA`
+  (inferência Onda 3B gera 2 riscos inferidos)
+- `multiestadual=false` evita variação de `risk_key` entre baterias
+
+**ID atribuído dinamicamente** — spec lê de variável de ambiente
+`E2E_DESTRUCTIVE_PROJECT_ID` (exposta pelo Orquestrador após a
+criação). Nunca hardcoded.
+
+**Limpeza entre baterias:** DELETE lógico do projeto ao final de
+cada bateria via SQL (permitido em projeto de testes dedicado).
+Projeto é recriado no início da próxima bateria com mesmo perfil.
+
+### 3.5 Estrutura de diretórios criada
 
 ```
 reports/                          (novo, .gitignored)
@@ -245,6 +285,36 @@ echo "SELECT COUNT(*) FROM risks_v4 WHERE project_id=930001;" | # execute via Ma
 
 ## Bloco 7 — Critérios de aceite (por bateria)
 
+### Gate G0 — smoke-test do reporter (C3) — antes de qualquer bateria
+
+**Pré-condição absoluta.** Antes de G1.1 da Bateria 1.
+
+**Arquivo:** `scripts/smoke-test-reporter.sh`
+
+**Executa 3 testes sintéticos que validam o reporter em tempo real:**
+
+1. **Append simples:** 1 processo escreve 10 linhas em `progress.md`
+   com delay de 500ms entre cada. Verificação: cada linha aparece
+   em tempo real (delta < 2s entre escrita e leitura).
+2. **Lock de arquivo (concorrência):** 2 processos paralelos escrevem
+   5 linhas cada simultaneamente. Verificação: arquivo final tem
+   10 linhas sem corrupção, sem interleaving partial.
+3. **Flush sem buffer:** kill -9 do processo após 3 escritas.
+   Verificação: as 3 linhas estão no disco (não perdidas em buffer).
+
+**Critério G0:** PASS em todos os 3 testes antes de qualquer bateria.
+
+**Ação se G0 FAIL:**
+- Reporter está quebrado — abortar bateria
+- Corrigir `vitest.config.ts` custom reporter
+- Reexecutar G0 até PASS
+
+**Por que G0 vem antes de G1.1:** se o reporter não funciona, o P.O.
+não consegue acompanhar a bateria em tempo real. A falha de infraestrutura
+de observabilidade precede qualquer falha de teste de negócio.
+
+---
+
 ### Bateria 1 — Baseline (primeira passada)
 
 **Objetivo:** fotografar o estado real vs esperado. Vai falhar muito —
@@ -298,12 +368,30 @@ esse é o ponto.
 - [ ] G3.1: 100% unit tests PASS
 - [ ] G3.2: 100% integration tests PASS
 - [ ] G3.3: 10/10 critérios de aferição PASS
-- [ ] G3.4: 21/21 bugs UAT verificados
+- [ ] G3.4: 21/21 bugs UAT verificados (ver exceção abaixo)
 - [ ] G3.5: Zero flaky tests em 3 execuções consecutivas (critério
   anti-intermitência)
 - [ ] G3.6: Drift check: zero divergências (DB × código × RN
   alinhados após PRs de governança P1)
 - [ ] G3.7: Compliance Score visível no RiskDashboardV4 (DEC-01)
+
+**EXCEÇÃO B3 (C7) — "blocked-by-product-decision":**
+
+Bugs marcados com label `blocked-by-product-decision` **NÃO contam**
+no denominador do 100%. Regras da exceção:
+
+- Cada exceção requer justificativa explícita do P.O. no issue do bug
+- Máximo **3 exceções** por bateria (acima disso, travar e reavaliar)
+- A justificativa deve citar qual decisão de produto está pendente
+- Bugs em exceção são listados no `final.md` como "débito consciente"
+
+**Exemplo legítimo:** bug B-XX requer decisão P.O. sobre se a UI deve
+mostrar X ou Y. Enquanto P.O. não decide, o teste está bloqueado.
+Label `blocked-by-product-decision` aplicada → sai do denominador.
+
+**Anti-abuso:** labels aplicadas sem justificativa do P.O. são
+consideradas tentativa de burlar o gate — Orquestrador remove e
+conta no denominador.
 
 ---
 
@@ -422,6 +510,63 @@ faltante — Claude Code corrige via PR antes de avançar.
 
 ---
 
+## Bloco 9.1 — Triagem dos 21 bugs UAT Gate E (C2)
+
+Fonte: `MATRIZ_RISCOS_SNAPSHOT_2026-04-18.md §10` — os 21 bugs
+catalogados no UAT Gate E de 2026-04-11 (B-01 a B-21).
+
+**Classificação obrigatória por cobertura de teste** — a ser preenchida
+pelo Claude Code ao implementar os arquivos da suite (B1):
+
+### Playwright COBRE (automatizável em B1-B3)
+
+Bugs verificáveis por DOM query, assertion de URL, chamada de API
+via tRPC client, ou contagem de elementos. Incluídos nas suites
+`risk-matrix-audit.spec.ts`, `soft-delete-cascade.spec.ts`,
+`consolidacao-v4.spec.ts`.
+
+```
+[ Claude Code lista quais dos 21 bugs estão aqui após implementação ]
+```
+
+### Inspeção humana (manual, checklist na Bateria 4)
+
+Bugs de UX, fluxo de aprovação jurídica, layout ou ordem visual que
+não são deterministicamente detectáveis por teste automatizado.
+Entram no `docs/governance/CASO_REAL_UAT_CHECKLIST.md` para
+verificação P.O. durante Bateria 4.
+
+```
+[ Claude Code lista quais dos 21 bugs estão aqui após implementação ]
+```
+
+### UX puro (fora do escopo desta suite)
+
+Bugs de percepção, preferência subjetiva, ou estética pura sem
+impacto funcional. Movidos para backlog separado — não entram
+no denominador dos gates B1-B4.
+
+```
+[ Claude Code lista quais dos 21 bugs estão aqui após implementação ]
+```
+
+**Regra de soma:** `|Playwright| + |Inspeção humana| + |UX puro| = 21`.
+
+**Entregável desta seção:** ao final da implementação da suite
+(primeira execução da B1), Claude Code atualiza este Bloco 9.1
+com a triagem completa. A versão **v1.2 da spec** refletirá a
+triagem concreta.
+
+**Impacto nos thresholds:**
+- B2 usa apenas bugs em "Playwright cobre" como denominador
+  (se a categoria tem 13 bugs, threshold é 17/13 — precisa ajuste)
+- **Ajuste automático:** Claude Code recalcula os thresholds de B2
+  e B3 com base no denominador real após a triagem
+- Se triagem revelar < 10 bugs automatizáveis: Orquestrador
+  reavalia escopo antes de B2
+
+---
+
 ## ADR — Decisões arquiteturais
 
 ### ADR-TST-01 — 4 baterias iterativas em vez de 1 execução única
@@ -464,6 +609,39 @@ além de PASS/FAIL, imprime:
 
 **Consequências:** aferição demora mais para rodar (~30s por critério),
 mas permite ação imediata do Orquestrador ao ler o relatório.
+
+---
+
+### Decisões P.O. registradas (P1, P2, P3)
+
+**DECISÃO P1 — Thresholds do score (D5 do snapshot):**
+- Thresholds oficiais: **75/50/25** (código — `compliance-score-v4.ts:46-51`)
+- Runtime atual é a fonte de verdade — RN será atualizada
+- Ação: `RN_CONSOLIDACAO_V4.md §3` será corrigida em PR pós-snapshot
+  (P1.5) para remover bypass por `totalAlta` e alinhar limiares
+- Justificativa: todos os snapshots históricos em `projects.scoringData`
+  usaram os thresholds do código; mudar código agora invalidaria histórico
+  (registrado P.O. 2026-04-18)
+
+**DECISÃO P2 — Cap 77.78% é design intencional (RI-06):**
+- `MAX_PESO=9` reserva espaço para severidade futura "crítica" (peso 9)
+- Severidade mais alta atual é "alta" (peso 7) → cap natural `7/9 = 77.78%`
+- Padrão comum em engines determinísticos (reserva para expansão
+  sem invalidar scores históricos)
+- Ação: documentar em `RN_CONSOLIDACAO_V4.md §3` como "reserva para
+  severidade crítica futura"
+- Validação (B1): projeto sintético com 10 riscos alta + confidence=1.0
+  deve produzir score ≈ 77 (confirma design, descarta bug)
+- (registrado P.O. 2026-04-18)
+
+**DECISÃO P3 — PR #E (CPIE-B) antes da Bateria 3:**
+- Plano A: PR #E mergeado antes de B3 → suite testa estado final
+- Plano B (se PR #E > 2 sprints):
+  - CPIE-B registrado como "débito aceito" no `final.md` de cada bateria
+  - Suite valida apenas **Score D** (`compliance-score-v4.ts`)
+  - Critério 8 do §13.5 marcado `N/A — débito PR #E aceito`
+  - Orquestrador decide Plano A ou B antes de despachar F6 da suite
+- (registrado P.O. 2026-04-18)
 
 ---
 
@@ -595,27 +773,73 @@ Mesmo com todos os gates PASS.
 
 ---
 
-## Pendências bloqueadoras (antes da aprovação da spec)
+## Pendências por bateria (estratificadas — C1)
 
-O Orquestrador precisa validar com o P.O. antes de abrir issue:
+Substitui a lista plana de "5 pendências bloqueadoras" da v1.0.
+Esta versão estratifica por bateria, evitando que pendências de
+B3/B4 bloqueiem a abertura de F1 para a B1.
 
-1. **D5 do snapshot (thresholds score):** seguir RN (70/50/30 + bypass
-   totalAlta) ou código (75/50/25 sem bypass)? A Bateria 3 não
-   pode passar em 10/10 critérios sem essa decisão.
+### ANTES DA BATERIA 1 (bloqueadoras de F1)
 
-2. **RI-06 (cap ~77.8% do score):** design intencional ou bug?
-   Se bug, corrigir antes da Bateria 3. Se intencional, documentar
-   na RN como "cap determinístico" antes da Bateria 3.
+- [ ] **P5 + C6** — Criar projeto `test_z20_destructive` com o perfil
+  definido em Bloco 3.4. Responsável: Orquestrador despacha Manus.
+  ID exposto em `E2E_DESTRUCTIVE_PROJECT_ID`.
+- [ ] **P1** — Confirmar que thresholds oficiais são 75/50/25 (código).
+  Já decidido (ver ADR "Decisões P.O. registradas"), pendência é
+  apenas confirmação pelo Orquestrador antes de abrir issue.
+- [ ] **C2** — Placeholder de triagem dos 21 bugs UAT inserido no
+  Bloco 9.1. Preenchimento concreto é responsabilidade do Claude Code
+  ao implementar a suite — não bloqueia F1.
+- [ ] **C3 / G0** — Smoke-test do reporter implementado antes de G1.1.
+  Responsável: Claude Code como primeiro artefato da F6.
 
-3. **PR #E (CPIE-B):** será feito ANTES ou DEPOIS da suite?
-   Se antes: critério 8 do §13.5 pode passar.
-   Se depois: critério 8 entra como débito aceito no caso real UAT.
+### ANTES DA BATERIA 3 (bloqueadoras de avanço B2 → B3)
 
-4. **Caso real do advogado:** definir projeto de UAT + perfil +
-   questionários antes da ETAPA 5. Ideal: advogado fornece 2026-04-XX.
+- [ ] **P3** — PR #E (CPIE-B) mergeado **OU** Plano B ativado
+  (CPIE como débito aceito, Score D isolado).
+  Responsável: Orquestrador decide antes de despachar correções B2.
+- [ ] **P1.5** — PR atualizando `RN_CONSOLIDACAO_V4.md §3` com
+  thresholds 75/50/25 mergeado (alinha RN × código).
+- [ ] **P1.2-P1.4** — Demais PRs de governança pós-snapshot
+  mergeados (D2, D3, D6 do snapshot §5) para drift check zerar.
 
-5. **Projeto de testes destrutivos:** ID a ser definido pelo
-   Orquestrador + criado no DB antes da Bateria 1.
+### ANTES DA BATERIA 4 (bloqueadoras de validação final)
+
+- [ ] **P4** — Projeto UAT do advogado provisionado no DB com os
+  **6 requisitos** (ver abaixo). Responsável: P.O. fornece caso
+  via advogado parceiro; Manus importa e executa pipeline completo.
+
+### 6 requisitos do projeto UAT (P4 — substitui lista v1.0)
+
+1. Caso de **empresa real** (anonimizado se necessário por LGPD)
+2. Cobrir **no mínimo 5 das 10 categorias** oficiais (garantir
+   diversidade entre alta/media/oportunidade)
+3. Ter **respostas completas nas Ondas 1+2** (SOLARIS + IA GEN) —
+   não apenas dados de perfil
+4. Ter CNAE(s) válido(s) para acionar **Onda 3 (RAG)** com hits
+   mínimos no corpus `ragDocuments`
+5. **NÃO ser o 930001** (projeto sintético de teste) nem o
+   `test_z20_destructive` (projeto dedicado a B1-B3)
+6. Ter `status=aprovado` OU `em_andamento` com Ondas 1+2 concluídas
+   no sistema — ou seja, o projeto já **passou pelo fluxo SOLARIS
+   completo**, não é apenas um seed de DB. Isso garante que a
+   Bateria 4 testa o pipeline integral, não dados sintéticos.
+
+### Matriz bloqueadora × bateria
+
+| Pendência | B1 | B2 | B3 | B4 |
+|---|---|---|---|---|
+| P1 (thresholds) | Confirma | — | Aplica RN | — |
+| P2 (cap 77.8%) | Valida em teste sintético | — | — | — |
+| P3 (PR #E) | — | — | **Bloqueia** | — |
+| P4 (projeto UAT) | — | — | — | **Bloqueia** |
+| P5 (projeto destrutivo) | **Bloqueia** | — | — | — |
+| C1 (estratificação) | — | — | — | — |
+| C2 (triagem bugs) | — | **Ajusta denominador** | **Ajusta denominador** | — |
+| C3 (reporter smoke) | **Bloqueia via G0** | — | — | — |
+| C5 (ORQ-16 por bateria) | — | — | — | — |
+| C6 (perfil destrutivo) | Ver P5 | — | — | — |
+| C7 (exceção B3) | — | — | **Aplica** | — |
 
 ---
 
@@ -638,5 +862,6 @@ O Orquestrador precisa validar com o P.O. antes de abrir issue:
 ---
 
 *IA SOLARIS · Spec de Suite de Testes · Matriz de Riscos v4*
-*Versão 1.0 · 2026-04-18 · Pendente aprovação P.O. + Orquestrador*
+*Versão 1.1 · 2026-04-18 · C1-C7 + P1-P5 aplicadas*
 *Após aprovação: submeter como issue com 5 labels spec-* + 4 blocos obrigatórios*
+*v1.2 será gerada após triagem concreta dos 21 bugs UAT (Bloco 9.1)*


### PR DESCRIPTION
## Summary

Snapshot exploratório da Matriz de Riscos v4 antes de produzir a suite de testes "planejado × realizado".

**Arquivo único (1420 linhas, 24 seções):**
`docs/governance/MATRIZ_RISCOS_SNAPSHOT_2026-04-18.md`

Consolida (DEC-07) o snapshot analítico + inventário de regras do Manus.

## Conteúdo

**Análise crítica:**
- 7 divergências catalogadas: D2 (órfão RN), D3 (severidade RN), D5 (thresholds score), D6 (timeline 2032/2033), D7 (artigos frontend)
- D1 e D8 descartadas após diagnóstico Manus
- Hierarquia de fontes: DB > código > RN doc
- 4 "scores" desambiguados (CPIE v1/v2, CPIE-B, Compliance Score v4)
- Lacuna identificada: Compliance Score só exibido no Step 7, não no RiskDashboardV4

**Inventário factual (integrado):**
- Schemas de `risks_v4`, `action_plans`, `tasks`, `audit_log`
- 19 procedures tRPC do router `risks-v4.ts`
- RN-RISK-01..10, RN-AP-01..09, RN-TASK-01..08, RN-CV4-01..14
- Constantes determinísticas: `SEVERITY_TABLE`, `SOURCE_RANK`, `TITULO_TEMPLATES`, `RAG_QUERIES`
- Pipeline completo de geração com arquivos:linha
- 12 regras implícitas catalogadas (RI-01..12)

**Estado do projeto 930001:**
- 10 riscos, 1 por categoria (regra P.O.)
- Gate 7: **4/4 PASS** (incluindo 100% rag_validated)
- CPIE-B zerado (débito ADR-0023 confirmado)

**Decisões registradas (DEC-01..09):**
- Score v4 na Matriz de Riscos
- `tributacao_servicos` removida do RN doc (órfã nunca implementada)
- "1 risco por categoria" como regra inviolável
- Meta 98% confiabilidade antes de liberação para advogados

## Status

- [x] Snapshot gerado e validado contra queries reais do 930001
- [x] Inventário Manus integrado (Opção A — arquivo único)
- [ ] **Aguardando aprovação P.O.** antes de iniciar suite de testes
- [ ] D5 (thresholds) precisa decisão P.O. antes da implementação do Score v4 na UI

## Relacionado

- Ref #712 (Z-19 UI refinements — PR #714 aberto)
- ADR-0022 (hot swap engine v4)
- ADR-0023 (CPIE-B débito)
- ADR-0025 (risk_categories configurável)

🤖 Generated with [Claude Code](https://claude.com/claude-code)