### PR TITLE
fix(risk-engine): cascata soft delete [#719]

### DIFF
--- a/server/lib/db-queries-risks-v4.ts
+++ b/server/lib/db-queries-risks-v4.ts
@@ -838,7 +838,7 @@ export async function restoreRiskWithCascade(
     );
     await query(
       `UPDATE tasks
-       SET status = 'pending', deleted_reason = NULL
+       SET status = 'todo', deleted_reason = NULL
        WHERE action_plan_id = ? AND status = 'deleted'`,
       [plan.id]
     );
@@ -854,7 +854,7 @@ export async function restoreRiskWithCascade(
         user_role: actor.user_role,
         before_state: { status: "deleted" },
         after_state: {
-          status: "pending",
+          status: "todo",
           cascade_source: "risk",
           cascade_source_id: riskId,
           cascade_via_plan: plan.id,

--- a/server/lib/db-queries-risks-v4.ts
+++ b/server/lib/db-queries-risks-v4.ts
@@ -717,12 +717,38 @@ export async function softDeleteRiskWithCascade(
     );
 
     // 3b. Soft delete das tasks do plano (apenas não-deletadas)
+    // Buscar tasks antes do delete para registrar audit_log individual por task
+    const tasks = await query<{ id: string }>(
+      `SELECT id FROM tasks
+       WHERE action_plan_id = ? AND status != 'deleted'`,
+      [plan.id]
+    );
     await query(
       `UPDATE tasks
        SET status = 'deleted', deleted_reason = ?
        WHERE action_plan_id = ? AND status != 'deleted'`,
       [`cascade from risk ${riskId}`, plan.id]
     );
+    // 3b-ii. audit_log para cada task deletada em cascata (N+1 por plano)
+    for (const task of tasks) {
+      await insertAuditLog({
+        project_id: projectId,
+        entity: "task",
+        entity_id: task.id,
+        action: "deleted",
+        user_id: actor.user_id,
+        user_name: actor.user_name,
+        user_role: actor.user_role,
+        before_state: { status: "active" },
+        after_state: {
+          status: "deleted",
+          cascade_source: "risk",
+          cascade_source_id: riskId,
+          cascade_via_plan: plan.id,
+        },
+        reason: `cascade from risk ${riskId}`,
+      });
+    }
 
     // 3c. audit_log do plano cascateado
     await insertAuditLog({
@@ -804,12 +830,38 @@ export async function restoreRiskWithCascade(
     );
 
     // 3b. Restaurar tasks para 'pending' (sem histórico do status anterior)
+    // Buscar tasks antes do restore para registrar audit_log individual por task
+    const tasksToRestore = await query<{ id: string }>(
+      `SELECT id FROM tasks
+       WHERE action_plan_id = ? AND status = 'deleted'`,
+      [plan.id]
+    );
     await query(
       `UPDATE tasks
        SET status = 'pending', deleted_reason = NULL
        WHERE action_plan_id = ? AND status = 'deleted'`,
       [plan.id]
     );
+    // 3b-ii. audit_log para cada task restaurada em cascata
+    for (const task of tasksToRestore) {
+      await insertAuditLog({
+        project_id: projectId,
+        entity: "task",
+        entity_id: task.id,
+        action: "restored",
+        user_id: actor.user_id,
+        user_name: actor.user_name,
+        user_role: actor.user_role,
+        before_state: { status: "deleted" },
+        after_state: {
+          status: "pending",
+          cascade_source: "risk",
+          cascade_source_id: riskId,
+          cascade_via_plan: plan.id,
+        },
+        reason: reason ?? `cascade from risk restore ${riskId}`,
+      });
+    }
 
     // 3c. audit_log do plano restaurado
     await insertAuditLog({

--- a/server/lib/db-queries-risks-v4.ts
+++ b/server/lib/db-queries-risks-v4.ts
@@ -663,3 +663,187 @@ export async function insertActionPlanV4WithAudit(
   });
   return id;
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sprint Z-21 #719 — Cascata soft delete + restore
+// Fix de bug detectado em Bateria 2 (Z-20 Gate 0):
+//   softDeleteRiskV4 / restoreRisk não propagavam para action_plans/tasks.
+// Viola RN_CONSOLIDACAO_V4.md §14 e RI-07 do snapshot §22.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Soft-delete de um risco COM cascata em action_plans e tasks.
+ * Registra audit_log para cada entidade afetada (N+1 entradas).
+ *
+ * Sequência (ordem importa — não usar DELETE com CASCADE no banco):
+ *   1. UPDATE risks_v4 SET status='deleted'
+ *   2. SELECT action_plans filhos ativos
+ *   3. Para cada plano:
+ *      a. UPDATE action_plans SET status='deleted'
+ *      b. UPDATE tasks WHERE action_plan_id SET status='deleted'
+ *      c. insertAuditLog entity='action_plan' action='deleted_cascade'
+ *   4. insertAuditLog entity='risk' action='deleted'
+ */
+export async function softDeleteRiskWithCascade(
+  riskId: string,
+  projectId: number,
+  deletedBy: number,
+  reason: string,
+  actor: { user_id: number; user_name: string; user_role: string }
+): Promise<void> {
+  // 1. Soft delete do risco
+  await query(
+    `UPDATE risks_v4
+     SET status = 'deleted', deleted_reason = ?, updated_by = ?
+     WHERE id = ? AND status = 'active'`,
+    [reason, deletedBy, riskId]
+  );
+
+  // 2. Buscar planos filhos ativos
+  const plans = await query<{ id: string }>(
+    `SELECT id FROM action_plans
+     WHERE risk_id = ? AND status != 'deleted'`,
+    [riskId]
+  );
+
+  // 3. Cascata para cada plano
+  for (const plan of plans) {
+    // 3a. Soft delete do plano
+    await query(
+      `UPDATE action_plans
+       SET status = 'deleted', deleted_reason = ?, updated_by = ?
+       WHERE id = ? AND status != 'deleted'`,
+      [`cascade from risk ${riskId}`, deletedBy, plan.id]
+    );
+
+    // 3b. Soft delete das tasks do plano (apenas não-deletadas)
+    await query(
+      `UPDATE tasks
+       SET status = 'deleted', deleted_reason = ?
+       WHERE action_plan_id = ? AND status != 'deleted'`,
+      [`cascade from risk ${riskId}`, plan.id]
+    );
+
+    // 3c. audit_log do plano cascateado
+    await insertAuditLog({
+      project_id: projectId,
+      entity: "action_plan",
+      entity_id: plan.id,
+      action: "deleted",
+      user_id: actor.user_id,
+      user_name: actor.user_name,
+      user_role: actor.user_role,
+      before_state: { status: "active" },
+      after_state: {
+        status: "deleted",
+        cascade_source: "risk",
+        cascade_source_id: riskId,
+      },
+      reason: `cascade from risk ${riskId}`,
+    });
+  }
+
+  // 4. audit_log do risco
+  await insertAuditLog({
+    project_id: projectId,
+    entity: "risk",
+    entity_id: riskId,
+    action: "deleted",
+    user_id: actor.user_id,
+    user_name: actor.user_name,
+    user_role: actor.user_role,
+    before_state: { status: "active" },
+    after_state: {
+      status: "deleted",
+      deleted_reason: reason,
+      cascaded_plans: plans.length,
+    },
+    reason,
+  });
+}
+
+/**
+ * Restore de um risco COM cascata (RI-07): action_plans e tasks voltam.
+ * Registra audit_log para cada entidade afetada (N+1 entradas).
+ *
+ * Regras:
+ *   - Planos restaurados voltam para 'rascunho' (aprovação deve ser refeita)
+ *   - Tasks restauradas voltam para 'pending' (não há histórico do status anterior)
+ *   - Apenas entidades com status='deleted' são afetadas
+ */
+export async function restoreRiskWithCascade(
+  riskId: string,
+  projectId: number,
+  restoredBy: number,
+  actor: { user_id: number; user_name: string; user_role: string },
+  reason?: string
+): Promise<void> {
+  // 1. Restaurar risco
+  await query(
+    `UPDATE risks_v4
+     SET status = 'active', deleted_reason = NULL, updated_by = ?
+     WHERE id = ? AND status = 'deleted'`,
+    [restoredBy, riskId]
+  );
+
+  // 2. Buscar planos deletados via cascata
+  const plans = await query<{ id: string }>(
+    `SELECT id FROM action_plans
+     WHERE risk_id = ? AND status = 'deleted'`,
+    [riskId]
+  );
+
+  // 3. Cascata de restore para cada plano
+  for (const plan of plans) {
+    // 3a. Restaurar plano para 'rascunho' (aprovação refeita)
+    await query(
+      `UPDATE action_plans
+       SET status = 'rascunho', deleted_reason = NULL, updated_by = ?
+       WHERE id = ? AND status = 'deleted'`,
+      [restoredBy, plan.id]
+    );
+
+    // 3b. Restaurar tasks para 'pending' (sem histórico do status anterior)
+    await query(
+      `UPDATE tasks
+       SET status = 'pending', deleted_reason = NULL
+       WHERE action_plan_id = ? AND status = 'deleted'`,
+      [plan.id]
+    );
+
+    // 3c. audit_log do plano restaurado
+    await insertAuditLog({
+      project_id: projectId,
+      entity: "action_plan",
+      entity_id: plan.id,
+      action: "restored",
+      user_id: actor.user_id,
+      user_name: actor.user_name,
+      user_role: actor.user_role,
+      before_state: { status: "deleted" },
+      after_state: {
+        status: "rascunho",
+        cascade_source: "risk",
+        cascade_source_id: riskId,
+      },
+      reason: reason ?? `cascade from risk restore ${riskId}`,
+    });
+  }
+
+  // 4. audit_log do risco
+  await insertAuditLog({
+    project_id: projectId,
+    entity: "risk",
+    entity_id: riskId,
+    action: "restored",
+    user_id: actor.user_id,
+    user_name: actor.user_name,
+    user_role: actor.user_role,
+    before_state: { status: "deleted" },
+    after_state: {
+      status: "active",
+      cascaded_plans: plans.length,
+    },
+    reason,
+  });
+}

--- a/server/routers/risks-v4.ts
+++ b/server/routers/risks-v4.ts
@@ -47,6 +47,8 @@ import {
   softDeleteTaskV4,
   getProjectAuditLog,
   deleteRisksByProject,
+  softDeleteRiskWithCascade,
+  restoreRiskWithCascade,
 } from "../lib/db-queries-risks-v4";
 import type {
   CategoriaV4,
@@ -326,8 +328,10 @@ export const risksV4Router = router({
     }),
 
   /**
-   * 3. deleteRisk
-   * Soft-delete de um risco (status → 'deleted'). Registra no audit_log.
+   * 3. deleteRisk — Sprint Z-21 #719: com cascata soft delete
+   * Soft-delete de um risco + cascata em action_plans + tasks.
+   * audit_log registra N+1 entradas (1 risco + N planos afetados).
+   * Ref: RN_CONSOLIDACAO_V4.md §14 · RI-07
    */
   deleteRisk: protectedProcedure
     .input(
@@ -340,27 +344,26 @@ export const risksV4Router = router({
       const risk = await getRiskV4ById(input.riskId);
       if (!risk) throw new TRPCError({ code: "NOT_FOUND", message: "Risco não encontrado" });
 
-      await softDeleteRiskV4(input.riskId, ctx.user.id, input.reason);
-
-      await insertAuditLog({
-        project_id: risk.project_id,
-        entity: "risk",
-        entity_id: input.riskId,
-        action: "deleted",
-        user_id: ctx.user.id,
-        user_name: ctx.user.name ?? ctx.user.email ?? "unknown",
-        user_role: ctx.user.role ?? "user",
-        before_state: { status: "active" },
-        after_state: { status: "deleted", deleted_reason: input.reason },
-        reason: input.reason,
-      });
+      await softDeleteRiskWithCascade(
+        input.riskId,
+        risk.project_id,
+        ctx.user.id,
+        input.reason,
+        {
+          user_id: ctx.user.id,
+          user_name: ctx.user.name ?? ctx.user.email ?? "unknown",
+          user_role: ctx.user.role ?? "user",
+        }
+      );
 
       return { success: true };
     }),
 
   /**
-   * 4. restoreRisk
-   * Restaura um risco deletado (status → 'active'). Registra no audit_log.
+   * 4. restoreRisk — Sprint Z-21 #719: com cascata restore (RI-07)
+   * Restaura risco + action_plans (status='rascunho') + tasks (status='pending').
+   * audit_log registra N+1 entradas.
+   * Ref: RI-07 snapshot §22
    */
   restoreRisk: protectedProcedure
     .input(
@@ -376,26 +379,17 @@ export const risksV4Router = router({
         throw new TRPCError({ code: "BAD_REQUEST", message: "Risco não está deletado" });
       }
 
-      // Restaurar via query direta (status → active)
-      const { drizzle } = await import("drizzle-orm/mysql2");
-      const db = drizzle(process.env.DATABASE_URL!);
-      await (db.$client as any).execute(
-        "UPDATE risks_v4 SET status = 'active', deleted_reason = NULL, updated_by = ? WHERE id = ?",
-        [ctx.user.id, input.riskId]
+      await restoreRiskWithCascade(
+        input.riskId,
+        risk.project_id,
+        ctx.user.id,
+        {
+          user_id: ctx.user.id,
+          user_name: ctx.user.name ?? ctx.user.email ?? "unknown",
+          user_role: ctx.user.role ?? "user",
+        },
+        input.reason
       );
-
-      await insertAuditLog({
-        project_id: risk.project_id,
-        entity: "risk",
-        entity_id: input.riskId,
-        action: "restored",
-        user_id: ctx.user.id,
-        user_name: ctx.user.name ?? ctx.user.email ?? "unknown",
-        user_role: ctx.user.role ?? "user",
-        before_state: { status: "deleted" },
-        after_state: { status: "active" },
-        reason: input.reason,
-      });
 
       return { success: true };
     }),

--- a/tests/e2e/cascata-soft-delete.spec.ts
+++ b/tests/e2e/cascata-soft-delete.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * cascata-soft-delete.spec.ts — Sprint Z-21 #719
+ *
+ * Valida a cascata implementada em softDeleteRiskWithCascade /
+ * restoreRiskWithCascade:
+ *   CT-1: deleteRisk → action_plans.status='deleted'
+ *   CT-2: deleteRisk → tasks.status='deleted' (via planos)
+ *   CT-3: audit_log tem N+1 entradas após delete
+ *   CT-4: restoreRisk → filhos restaurados (RI-07)
+ *
+ * Complementa tests/e2e/soft-delete-cascade.spec.ts (#720 converterá
+ * os 4 fixme do arquivo paralelo).
+ *
+ * Pré-requisitos:
+ *   - DATABASE_URL configurada (TiDB Cloud)
+ *   - E2E_DESTRUCTIVE_PROJECT_ID aponta para projeto com dados
+ *     populados (risks + planos + tasks aprovados)
+ *   - Auth via loginViaTestEndpoint (padrão z17)
+ *
+ * Auth pattern: retry 3x com backoff (padrão z17-pipeline-completo).
+ */
+import { test, expect } from "@playwright/test";
+import { loginViaTestEndpoint } from "./fixtures/auth";
+
+const DESTRUCTIVE_ID = process.env.E2E_DESTRUCTIVE_PROJECT_ID;
+const isConfigured = Boolean(DESTRUCTIVE_ID);
+
+test.describe("Cascata soft delete + restore — #719", () => {
+  test.skip(
+    !isConfigured,
+    "E2E_DESTRUCTIVE_PROJECT_ID ausente — projeto destrutivo não configurado"
+  );
+
+  test.beforeEach(async ({ page }) => {
+    let lastErr: Error | null = null;
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      try {
+        await loginViaTestEndpoint(page);
+        return;
+      } catch (err) {
+        lastErr = err as Error;
+        if (attempt < 3) await new Promise((r) => setTimeout(r, 3000 * attempt));
+      }
+    }
+    throw lastErr;
+  });
+
+  test("CT-1: RiskDashboard com projeto destrutivo carrega", async ({ page }) => {
+    test.setTimeout(60_000);
+    await page.goto(`/projetos/${DESTRUCTIVE_ID}/risk-dashboard-v4`);
+    await page.waitForLoadState("networkidle");
+    await page.waitForTimeout(3000);
+
+    const bodyText = (await page.textContent("body")) ?? "";
+    expect(bodyText).not.toContain("Carregando...");
+    // Presença mínima: pelo menos o shell do dashboard renderiza
+    expect(bodyText.length).toBeGreaterThan(100);
+  });
+
+  test("CT-2: Aba Histórico acessível (para inspeção audit_log cascata)", async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+    await page.goto(`/projetos/${DESTRUCTIVE_ID}/risk-dashboard-v4`);
+    await page.waitForLoadState("networkidle");
+    await page.waitForTimeout(3000);
+
+    const tab = page.locator('[data-testid="history-tab"]');
+    const visible = await tab.isVisible({ timeout: 10_000 }).catch(() => false);
+    expect(visible).toBe(true);
+  });
+
+  // ── Testes de mutação real (DB) ───────────────────────────────────────────
+  // Estes 2 CTs executam cascata real e validam estado pós-operação.
+  // São marcados como `fixme` até o Manus popular 1200001 com dados completos
+  // (riscos aprovados + planos + tarefas via AÇÃO 2 da Sprint Z-20).
+
+  test.fixme(
+    "CT-3: deleteRisk cascateia para action_plans + tasks + audit_log N+1",
+    () => {}
+  );
+
+  test.fixme(
+    "CT-4: restoreRisk (RI-07) cascateia — planos='rascunho', tasks='pending'",
+    () => {}
+  );
+
+  /*
+   * Ativação dos 2 fixme acima requer:
+   *   (a) Issue #720 mergeada (converter fixme → test real com fixtures DB)
+   *   (b) Projeto 1200001 populado via AÇÃO 2 da Z-20:
+   *       trpc.risksV4.generateRisks + bulkApprove + approveActionPlan
+   *   (c) Inspeção do audit_log via SQL direto (além do Playwright DOM)
+   *
+   * Após essas 3 condições, CT-3 e CT-4 podem ser implementados em #720.
+   */
+});

--- a/tests/e2e/cascata-soft-delete.spec.ts
+++ b/tests/e2e/cascata-soft-delete.spec.ts
@@ -65,9 +65,9 @@ test.describe("Cascata soft delete + restore — #719", () => {
     await page.waitForLoadState("networkidle");
     await page.waitForTimeout(3000);
 
+    await page.waitForSelector('[data-testid="history-tab"]', { timeout: 15_000 });
     const tab = page.locator('[data-testid="history-tab"]');
-    const visible = await tab.isVisible({ timeout: 10_000 }).catch(() => false);
-    expect(visible).toBe(true);
+    await expect(tab).toBeVisible();
   });
 
   // ── Testes de mutação real (DB) ───────────────────────────────────────────


### PR DESCRIPTION
## Objetivo
Implementar cascata soft delete + restore para riscos v4 (RI-07): quando um risco é deletado, seus action_plans e tasks são deletados em cascata. Ao restaurar, voltam com status inicial (rascunho/todo). Registra audit_log N+1 para cada entidade afetada.

## Escopo da alteração
- `server/lib/db-queries-risks-v4.ts` — funções `softDeleteRiskWithCascade` e `restoreRiskWithCascade`
- `tests/e2e/cascata-soft-delete.spec.ts` — CT-1/CT-2 smoke, CT-3/CT-4 fixme

## Classificação da task
- **Tipo**: feature + bugfix
- **Risco**: médio (operações de escrita em 3 tabelas + audit_log)
- **Tabelas afetadas**: risks_v4, action_plans, tasks, audit_log

## Checklist final
- [x] TypeScript sem erros
- [x] Vitest passando
- [x] CT-1 PASS, CT-2 PASS, CT-3/CT-4 skipped (fixme esperado)
- [x] audit_log N+1 validado em runtime (PASSO 3 + queries 4a/4b/4c)
- [x] Bug `pending→todo` encontrado e corrigido (commit 0c3c07f)

## Evidência JSON

```json
{
  "head": "0c3c07f",
  "pr": 722,
  "sprint": "Z-21",
  "validacao_ativa": {
    "risk_id": "44d845c5-128e-44bb-a837-47f6f9bd3e11",
    "baseline_timestamp": "2026-04-18T17:31:57Z",
    "restore_http_status": 200,
    "audit_log_4a": {
      "task_restored": 3,
      "action_plan_restored": 1,
      "risk_restored": 1
    },
    "audit_log_4b_cascade_source": "risk (todos os 3 tasks)",
    "tasks_banco_pos_restore": 9,
    "veredito": "PASS"
  },
  "bug_encontrado_e_corrigido": {
    "descricao": "tasks.status enum('todo','doing','done','blocked','deleted') nao tem 'pending' — UPDATE SET status='pending' causava Data truncated HTTP 500",
    "correcao": "status 'pending' substituido por 'todo' em restoreRiskWithCascade",
    "commit": "0c3c07f"
  },
  "playwright": {
    "CT1": "PASS",
    "CT2": "PASS",
    "CT3": "skipped (fixme)",
    "CT4": "skipped (fixme)",
    "exit_code": 0
  },
  "unexpected_behavior": false,
  "tests_passed": true,
  "rag_impact": false
}
```

## Declaração final
Código revisado, testado e validado em runtime. Bug `pending→todo` encontrado durante validação ativa e corrigido no commit `0c3c07f`. PR apto para merge após aprovação do P.O.
