### PR TITLE
docs(governance): R-SYNC-02 fetch com refspec explícito

### DIFF
--- a/.claude/rules/governance.md
+++ b/.claude/rules/governance.md
@@ -248,6 +248,25 @@ Isso garante que o S3 sempre espelha o GitHub.
 Causa raiz documentada: PRs #473/#474 (Claude Code)
 criaram bifurcacao detectada na Sprint Z-12.
 
+## R-SYNC-02 — Fetch com refspec explicito (Manus apenas)
+
+Projeto tem 3 remotes: `origin` (S3 Manus), `github` e `solaris` (ambos GitHub).
+O fetch config de `origin` mapeia `refs/heads/*:refs/remotes/origin/*`,
+o que pode criar ref local ambigua `refs/heads/origin/main` quando se roda
+`git fetch github main` ou `git fetch solaris main` sem refspec explicito.
+
+Sintoma: `warning: refname 'origin/main' is ambiguous` + `webdev_save_checkpoint`
+falha com `unable to push to remote` (bloqueio historico sprint Z-22 2026-04-20).
+
+REGRA:
+  - **NUNCA** usar `git fetch github main` ou `git fetch solaris main`
+  - **SEMPRE** usar refspec completo:
+    `git fetch github refs/heads/main:refs/remotes/github/main`
+    `git fetch solaris refs/heads/main:refs/remotes/solaris/main`
+  - Se ambiguidade ocorrer: `git update-ref -d refs/heads/origin/main`
+
+Causa raiz documentada: sessao 2026-04-20, checkpoint v7.16 bloqueado por 3h.
+
 ## F7 — Deploy + Smoke test (OBRIGATORIO)
 
 Apos todo Gate 7, antes de declarar sprint encerrada:


### PR DESCRIPTION
## Escopo

Documenta regra nova preventiva descoberta durante resolução do bloqueio de checkpoint v7.16 (sessão 2026-04-20, ~3h bloqueados).

## Arquivo tocado

`.claude/rules/governance.md` — adiciona seção R-SYNC-02 após R-SYNC-01.

## Contexto

Projeto tem 3 remotes:
- `origin` (S3 Manus)
- `github` (GitHub)
- `solaris` (GitHub)

Fetch config de `origin` mapeia `refs/heads/*:refs/remotes/origin/*`.

Quando alguém roda `git fetch github main` sem refspec explícito, o git cria `refs/heads/origin/main` como **branch local**, conflitando com `refs/remotes/origin/main` do S3 Manus. Sintoma: `warning: refname 'origin/main' is ambiguous` + `webdev_save_checkpoint` falha com `unable to push to remote`.

## Regra adicionada

- **NUNCA** usar `git fetch github main` ou `git fetch solaris main` diretos
- **SEMPRE** usar refspec completo: `git fetch github refs/heads/main:refs/remotes/github/main`
- Se ambiguidade ocorrer: `git update-ref -d refs/heads/origin/main`

## Classificação

- [x] Governança / Docs
- [x] Baixo risco
- [x] Apenas documentação

```json
{
  "head": "332597a",
  "branch": "docs/rsync-02-refspec-explicito",
  "arquivos": [".claude/rules/governance.md"],
  "tests_passed": "N/A (docs)",
  "typescript_errors": 0,
  "risk_level": "low",
  "data_integrity": true,
  "regression": false,
  "rag_impact": false,
  "unexpected_behavior": false
}
```

## Classificação da task

- [x] Nível 1 — Seguro

## Checklist final

- [x] Código revisado pelo próprio autor
- [x] Evidência JSON preenchida
- [x] Sem arquivos fora do escopo
- [x] Documentação atualizada

Preventivo — evita repetição de bloqueio de 3h em sessões futuras.