### PR TITLE
docs(curadoria): fluxo E2E SOLARIS + spec CSV Onda 1 (consultor)

### DIFF
--- a/docs/curadoria/FLUXO-E2E-SOLARIS.md
+++ b/docs/curadoria/FLUXO-E2E-SOLARIS.md
@@ -1,0 +1,208 @@
+# Fluxo E2E — Questionário SOLARIS (Onda 1)
+
+> Documento de contexto para consultor externo.
+> Última atualização: 2026-04-20 · Baseline: v7.19 (produção `iasolaris.manus.space`)
+> Fonte da verdade: código em `server/routers/solarisAdmin.ts` + `server/lib/solaris-query.ts` + `drizzle/schema.ts`
+
+---
+
+## 1. Contexto de negócio
+
+A plataforma **IA SOLARIS** é uma ferramenta de apoio à decisão para compliance tributário sob a **Reforma Tributária brasileira** (LC 214/2025, EC 132/2023, CGIBS). Advogados e equipes fiscais usam a plataforma para:
+
+1. Criar projetos associados a uma ou mais empresas (CNPJ + CNAEs)
+2. Responder um diagnóstico estruturado em **3 ondas de perguntas** (ver §2)
+3. Gerar um briefing, matriz de risco e plano de ação
+
+## 2. Arquitetura de 3 ondas de perguntas
+
+Cada projeto passa por 3 ondas sequenciais de perguntas. Cada onda tem uma **fonte diferente** e uma **regra de prioridade diferente** no diagnóstico.
+
+| Onda | Fonte | Característica | Quem cria |
+|---|---|---|---|
+| **1ª — SOLARIS** | Curadoria jurídica | Perguntas escritas e revisadas por advogados SOLARIS. Zero IA. | **Equipe jurídica via CSV upload** (este documento) |
+| **2ª — IA Generativa** | IA Generativa | Perguntas dinâmicas geradas por LLM com base no perfil da empresa + RAG validado | Sistema (LLM + RAG) |
+| **3ª — CNAE / Regulatório** | RAG (corpus de leis) | Perguntas pré-curadas por categoria CNAE (QCNAE-01 a QCNAE-05) | Corpus regulatório ingerido |
+
+A **Onda 1 (SOLARIS)** é a mais crítica: captura conhecimento tácito dos advogados que o LLM e o RAG não conseguem reproduzir.
+
+## 3. Fluxo E2E do questionário SOLARIS
+
+```
+┌──────────────────────────────┐
+│  ETAPA 1 — CURADORIA         │
+│  Advogados SOLARIS           │
+│  escrevem perguntas em CSV   │
+└──────────────┬───────────────┘
+               ↓
+┌──────────────────────────────┐
+│  ETAPA 2 — UPLOAD            │
+│  /admin/solaris-questions    │
+│  role: equipe_solaris        │
+│  • Dry-run (preview)         │
+│  • Validação por linha       │
+│  • Confirmação → INSERT      │
+│  • Lote rastreável           │
+└──────────────┬───────────────┘
+               ↓
+┌──────────────────────────────┐
+│  ETAPA 3 — ARMAZENAMENTO     │
+│  Tabela: solaris_questions   │
+│  Identificação: código       │
+│  SOL-XXX + upload_batch_id   │
+│  Estado: ativo=1 / 0 (soft)  │
+└──────────────┬───────────────┘
+               ↓
+┌──────────────────────────────┐
+│  ETAPA 4 — MATCHING          │
+│  Usuário cria projeto        │
+│  com CNAEs confirmados       │
+│  Sistema chama:              │
+│  querySolarisByCnaes(cnaes)  │
+│  Filtra por cnaeGroups       │
+└──────────────┬───────────────┘
+               ↓
+┌──────────────────────────────┐
+│  ETAPA 5 — EXIBIÇÃO          │
+│  Questionário SOLARIS        │
+│  (badge azul "Equipe         │
+│   Jurídica SOLARIS")         │
+│  Usuário responde S/N/N/A    │
+└──────────────┬───────────────┘
+               ↓
+┌──────────────────────────────┐
+│  ETAPA 6 — RESPOSTAS         │
+│  Tabela: solaris_answers     │
+│  (projectId, questionId,     │
+│   codigo, resposta)          │
+│  Idempotente (UPSERT)        │
+└──────────────┬───────────────┘
+               ↓
+┌──────────────────────────────┐
+│  ETAPA 7 — PIPELINE          │
+│  Respostas alimentam:        │
+│  • Geração de Briefing (IA)  │
+│  • Matriz de Riscos v4       │
+│  • Plano de Ação             │
+└──────────────────────────────┘
+```
+
+## 4. Contratos de dados
+
+### 4.1 Tabela `solaris_questions` (origem das perguntas)
+
+```sql
+CREATE TABLE solaris_questions (
+  id            INT AUTO_INCREMENT PRIMARY KEY,
+  codigo        VARCHAR(20)  NOT NULL UNIQUE,    -- ex: SOL-001
+  titulo        VARCHAR(500) NOT NULL,
+  texto         TEXT         NOT NULL,            -- corpo da pergunta
+  topicos       TEXT         NOT NULL,            -- "kw1;kw2;kw3"
+  cnae_groups   JSON         NULL,                -- null = universal
+  categoria     VARCHAR(100) NOT NULL,            -- área temática
+  severidade_base ENUM('baixa','media','alta','critica') NOT NULL,
+  vigencia_inicio DATE       NULL,
+  risk_category_code VARCHAR(100) NULL,           -- FK risk_categories.codigo
+  classification_scope ENUM('risk_engine','diagnostic_only') DEFAULT 'risk_engine',
+  upload_batch_id VARCHAR(36) NOT NULL,           -- rastreabilidade
+  ativo         TINYINT      NOT NULL DEFAULT 1,  -- soft delete
+  obrigatorio   TINYINT      NOT NULL DEFAULT 1,
+  criado_em     BIGINT       NOT NULL,
+  atualizado_em BIGINT       NOT NULL
+);
+```
+
+### 4.2 Tabela `solaris_answers` (respostas do usuário)
+
+```sql
+CREATE TABLE solaris_answers (
+  id         INT AUTO_INCREMENT PRIMARY KEY,
+  projectId  INT NOT NULL,
+  questionId INT NOT NULL,                        -- FK solaris_questions.id
+  codigo     VARCHAR(20) NOT NULL,                -- denormalizado para rastreio histórico
+  resposta   TEXT NOT NULL,                       -- S/N/N_A/livre
+  respondido_em BIGINT NOT NULL,
+  UNIQUE KEY (projectId, questionId)
+);
+```
+
+## 5. Regra de matching CNAE
+
+Implementada em `server/lib/solaris-query.ts`:
+
+```typescript
+export async function querySolarisByCnaes(cnaes: string[]): Promise<SolarisQuestion[]> {
+  const all = await getOnda1Questions();  // filtra ativo=1
+  if (cnaes.length === 0) return all;
+  return all.filter(q => {
+    if (!q.cnaeGroups) return true;            // null/vazio → universal
+    const groups = parseJsonOrCsv(q.cnaeGroups);
+    return cnaes.some(cnae =>
+      groups.some(g => cnae.startsWith(g) || g.startsWith(cnae))
+    );
+  });
+}
+```
+
+**Regras:**
+- `cnaeGroups = null` ou `[]` → **universal** (aparece para todos)
+- `cnaeGroups = ["46"]` → aparece em projetos com CNAE iniciado por `46` (comércio)
+- `cnaeGroups = ["4639-7/01"]` → aparece em projetos com esse CNAE exato
+- Matching é **prefix bidirecional**: `cnae.startsWith(group) || group.startsWith(cnae)`
+
+## 6. Fluxo de validação no upload
+
+Estágio | Responsável | Ação
+---|---|---
+**Upload** | UI `/admin/solaris-questions` | Usuário escolhe arquivo `.csv` (UTF-8, separador vírgula)
+**Parse** | Backend `parseCsv()` | Detecta header, separa linhas, ignora comentários `#...`
+**Validação Zod** | `CsvRowSchema.safeParse()` | Valida cada linha contra schema (ver §7)
+**Dry-run** | Backend | Retorna `{valid: N, invalid: [{line, error}]}` sem persistir
+**Confirmação** | UI | Usuário aprova → `uploadMutation.mutate({dryRun: false})`
+**INSERT** | Backend | Transação com `upload_batch_id` UUID gerado por lote
+**Rastreio** | Tabela `solaris_upload_batches` | Registra (id, uploaded_by, uploaded_at, total)
+
+## 7. Tolerância e erros
+
+**Critério conservador:** se qualquer linha falha no dry-run, a UI destaca mas **permite publicar as linhas válidas**. Usuário decide se quer parcial ou corrigir tudo antes.
+
+**Erros comuns:**
+- `Número de colunas inválido: esperado 9, encontrado 7` → CSV com colunas faltando
+- `Campo 'titulo' é obrigatório` → célula vazia em coluna obrigatória
+- `Invalid enum value. Expected 'baixa' | 'media' | 'alta' | 'critica'` → typo em severidade
+- `Invalid literal value, expected "solaris"` → campo `lei` com outro valor
+- `Expected string, received null` → ausência de aspas em valor com vírgula
+
+## 8. Estado pós-upload
+
+Após confirmar upload:
+1. Questões vão para `solaris_questions` com `ativo=1`
+2. Lote recebe `upload_batch_id` único
+3. Histórico visível em `/admin/solaris-questions` aba **Histórico de Lotes**
+4. Soft-delete disponível: `solarisAdmin.deleteBatch({upload_batch_id})` desativa todas as questões do lote
+5. Rollback: `solarisAdmin.restoreQuestions({ids})` reativa individualmente
+
+## 9. Referências de código (fonte da verdade)
+
+| Arquivo | Responsabilidade |
+|---|---|
+| `server/routers/solarisAdmin.ts` | tRPC procedures (uploadCsv, listQuestions, deleteBatch, etc.) |
+| `server/lib/solaris-query.ts` | Matching CNAE → perguntas aplicáveis |
+| `server/db.ts` (L1262) | `getOnda1Questions()` — query com filtro `ativo=1` |
+| `drizzle/schema.ts` (L1654) | Schema da tabela `solaris_questions` |
+| `client/src/pages/AdminSolarisQuestions.tsx` | UI de upload/listagem/histórico (956 linhas) |
+| `client/public/template-solaris-questions.csv` | Template CSV baixável |
+| `docs/uat/solaris-questions-uat-v1.csv` | Exemplo de CSV válido com 12 perguntas (SOL-013..SOL-025) |
+
+## 10. Próximos passos para o consultor
+
+Para validar as 2 listas enviadas pelos advogados:
+
+1. Ler a **spec técnica do CSV** em `ONDA-1-SOLARIS-CSV-SPEC.md` (arquivo irmão deste)
+2. Normalizar os campos das listas para o schema
+3. Gerar CSV final pronto para upload via `/admin/solaris-questions`
+4. Sugerir códigos `SOL-XXX` sequenciais a partir do último já publicado (ex: se último é `SOL-025`, novas começam em `SOL-026`)
+
+---
+
+*Documento gerado a partir do código fonte em 2026-04-20. Se código mudar, este arquivo pode ficar desatualizado — verificar contra os arquivos de referência (§9).*

