### PR TITLE
fix(e2e): SameSite=Lax em localhost + fixtures baseURL + CT-4 timeout 120s

### DIFF
--- a/server/_core/cookies.ts
+++ b/server/_core/cookies.ts
@@ -39,10 +39,15 @@ export function getSessionCookieOptions(
   //       ? hostname
   //       : undefined;
 
+  const secure = isSecureRequest(req);
+  // Chrome rejeita SameSite=None sem Secure (RFC 6265bis).
+  // Em localhost (HTTP), usar SameSite=Lax para que o Playwright/Chromium aceite o cookie E2E.
+  const sameSite = secure ? ("none" as const) : ("lax" as const);
+
   return {
     httpOnly: true,
     path: "/",
-    sameSite: "none",
-    secure: isSecureRequest(req),
+    sameSite,
+    secure,
   };
 }

--- a/tests/e2e/compliance-dashboard.spec.ts
+++ b/tests/e2e/compliance-dashboard.spec.ts
@@ -74,7 +74,7 @@ test.describe("Compliance Dashboard v3 (#725)", () => {
   test("CT-4 — link menu 'Dashboard Compliance' aparece no layout global", async ({
     page,
   }) => {
-    test.setTimeout(60_000);
+    test.setTimeout(120_000); // Fix run8: CT-4 leva ~1.6min quando roda após CT-3 (tRPC cache warming)
     // Painel inicial (rota "/") — ComplianceLayout garantido, sem dependencia
     // do estado de um projeto especifico.
     await page.goto("/", { waitUntil: "domcontentloaded" });

--- a/tests/e2e/fixtures/auth.ts
+++ b/tests/e2e/fixtures/auth.ts
@@ -9,10 +9,13 @@
  *
  * Fix v2: usar page.request em vez de playwrightRequest.newContext para evitar
  * fechamento acidental do browser context ao chamar ctx.dispose().
+ * Fix v3 (run6): PLAYWRIGHT_BASE_URL tem prioridade sobre E2E_BASE_URL para garantir
+ * que o goto pós-login aponte para localhost em vez de produção.
  */
 import { type Page } from '@playwright/test';
 
-const BASE_URL = process.env.E2E_BASE_URL || 'https://iasolaris.manus.space';
+// PLAYWRIGHT_BASE_URL tem prioridade (passado via CLI); E2E_BASE_URL é fallback; produção é último recurso
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || process.env.E2E_BASE_URL || 'https://iasolaris.manus.space';
 const TEST_SECRET = process.env.E2E_TEST_SECRET || '';
 
 // clientId fixo: usuário demo que sempre existe no banco


### PR DESCRIPTION
## Problema

Chrome (RFC 6265bis) rejeita cookies `SameSite=None` sem `Secure` em conexões HTTP.
Em localhost, o `app_session_id` era rejeitado pelo Chromium headless → redirect para OAuth → 403 CloudFront.

## Fixes

| Arquivo | Mudança |
|---|---|
| `server/_core/cookies.ts` | `SameSite=Lax` quando `secure=false` (localhost HTTP) |
| `tests/e2e/fixtures/auth.ts` | `PLAYWRIGHT_BASE_URL` prioritário sobre `E2E_BASE_URL` |
| `tests/e2e/compliance-dashboard.spec.ts` | CT-4 `test.setTimeout` 60s→120s |

## Evidência

```
5 passed (22.9s)
✓ CT-1 — rota /compliance-dashboard carrega (2.3s)
✓ CT-2 — 'Gerar Dashboard' renderiza os 3 cards (3.1s)
✓ CT-3 — modal da formula abre com breakdown (3.3s)
✓ CT-4 — link menu 'Dashboard Compliance' aparece no layout global (9.6s)
✓ CT-5 — botão Exportar PDF visível apos gerar (3.0s)
```

Refs: #725 #728