### PR TITLE
fix: stepper detecta conclusão por evidência (UAT bug #2)

### DIFF
--- a/client/src/components/DiagnosticoStepper.tsx
+++ b/client/src/components/DiagnosticoStepper.tsx
@@ -82,6 +82,18 @@ interface DiagnosticoStepperProps {
    * o stepper deriva honestamente o estado em vez de marcar tudo como concluído (#739).
    */
   currentStep?: number;
+  /**
+   * Evidências de conclusão por etapa — usadas para promover etapas a "completed"
+   * quando o projectStatus não avançou mas há dados salvos (fix UAT 2026-04-20 bug #2:
+   * usuário respondeu tudo mas stepper mostrava "Iniciar").
+   * Regra: evidência só PROMOVE, nunca rebaixa.
+   */
+  evidence?: {
+    totalAnswers?: number;     // Onda 2: totalAnswers > 0 = completed
+    hasBriefing?: boolean;     // Briefing: true = completed
+    hasRiskMatrices?: boolean; // Matrizes: true = completed
+    hasActionPlan?: boolean;   // Plano: true = completed
+  };
   /** Se true, desabilita todos os botões (loading state) */
   isLoading?: boolean;
   /** Classe CSS adicional */
@@ -232,10 +244,23 @@ const POST_APPROVAL_STATUSES = new Set([
   "arquivado",
 ]);
 
+/**
+ * Evidências de conclusão por etapa — passadas pelo ProjetoDetalhesV2 a partir
+ * do summary do backend. Usadas para promover etapas a "completed" quando o
+ * projectStatus não avançou mas há dados salvos.
+ */
+export interface StepEvidence {
+  totalAnswers?: number;
+  hasBriefing?: boolean;
+  hasRiskMatrices?: boolean;
+  hasActionPlan?: boolean;
+}
+
 export function projectStatusToStepState(
   projectStatus: string,
   legacyState?: DiagnosticLayerState,
-  currentStep?: number
+  currentStep?: number,
+  evidence?: StepEvidence
 ): StepState {
   const base: StepState = {
     onda1: "not_started",
@@ -303,6 +328,55 @@ export function projectStatusToStepState(
     base.corporate = legacyState.corporate;
     base.operational = legacyState.operational;
     base.cnae = legacyState.cnae;
+  }
+
+  // fix UAT 2026-04-20 bug #2: promover etapas a "completed" quando há evidência
+  // de dados salvos, independente do projectStatus não ter avançado. Só PROMOVE,
+  // nunca rebaixa — se statusMap já marcou como completed, mantém.
+  if (evidence) {
+    const promoteToCompleted = (id: StepId) => {
+      if (base[id] !== "completed") base[id] = "completed";
+    };
+
+    // Onda 2 IA: se tem respostas salvas, Onda 1 também deve estar completed
+    // (o fluxo não permite chegar em Onda 2 sem passar pela Onda 1)
+    if ((evidence.totalAnswers ?? 0) > 0) {
+      promoteToCompleted("onda1");
+      promoteToCompleted("onda2");
+    }
+
+    // Briefing gerado → briefing completed (e implicitamente tudo antes)
+    if (evidence.hasBriefing) {
+      promoteToCompleted("onda1");
+      promoteToCompleted("onda2");
+      promoteToCompleted("corporate");
+      promoteToCompleted("operational");
+      promoteToCompleted("cnae");
+      promoteToCompleted("briefing");
+    }
+
+    // Matrizes geradas → até matrizes completed
+    if (evidence.hasRiskMatrices) {
+      promoteToCompleted("onda1");
+      promoteToCompleted("onda2");
+      promoteToCompleted("corporate");
+      promoteToCompleted("operational");
+      promoteToCompleted("cnae");
+      promoteToCompleted("briefing");
+      promoteToCompleted("matrizes");
+    }
+
+    // Plano gerado → tudo completed
+    if (evidence.hasActionPlan) {
+      promoteToCompleted("onda1");
+      promoteToCompleted("onda2");
+      promoteToCompleted("corporate");
+      promoteToCompleted("operational");
+      promoteToCompleted("cnae");
+      promoteToCompleted("briefing");
+      promoteToCompleted("matrizes");
+      promoteToCompleted("plano");
+    }
   }
 
   return base;
@@ -494,11 +568,12 @@ export function DiagnosticoStepper({
   onStartPlano,
   projectStatus,
   currentStep,
+  evidence,
   isLoading = false,
   className,
 }: DiagnosticoStepperProps) {
-  // Derivar stepState a partir do projectStatus (preferência) ou legacyState
-  const stepState = projectStatusToStepState(projectStatus ?? "", diagnosticStatus, currentStep);
+  // Derivar stepState: (1) statusMap baseline, (2) legacyState override, (3) evidence promotion
+  const stepState = projectStatusToStepState(projectStatus ?? "", diagnosticStatus, currentStep, evidence);
 
   const completedCount = Object.values(stepState).filter(
     (s) => s === "completed"

--- a/client/src/pages/ProjetoDetalhesV2.tsx
+++ b/client/src/pages/ProjetoDetalhesV2.tsx
@@ -466,6 +466,12 @@ export default function ProjetoDetalhesV2() {
                 isLoading={completeDiagnosticLayer.isPending}
                 projectStatus={summary.status}
                 currentStep={(summary as any).currentStep}
+                evidence={{
+                  totalAnswers: summary.totalAnswers,
+                  hasBriefing: summary.hasBriefing,
+                  hasRiskMatrices: summary.hasRiskMatrices,
+                  hasActionPlan: summary.hasActionPlan,
+                }}
                 onStartOnda1={() => setLocation(`/projetos/${projectId}/questionario-solaris`)}
                 onStartOnda2={() => setLocation(`/projetos/${projectId}/questionario-iagen`)}
                 onStartLayer={(layer) => {


### PR DESCRIPTION
## Escopo de fechamento

Refs UAT 2026-04-20 (sem issue dedicada — surgiu do teste manual do P.O.)

## Objetivo

Corrigir bug reportado pelo P.O.: após responder todos os questionários, o `DiagnosticoStepper` mostra botão "Iniciar" em vez de "Revisitar". Causa raiz: estado derivava apenas do `projectStatus`, ignorando evidências de dados salvos.

## Arquivos que serão tocados

- `client/src/components/DiagnosticoStepper.tsx`
- `client/src/pages/ProjetoDetalhesV2.tsx`

## Escopo da alteração

**Tipo:**
- [x] Bugfix

**Componentes afetados:**
- [x] Frontend (React)

## Classificação de risco

- [x] Baixo — sem impacto em dados ou fluxo principal
- [ ] Médio
- [ ] Alto

**Justificativa:** função pura (`projectStatusToStepState`) aceita novo parâmetro opcional. Regra "evidence SÓ PROMOVE, nunca rebaixa" garante backwards-compatibility — fluxo atual preservado, apenas adiciona detecção que não existia.

## Declaração de escopo

- [x] NÃO altera comportamento visível ao usuário final (apenas corrige exibição incorreta)
- [x] NÃO toca no adaptador `getDiagnosticSource()`
- [x] NÃO impacta o domínio RAG
- [x] NÃO ativa `DIAGNOSTIC_READ_MODE=new`
- [x] NÃO executa DROP COLUMN em colunas legadas

## Validação executada

- [x] `pnpm tsc --noEmit` — 0 erros
- [x] Inspeção manual da função (evidence promove, nunca rebaixa)

```json
{
  "head": "3e0e37a",
  "branch": "fix/stepper-evidence-based-completion",
  "arquivos": ["client/src/components/DiagnosticoStepper.tsx", "client/src/pages/ProjetoDetalhesV2.tsx"],
  "tests_passed": 0,
  "typescript_errors": 0,
  "risk_level": "low",
  "data_integrity": true,
  "regression": false,
  "rag_impact": false,
  "unexpected_behavior": false
}
```

## Classificação da task

- [x] Nível 1 — Seguro
- [ ] Nível 2 — Controlado
- [ ] Nível 3 — Crítico

## Auto-auditoria Q1–Q7

```
Q1 — Tipos nulos:         [ OK ] — evidence? opcional; cada campo opcional
Q2 — SQL TiDB:            [ N/A ]
Q3 — Filtros NULL/'':     [ OK ] — usa ?? 0 e !! boolean guards
Q4 — Endpoint registrado: [ N/A ] — usa summary existente
Q5 — isError ≠ vazio:     [ N/A ]
Q6 — Retorno explícito:   [ N/A ]
Q7 — Driver único:        [ N/A ]
R9 — Evento estruturado:  [ N/A ]
S6 — Rollback declarado:  [ OK ] — reverter commit

Risk score: low
Resultado: APTO PARA COMMIT
```

## Auto-auditoria Q1–5

- Q1 OK · Q2 N/A · Q3 OK · Q4 N/A · Q5 N/A · Q8 OK
- **Resultado: APTO PARA COMMIT**

## Comportamento

| Cenário | Antes | Depois |
|---|---|---|
| Respondeu tudo mas status não avançou | "Iniciar" em todas | "Revisitar" nas etapas com evidência |
| `totalAnswers > 0` | Onda 1/2 = "Iniciar" | Onda 1/2 = "Revisitar" |
| `hasBriefing = true` | Briefing = "Iniciar" | Todas etapas 1-6 = "Revisitar" |
| `hasRiskMatrices = true` | Matrizes = "Iniciar" | Todas etapas 1-7 = "Revisitar" |
| `hasActionPlan = true` | Plano = "Iniciar" | Todas 8 etapas = "Revisitar" |
| Status já "completed" pelo statusMap | "Revisitar" | "Revisitar" (nunca rebaixa) |
| Projeto novo (zero evidência) | "Iniciar" | "Iniciar" (sem regressão) |

## Regra inviolável

`evidence` SÓ PROMOVE (never demote). Se o `statusMap` ou `legacyState` já marcou uma etapa como "completed", a evidência não pode rebaixá-la. Isso preserva o comportamento do fix #739 (currentStep) e todo código legado.

## Cascata de promoção

O fluxo é sequencial — se um evidence aponta X, as etapas anteriores também são promovidas:

```
hasActionPlan  → todas 8 etapas
hasRiskMatrices → 1..7 (onda1..matrizes)
hasBriefing    → 1..6 (onda1..briefing)
totalAnswers>0 → 1..2 (onda1, onda2)
```

## Checklist final

- [x] Código revisado pelo próprio autor
- [x] Evidência JSON preenchida
- [x] Sem arquivos fora do escopo declarado
- [x] Documentação não exige atualização
- [x] Feature flag N/A

## Declaração final

Fix targeted, reversível, função pura. Resolve bug de UX reportado no UAT sem alterar fluxo de aprovação ou dados. Implementação determinística, sem risco oculto.