--- a/docs/curadoria/ONDA-1-SOLARIS-CSV-SPEC.md
+++ b/docs/curadoria/ONDA-1-SOLARIS-CSV-SPEC.md
@@ -1,0 +1,221 @@
+# Spec Técnica — CSV de Upload SOLARIS (Onda 1)
+
+> Especificação completa do formato CSV aceito pela procedure `solarisAdmin.uploadCsv`.
+> Use este documento para **validar** e **normalizar** listas de perguntas enviadas por advogados.
+> Fonte da verdade: `server/routers/solarisAdmin.ts` — schema `CsvRowSchema` (linhas 41-60).
+> Última atualização: 2026-04-20 · v7.19
+
+---
+
+## 1. Formato geral
+
+- **Encoding:** UTF-8
+- **Separador:** vírgula (`,`)
+- **Delimitador de campo:** aspas duplas (`"`) — obrigatório quando o valor contém vírgula, quebra de linha ou aspas
+- **Quebra de linha:** LF ou CRLF (ambos aceitos; `trim()` remove whitespace)
+- **Comentários:** linhas iniciadas com `#` são ignoradas
+- **Header:** obrigatório na linha 1, com todas as colunas obrigatórias
+- **Ordem das colunas:** flexível (mapeamento é por nome do header)
+
+## 2. Colunas — spec detalhada
+
+| # | Coluna | Tipo | Obrigatório | Validação |
+|---|---|---|---|---|
+| 1 | `titulo` | string | **SIM** | `min(1)` — não pode ser vazio |
+| 2 | `conteudo` | string | **SIM** | `min(1)` — texto completo da pergunta |
+| 3 | `topicos` | string | **SIM** | `min(1)` — palavras-chave separadas por `;` |
+| 4 | `cnaeGroups` | string | sim (pode vazio) | JSON array ou vazio (`[]`) |
+| 5 | `lei` | literal | **SIM** | Deve ser exatamente `solaris` (literal fixo) |
+| 6 | `artigo` | string | **SIM** | Padrão `SOL-NNN` (ex: `SOL-026`) |
+| 7 | `categoria` | enum | **SIM** | `contabilidade_fiscal` · `negocio` · `ti` · `juridico` |
+| 8 | `severidade_base` | enum | **SIM** | `baixa` · `media` · `alta` · `critica` |
+| 9 | `vigencia_inicio` | string | opcional | ISO date `YYYY-MM-DD` ou vazio |
+| 10 | `risk_category_code` | string | opcional | FK para `risk_categories.codigo` (ex: `inscricao_cadastral`) |
+| 11 | `classification_scope` | enum | opcional | `risk_engine` (default) · `diagnostic_only` |
+
+## 3. Regra de cada campo
+
+### 3.1 `titulo`
+- **O que é:** título curto da pergunta, usado em listagens e relatórios.
+- **Tamanho prático:** até ~100 caracteres (armazenado em varchar(500), não há truncamento).
+- **Exemplo:** `"Apuração do IBS por regime de competência"`
+
+### 3.2 `conteudo`
+- **O que é:** texto completo da pergunta exibido ao usuário no questionário.
+- **Pode conter aspas** (escapar dobrando: `""`) e vírgulas (colocando todo o valor entre aspas).
+- **Idioma:** português. Estilo: afirmativa clara + interrogação no final.
+- **Exemplo:** `"A empresa apura o IBS pelo regime de competência conforme exigido pelo art. 9º da LC 214/2025?"`
+
+### 3.3 `topicos`
+- **O que é:** palavras-chave para busca e classificação interna, separadas por `;`.
+- **Formato:** `snake_case` (palavras separadas por `_`) ou palavras simples.
+- **Mínimo:** 1 tópico. Recomendado: 3-5.
+- **Exemplo:** `"ibs;competencia;apuracao"`
+
+### 3.4 `cnaeGroups`  ← atenção especial
+- **O que é:** lista de prefixos CNAE em que a pergunta se aplica.
+- **Formato:** JSON array ou vazio.
+- **Regra de matching** (CRÍTICA):
+  - `[]` ou campo vazio → pergunta **universal** (aparece para todos os CNAEs)
+  - `["46"]` → aparece em CNAEs iniciados por `46` (ex: `46.39-7/01`)
+  - `["46.39-7/01"]` → aparece só nesse CNAE exato
+  - `["46", "47"]` → aparece em CNAEs iniciados por `46` **ou** `47`
+- **Matching é prefix bidirecional** (`startsWith` nos dois sentidos)
+- **Padrão** de curadoria: se a pergunta é **genérica** (aplica-se a qualquer empresa), use `[]`. Se é **específica** de um setor, liste os prefixos.
+
+### 3.5 `lei`
+- **O que é:** identificador da fonte da pergunta.
+- **Valor fixo:** sempre `solaris` (literal).
+- **Não aceita outros valores.** Qualquer outro texto resulta em erro.
+- **Por quê:** distingue perguntas de Onda 1 (SOLARIS) de Onda 2 (IA Gen) e Onda 3 (RAG).
+
+### 3.6 `artigo`
+- **O que é:** código identificador único da pergunta.
+- **Padrão:** `SOL-NNN` (3 dígitos zero-padded).
+- **Sequencial.** Antes de gerar novos, verificar qual é o último código em uso.
+- **Exemplos publicados:** `SOL-001` a `SOL-025` (até v7.19). Novos começam em `SOL-026`.
+- **Único:** não pode repetir código já existente (unique constraint).
+
+### 3.7 `categoria`
+- **O que é:** área temática da pergunta — determina quem é o responsável natural pela resposta.
+- **Enum fechado:**
+  | Valor | Significado |
+  |---|---|
+  | `contabilidade_fiscal` | Apuração, escrituração, tributação (contador) |
+  | `negocio` | Operação, produto, cliente, mercado (área de negócio) |
+  | `ti` | ERP, NF-e, Sped, integração de sistemas (TI) |
+  | `juridico` | Contratos, benefícios fiscais, transição legal (jurídico) |
+
+### 3.8 `severidade_base`
+- **O que é:** nível de impacto/risco se a empresa responder "não" ou "não sei".
+- **Enum fechado:**
+  | Valor | Guideline |
+  |---|---|
+  | `baixa` | Melhoria incremental; sem risco de autuação |
+  | `media` | Risco de glosa ou obrigação acessória |
+  | `alta` | Risco de autuação ou perda de crédito relevante |
+  | `critica` | Violação direta de norma com prazo fixado |
+
+### 3.9 `vigencia_inicio` (opcional)
+- **O que é:** data em que a pergunta passa a valer (útil para perguntas que só fazem sentido após certa data de transição).
+- **Formato:** `YYYY-MM-DD` (ISO 8601) ou vazio.
+- **Comportamento:** se vazio/null, pergunta vigente desde sempre.
+- **Exemplo:** `2026-07-01` (para perguntas que só se aplicam após início da fase de testes IBS).
+
+### 3.10 `risk_category_code` (opcional, Z-11 ENTREGA 2)
+- **O que é:** FK para `risk_categories.codigo` — liga a pergunta a uma categoria de risco do engine v4.
+- **Valores comuns:** `inscricao_cadastral`, `split_payment`, `transicao_iss_ibs`, `obrigacao_acessoria`, etc.
+- **Use quando:** a pergunta é um gatilho direto para um tipo de risco específico.
+- **Default se vazio:** pergunta é informativa (não gera risco direto).
+
+### 3.11 `classification_scope` (opcional, Z-11 ENTREGA 2)
+- **O que é:** define se a resposta alimenta o motor de riscos ou é apenas diagnóstica.
+- **Enum:**
+  - `risk_engine` (default) → resposta alimenta `risks_v4`
+  - `diagnostic_only` → resposta fica registrada mas não gera risco
+
+## 4. Template válido — minimal
+
+```csv
+titulo,conteudo,topicos,cnaeGroups,lei,artigo,categoria,severidade_base,vigencia_inicio
+Apuração do IBS,"A empresa apura IBS por competência (art. 9º LC 214/2025)?",ibs;competencia,[],solaris,SOL-026,contabilidade_fiscal,alta,
+```
+
+## 5. Template válido — com todos os campos opcionais
+
+```csv
+titulo,conteudo,topicos,cnaeGroups,lei,artigo,categoria,severidade_base,vigencia_inicio,risk_category_code,classification_scope
+Inscrição no CGIBS,"A empresa está cadastrada no Comitê Gestor do IBS?",ibs;cadastro;cgibs,[],solaris,SOL-027,juridico,critica,2026-01-01,inscricao_cadastral,risk_engine
+```
+
+## 6. Checklist de validação antes do upload
+
+Para cada linha enviada pelos advogados, verificar:
+
+- [ ] `titulo` preenchido
+- [ ] `conteudo` preenchido e terminando com `?`
+- [ ] `topicos` com pelo menos 1 palavra-chave
+- [ ] `cnaeGroups` é `[]` (universal) ou JSON array válido
+- [ ] `lei` é exatamente `solaris` (sem maiúsculas, sem espaços)
+- [ ] `artigo` segue padrão `SOL-NNN` e é **sequencial não duplicado**
+- [ ] `categoria` é um dos 4 valores do enum
+- [ ] `severidade_base` é um dos 4 valores do enum
+- [ ] `vigencia_inicio` vazio ou `YYYY-MM-DD`
+- [ ] Se `risk_category_code` preenchido: consta em `risk_categories.codigo`
+- [ ] Se `classification_scope` preenchido: `risk_engine` ou `diagnostic_only`
+- [ ] Valores com vírgula estão entre aspas `"..."`
+- [ ] Arquivo salvo em **UTF-8**, separador **vírgula**
+- [ ] Header na primeira linha
+- [ ] Linhas `#comentário` podem ser usadas livremente
+
+## 7. Erros comuns e correção
+
+| Erro reportado pelo dry-run | Causa | Correção |
+|---|---|---|
+| `Número de colunas inválido` | Vírgula em valor sem aspas | Envolver valor em `"..."` |
+| `Campo 'titulo' é obrigatório` | Célula vazia | Preencher |
+| `Invalid enum value. Expected 'baixa' \| 'media'...` | Typo em severidade | Corrigir para enum exato |
+| `Invalid literal value, expected "solaris"` | Lei errada (ex: `SOLARIS`) | Mudar para `solaris` (minúsculo) |
+| `Duplicate entry 'SOL-015' for key 'codigo'` | Código duplicado | Trocar para próximo `SOL-NNN` não usado |
+| `Invalid enum value for 'categoria'` | Categoria em português natural (ex: `Fiscal`) | Mapear para enum: `Fiscal` → `contabilidade_fiscal` |
+
+## 8. Exemplo completo validado (trecho real do UAT v1)
+
+Ver `docs/uat/solaris-questions-uat-v1.csv` no repositório — 12 perguntas (SOL-013..SOL-025) prontas para referência. Abaixo as 3 primeiras:
+
+```csv
+titulo,conteudo,topicos,cnaeGroups,lei,artigo,area,severidade_base,vigencia_inicio
+Apuração do IBS por regime de competência,"A empresa apura o IBS pelo regime de competência conforme exigido pelo art. 9º da LC 214/2025?",ibs;competencia;apuracao,[],solaris,SOL-013,contabilidade_fiscal,alta,
+Segregação contábil IBS x CBS,"Existe conta contábil segregada para IBS e CBS conforme orientação do CFC para a Reforma Tributária?",ibs;cbs;segregacao;contabilidade,[],solaris,SOL-014,contabilidade_fiscal,alta,
+Cadastro no Comitê Gestor do IBS,"A empresa está cadastrada no Comitê Gestor do IBS conforme prazo definido na LC 214/2025?",ibs;cadastro;comite_gestor,[],solaris,SOL-015,juridico,critica,2026-01-01
+```
+
+> **NOTA:** Este exemplo usa o nome de coluna `area` em vez de `categoria` — isso é o nome **antigo**. O schema atual (v7.19) espera `categoria`. Se o CSV recebido dos advogados usar `area`, renomear para `categoria` antes do upload.
+
+## 9. Fluxo sugerido para o consultor
+
+Dado que os advogados enviaram **2 listas fora do padrão**, recomendo:
+
+1. **Ler as 2 listas** — identificar campos que existem nas listas e mapeá-los para as 11 colunas acima.
+2. **Diagnóstico de gaps:**
+   - Quais campos obrigatórios estão faltando?
+   - Quais valores precisam ser normalizados (ex: severidade "médio" → `media`)?
+   - Há perguntas duplicadas entre as 2 listas?
+3. **Gerar CSV único consolidado:**
+   - Usar codigos `SOL-XXX` sequenciais a partir do último já publicado (ex: começar em `SOL-026`)
+   - Usar `cnaeGroups=[]` como default (universal) salvo se advogado especificou setor
+   - Mapear categorias para o enum de 4 valores
+   - Definir `severidade_base` conservadora (quando em dúvida, usar `media`)
+4. **Validar com dry-run** via `/admin/solaris-questions` antes de confirmar publicação.
+5. **Publicar** em lote único (facilita rollback se necessário).
+
+## 10. Perguntas ao consultor — template de retorno
+
+Ao devolver o CSV validado, o consultor pode anexar um resumo:
+
+```markdown
+## Resumo da consolidação
+
+- Total de perguntas das 2 listas originais: X
+- Duplicatas identificadas: Y
+- Perguntas consolidadas: Z
+- Códigos atribuídos: SOL-026 a SOL-0__
+- Categorias utilizadas: [listar as 4 que aparecem]
+- Severidades distribuídas:
+  - critica: A
+  - alta: B
+  - media: C
+  - baixa: D
+- Perguntas com `cnaeGroups` específico: E (detalhar quais e por quê)
+- Perguntas universais (`cnaeGroups=[]`): F
+
+## Observações
+
+[Gaps encontrados, ambiguidades, sugestões de revisão jurídica]
+```
+
+---
+
+*Spec gerada a partir do código fonte em 2026-04-20 (v7.19).
+Arquivos de referência: `server/routers/solarisAdmin.ts` (linhas 41-60 — `CsvRowSchema`)
+e `drizzle/schema.ts` (linhas 1654-1700 — tabela `solaris_questions`).*


