### PR TITLE
feat(ux): guia Sim/Não/N.A. no Questionário IA Gen (Onda 2)

### DIFF
--- a/client/src/pages/QuestionarioIaGen.tsx
+++ b/client/src/pages/QuestionarioIaGen.tsx
@@ -33,6 +33,31 @@ interface Pergunta {
   confidence_score: number;
 }
 
+// ─── Prefix helper (fix UAT 2026-04-20 — opção A2) ───────────────────────────
+// Sugere formato Sim/Não/N.A. + justificativa sem alterar schema.
+// Backend continua aceitando qualquer texto em iagen_answers.resposta.
+
+const PREFIX_OPTIONS = [
+  { prefix: "Sim. ", label: "Sim", testId: "sim" },
+  { prefix: "Não. ", label: "Não", testId: "nao" },
+  { prefix: "N/A. ", label: "Não se aplica", testId: "na" },
+] as const;
+
+const KNOWN_PREFIXES = PREFIX_OPTIONS.map((o) => o.prefix);
+
+/**
+ * Aplica um prefixo (Sim./Não./N/A.) ao texto atual.
+ * - Se já tem um prefixo conhecido → substitui
+ * - Se não tem → prepend no início preservando o texto
+ */
+function applyPrefix(currentText: string, newPrefix: string): string {
+  const existing = KNOWN_PREFIXES.find((p) => currentText.startsWith(p));
+  if (existing) {
+    return newPrefix + currentText.slice(existing.length);
+  }
+  return newPrefix + currentText;
+}
+
 export default function QuestionarioIaGen() {
   const params = useParams<{ id: string }>();
   const projectId = Number(params.id);
@@ -264,13 +289,38 @@ export default function QuestionarioIaGen() {
               Objetivo: {perguntaAtual.objetivo_diagnostico}
             </p>
 
+            {/* fix UAT 2026-04-20: guia de formato + botões de prefix — respostas ganham
+                consistência visual sem mudança de schema (opção A2 · mesmo padrão da Onda 1). */}
+            <p className="text-xs text-muted-foreground mb-2">
+              💡 Formato sugerido: <strong>Sim</strong>, <strong>Não</strong> ou <strong>Não se aplica</strong> — seguido de justificativa breve.
+            </p>
+
+            <div className="flex gap-2 flex-wrap mb-2" data-testid="prefix-buttons">
+              {PREFIX_OPTIONS.map((opt) => (
+                <Button
+                  key={opt.prefix}
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() =>
+                    handleResposta(applyPrefix(respostas[perguntaAtual.id] ?? "", opt.prefix))
+                  }
+                  data-testid={`prefix-btn-${opt.testId}`}
+                  className="h-7 text-xs"
+                >
+                  {opt.label}
+                </Button>
+              ))}
+            </div>
+
             {/* Campo de resposta */}
             <Textarea
-              placeholder="Digite sua resposta aqui..."
+              placeholder="Ex: Sim. A empresa possui sistema de NF-e integrado com emissão automática..."
               value={respostas[perguntaAtual.id] ?? ""}
               onChange={(e) => handleResposta(e.target.value)}
               className="min-h-[120px] resize-none"
               autoFocus
+              data-testid={`textarea-resposta-${perguntaAtual.id}`}
             />
 
             {(respostas[perguntaAtual.id] ?? "").trim().length > 0 && (


### PR DESCRIPTION
## Escopo

Estende para a Onda 2 (IA Gen) o mesmo fix A2 aplicado na Onda 1 no PR #758 (mergeado).

## Arquivo

`client/src/pages/QuestionarioIaGen.tsx`

## Motivo

Consistência UX entre as ondas. Como ambas usam Textarea de texto livre, aplicar o mesmo guia de formato evita que o usuário tenha que adaptar o comportamento entre Onda 1 e Onda 2.

## Detalhes

- 3 botões "Sim / Não / Não se aplica" acima do Textarea
- Click insere prefixo ("Sim. ", "Não. ", "N/A. ") preservando texto existente
- Substitui prefixo anterior se já houver (não duplica)
- Placeholder realista: "Ex: Sim. A empresa possui sistema de NF-e integrado..."
- Helpers `PREFIX_OPTIONS` + `applyPrefix` duplicados do padrão Onda 1 (refactor para shared util é débito menor — tracker em sprint futura)

## Escopo

- [x] Feature UX
- [x] Frontend apenas
- [x] Baixo risco (aditivo)

## Declaração de escopo

- [x] NÃO altera schema
- [x] NÃO altera contrato tRPC
- [x] NÃO toca getDiagnosticSource
- [x] NÃO impacta RAG
- [x] NÃO executa DROP COLUMN
- [x] Respostas antigas sem prefixo continuam válidas

## Validação

`pnpm check` — 0 erros.

```json
{
  "head": "7f8a784",
  "branch": "feat/iagen-prefix-buttons",
  "arquivos": ["client/src/pages/QuestionarioIaGen.tsx"],
  "tests_passed": 0,
  "typescript_errors": 0,
  "risk_level": "low",
  "data_integrity": true,
  "regression": false,
  "rag_impact": false,
  "unexpected_behavior": false
}
```

## Classificação da task

- [x] Nível 1 — Seguro

## Auto-auditoria Q1–Q7

```
Q1 Tipos nulos:         [ OK ] — respostas[id] ?? ""
Q2 SQL TiDB:            [ N/A ]
Q3 Filtros NULL/'':     [ OK ]
Q4 Endpoint registrado: [ N/A ]
Q5 isError != vazio:    [ N/A ]
Q6 Retorno explícito:   [ N/A ]
Q7 Driver único:        [ N/A ]
R9 Evento estruturado:  [ N/A ]
S6 Rollback declarado:  [ OK ]

Risk score: low
Resultado: APTO PARA COMMIT
```

## Auto-auditoria Q1–5

- Q1 OK · Q2 N/A · Q3 OK · Q4 N/A · Q5 N/A · Q8 OK
- **Resultado: APTO PARA COMMIT**

## Checklist final

- [x] Código revisado pelo próprio autor
- [x] Evidência JSON preenchida
- [x] Sem arquivos fora do escopo
- [x] Documentação não exige atualização
- [x] Feature flag N/A

## Declaração final

Extensão natural do PR #758 para manter consistência entre ondas. Zero risco de regressão.