### PR TITLE
fix(e2e): data-testid="action-plan-modal" no NewPlanModal — CT-01 z14

### DIFF
--- a/client/src/components/RiskDashboardV4.tsx
+++ b/client/src/components/RiskDashboardV4.tsx
@@ -482,7 +482,7 @@ function NewPlanModal({
 
   return (
     <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="sm:max-w-md" data-testid="action-plan-modal">
         <DialogHeader>
           <DialogTitle>Novo plano de ação</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
## Tipo
fix

## Escopo
`client/src/components/RiskDashboardV4.tsx` — 1 linha

## Problema
O spec `z14-risk-action-plan CT-01` procurava `data-testid="action-plan-modal"` no `NewPlanModal` inline de `RiskDashboardV4.tsx`, mas o `DialogContent` não tinha o atributo. O testid existia apenas em `ActionPlanPage.tsx` (página diferente). Detectado durante F7 Checkpoint 3.5.

## Fix
Adicionado `data-testid="action-plan-modal"` ao `DialogContent` do `NewPlanModal` (linha 485).

## Evidência
```json
{
  "checkpoint": "3.5-fix",
  "spec": "z14-risk-action-plan CT-01",
  "problema": "data-testid='action-plan-modal' ausente no NewPlanModal (RiskDashboardV4.tsx linha 485)",
  "fix": "1 linha: adicionar data-testid ao DialogContent",
  "ct_isolado_antes": "FAIL (testid nao encontrado)",
  "ct_isolado_depois": "PASS 4.9s",
  "regressao_pr737": false,
  "causa": "testid nunca existiu no componente inline — pré-existente"
}
```

## Checklist
- [x] Não é regressão do PR #737
- [x] CT-01 PASS isolado após fix (4.9s)
- [x] 1 arquivo, 1 linha alterada
- [x] Refs #737 #725