### PR DESCRIPTION
## Escopo

Docs-only. Gera contexto para consultor externo validar 2 listas de perguntas SOLARIS recebidas dos advogados.

## Arquivos

- `docs/curadoria/FLUXO-E2E-SOLARIS.md` (novo) — contexto de negócio, arquitetura 3 ondas, fluxo E2E com diagrama ASCII, contratos de dados
- `docs/curadoria/ONDA-1-SOLARIS-CSV-SPEC.md` (novo) — spec completa do schema CSV (11 colunas), validação por campo, checklist pré-upload, template, exemplos reais

## Fonte da verdade

Gerados a partir do código atual em v7.19:
- `server/routers/solarisAdmin.ts:41-60` — `CsvRowSchema` Zod
- `server/lib/solaris-query.ts` — matching CNAE
- `drizzle/schema.ts:1654-1700` — tabela `solaris_questions`
- `docs/uat/solaris-questions-uat-v1.csv` — exemplo real SOL-013..SOL-025

## Escopo da alteração

- [x] Governança / Docs
- [x] Apenas documentação

## Classificação de risco

- [x] Baixo — sem impacto em dados ou fluxo principal

## Declaração de escopo

- [x] NÃO altera comportamento
- [x] NÃO toca getDiagnosticSource
- [x] NÃO impacta RAG
- [x] NÃO ativa DIAGNOSTIC_READ_MODE=new
- [x] NÃO executa DROP COLUMN

## Validação

- [x] Apenas arquivos .md
- [x] Conteúdo validado contra código atual

```json
{
  "head": "e1d043e",
  "branch": "docs/solaris-csv-consultor",
  "arquivos": ["docs/curadoria/FLUXO-E2E-SOLARIS.md", "docs/curadoria/ONDA-1-SOLARIS-CSV-SPEC.md"],
  "tests_passed": "N/A (docs)",
  "typescript_errors": 0,
  "risk_level": "low",
  "data_integrity": true,
  "regression": false,
  "rag_impact": false,
  "unexpected_behavior": false
}
```

## Classificação da task

- [x] Nível 1 — Seguro

## Checklist final

- [x] Código revisado pelo próprio autor
- [x] Evidência JSON preenchida
- [x] Sem arquivos fora do escopo
- [x] Documentação atualizada

## Relevância para o backlog

Resolve parcialmente issue #158 (L-2 docs) que pedia:
1. Template CSV com 3+ exemplos — já existia em `client/public/template-solaris-questions.csv` + `docs/uat/solaris-questions-uat-v1.csv` (12 perguntas)
2. Guia de preenchimento — ESTE PR entrega (`ONDA-1-SOLARIS-CSV-SPEC.md`)

## Declaração final

Docs-only. Sem risco operacional. Pode ser mergeado direto.