### PR TITLE
fix: briefing determinismo + botões Sim/Não/N.A. em NCM/NBS

### DIFF
--- a/client/src/pages/BriefingV3.tsx
+++ b/client/src/pages/BriefingV3.tsx
@@ -285,6 +285,12 @@ export default function BriefingV3() {
   // q_servico: isToBeFlowState cobre; após skip CNAE transita para diagnostico_cnae (fix B-Z11-012)
   // Guard mantém q_servico para navegação direta antes do skip (B-Z11-011)
   const canApprove = ['diagnostico_cnae', 'briefing', 'q_servico'].includes((project as any)?.status ?? '');
+  // fix(N5 UAT 2026-04-20): status pós-aprovação → briefing já aprovado. Não exibir banner
+  // "Diagnóstico incompleto" (seria contraditório com o banner "Briefing aprovado anteriormente").
+  const isAlreadyApproved = [
+    'matriz_riscos', 'plano_acao', 'em_avaliacao', 'aprovado',
+    'em_andamento', 'concluido', 'arquivado'
+  ].includes((project as any)?.status ?? '');
 
   const handleApprove = async () => {
     if (!briefing) return;
@@ -731,6 +737,8 @@ export default function BriefingV3() {
                     <Button
                       variant="ghost"
                       size="sm"
+                      // fix(UX2 UAT 2026-04-20): desabilita durante geração — evita double-click/múltiplas gerações simultâneas.
+                      disabled={isGenerating || generateBriefing.isPending}
                       onClick={() => {
                         // fix(G5 UAT 2026-04-20): confirmação antes de regenerar — evita perder edição em andamento.
                         // Exibe somente se há briefing atual (primeira geração não precisa confirmar).
@@ -747,8 +755,8 @@ export default function BriefingV3() {
                       className="text-xs gap-1.5"
                       data-testid="btn-regenerar-briefing"
                     >
-                      <RefreshCw className="h-3.5 w-3.5" />
-                      Regenerar
+                      {isGenerating ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+                      {isGenerating ? "Gerando..." : "Regenerar"}
                     </Button>
                   )}
                 </div>
@@ -783,7 +791,8 @@ export default function BriefingV3() {
                   </div>
                 </div>
                 {/* B-Z11-010: aviso quando status não permite aprovar */}
-                {!canApprove && (
+                {/* fix(N5 UAT 2026-04-20): só exibir se NÃO está pós-aprovação */}
+                {!canApprove && !isAlreadyApproved && (
                   <div className="flex items-start gap-3 p-4 rounded-xl bg-red-50 border border-red-200">
                     <AlertCircle className="h-5 w-5 text-red-600 shrink-0 mt-0.5" />
                     <div>

--- a/client/src/pages/QuestionarioProduto.tsx
+++ b/client/src/pages/QuestionarioProduto.tsx
@@ -26,6 +26,25 @@ import {
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
 
+// ─── Prefix helper (fix UAT 2026-04-20 — opção A2, padrão Onda 1/2) ─────────
+// Sugere formato Sim/Não/N.A. + justificativa. Backend aceita qualquer texto.
+
+const PREFIX_OPTIONS = [
+  { prefix: "Sim. ", label: "Sim", testId: "sim" },
+  { prefix: "Não. ", label: "Não", testId: "nao" },
+  { prefix: "N/A. ", label: "Não se aplica", testId: "na" },
+] as const;
+
+const KNOWN_PREFIXES = PREFIX_OPTIONS.map((o) => o.prefix);
+
+function applyPrefix(currentText: string, newPrefix: string): string {
+  const existing = KNOWN_PREFIXES.find((p) => currentText.startsWith(p));
+  if (existing) {
+    return newPrefix + currentText.slice(existing.length);
+  }
+  return newPrefix + currentText;
+}
+
 export default function QuestionarioProduto() {
   const [, params] = useRoute("/projetos/:id/questionario-produto");
   const projectId = parseInt(params?.id ?? "0");
@@ -168,12 +187,39 @@ export default function QuestionarioProduto() {
             )}
           </CardHeader>
           <CardContent className="space-y-3">
+            {/* fix UAT 2026-04-20: guia de formato + botões de prefix — padrão das Ondas 1 e 2. */}
+            <p className="text-xs text-muted-foreground">
+              💡 Formato sugerido: <strong>Sim</strong>, <strong>Não</strong> ou <strong>Não se aplica</strong> — seguido de justificativa breve.
+            </p>
+
+            <div className="flex gap-2 flex-wrap" data-testid="prefix-buttons">
+              {PREFIX_OPTIONS.map((opt) => (
+                <Button
+                  key={opt.prefix}
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() =>
+                    setAnswers((prev) => ({
+                      ...prev,
+                      [perguntaAtual.id]: applyPrefix(prev[perguntaAtual.id] ?? "", opt.prefix),
+                    }))
+                  }
+                  data-testid={`prefix-btn-${opt.testId}`}
+                  className="h-7 text-xs"
+                >
+                  {opt.label}
+                </Button>
+              ))}
+            </div>
+
             <Textarea
-              placeholder="Digite sua resposta aqui…"
+              placeholder="Ex: Sim. O NCM está cadastrado corretamente conforme TIPI..."
               value={answers[perguntaAtual.id] ?? ""}
               onChange={(e) => setAnswers((prev) => ({ ...prev, [perguntaAtual.id]: e.target.value }))}
               rows={4}
               className="resize-none"
+              data-testid={`textarea-resposta-${perguntaAtual.id}`}
             />
             {/* ADR-0016 BUG-NCM-01: Botão Pular pergunta */}
             {!answers[perguntaAtual.id]?.trim() && !skippedIds.has(String(perguntaAtual.id)) && (

--- a/client/src/pages/QuestionarioServico.tsx
+++ b/client/src/pages/QuestionarioServico.tsx
@@ -27,6 +27,24 @@ import {
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
 
+// ─── Prefix helper (fix UAT 2026-04-20 — opção A2, padrão Onda 1/2) ─────────
+
+const PREFIX_OPTIONS = [
+  { prefix: "Sim. ", label: "Sim", testId: "sim" },
+  { prefix: "Não. ", label: "Não", testId: "nao" },
+  { prefix: "N/A. ", label: "Não se aplica", testId: "na" },
+] as const;
+
+const KNOWN_PREFIXES = PREFIX_OPTIONS.map((o) => o.prefix);
+
+function applyPrefix(currentText: string, newPrefix: string): string {
+  const existing = KNOWN_PREFIXES.find((p) => currentText.startsWith(p));
+  if (existing) {
+    return newPrefix + currentText.slice(existing.length);
+  }
+  return newPrefix + currentText;
+}
+
 export default function QuestionarioServico() {
   const [, params] = useRoute("/projetos/:id/questionario-servico");
   const projectId = parseInt(params?.id ?? "0");
@@ -166,12 +184,39 @@ export default function QuestionarioServico() {
             )}
           </CardHeader>
           <CardContent className="space-y-3">
+            {/* fix UAT 2026-04-20: guia de formato + botões de prefix — padrão das Ondas 1 e 2. */}
+            <p className="text-xs text-muted-foreground">
+              💡 Formato sugerido: <strong>Sim</strong>, <strong>Não</strong> ou <strong>Não se aplica</strong> — seguido de justificativa breve.
+            </p>
+
+            <div className="flex gap-2 flex-wrap" data-testid="prefix-buttons">
+              {PREFIX_OPTIONS.map((opt) => (
+                <Button
+                  key={opt.prefix}
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() =>
+                    setAnswers((prev) => ({
+                      ...prev,
+                      [perguntaAtual.id]: applyPrefix(prev[perguntaAtual.id] ?? "", opt.prefix),
+                    }))
+                  }
+                  data-testid={`prefix-btn-${opt.testId}`}
+                  className="h-7 text-xs"
+                >
+                  {opt.label}
+                </Button>
+              ))}
+            </div>
+
             <Textarea
-              placeholder="Digite sua resposta aqui…"
+              placeholder="Ex: Sim. O NBS está corretamente classificado para a transição ISS→IBS..."
               value={answers[perguntaAtual.id] ?? ""}
               onChange={(e) => setAnswers((prev) => ({ ...prev, [perguntaAtual.id]: e.target.value }))}
               rows={4}
               className="resize-none"
+              data-testid={`textarea-resposta-${perguntaAtual.id}`}
             />
             {/* ADR-0016 BUG-NCM-01: Botão Pular pergunta */}
             {!answers[perguntaAtual.id]?.trim() && !skippedIds.has(String(perguntaAtual.id)) && (

--- a/server/routers-fluxo-v3.ts
+++ b/server/routers-fluxo-v3.ts
@@ -1100,6 +1100,17 @@ RESPONSABILIDADES:
 4. Identificar inconsistências nas respostas quando existirem
 5. Gerar confidence score honesto com limitações declaradas
 
+REGRA DE DETERMINISMO (fix N1b UAT 2026-04-20):
+- Use APENAS critérios objetivos. Mesma entrada → mesma saída.
+- Dois gaps com mesma base legal devem sempre aparecer na mesma ordem (alfabética por artigo).
+- Nível de risco é função determinística: "alto" se >=2 gaps com urgência=imediata; "medio" se 1 gap imediata; "baixo" apenas se 0 gap imediata.
+
+REGRA CRÍTICA — INCONSISTÊNCIAS vs LIMITAÇÕES (fix N2 UAT 2026-04-20):
+- "inconsistencias" = APENAS contradições diretas entre duas respostas (ex: "Sim" em P1 + "Não" em P2 para temas correlatos).
+- "inconsistencias" NUNCA deve incluir: "falta de informação", "ausência de resposta", "impossibilidade de aferir", "não informado", "sem dados detalhados" — TUDO ISSO vai em "confidence_score.limitacoes".
+- Se a única "contradição" detectada é que o usuário não respondeu, NÃO liste como inconsistência. Liste como limitação.
+- Array "inconsistencias" pode ser vazio [] — e isso é saudável.
+
 ${regulatoryContext}
 
 ${OUTPUT_CONTRACT}`,
@@ -1121,7 +1132,10 @@ Gere o Briefing estruturado em JSON:
           },
         ],
         BriefingStructuredSchema,
-        { temperature: 0.2, context: "generateBriefing" }
+        // fix(T1 UAT 2026-04-20): temperatura 0 para máximo determinismo. Variabilidade
+        // observada com T=0.2 (2→1→2 inconsistências em gerações consecutivas) era
+        // inaceitável no contexto jurídico. Com T=0, mesma entrada → (quase) mesma saída.
+        { temperature: 0, context: "generateBriefing" }
       );
 
       // Converter estruturado para Markdown (compatibilidade com UI existente)
@@ -2343,6 +2357,17 @@ REGRA OBRIGATÓRIA — IBS INTERESTADUAL (B-Z11-003/004 fix):
 - NUNCA inverter causas raiz: se o gap é de operação interestadual, a causa é a partilha IBS (Art. 15), não o regime de bens pessoais (Art. 57).
 - Se o gap é de crédito IBS/CBS, a causa_raiz deve ser sobre apuração de créditos, não sobre obrigações acessórias.
 
+REGRA DE DETERMINISMO (fix N1b UAT 2026-04-20):
+- Use APENAS critérios objetivos. Mesma entrada → mesma saída.
+- Gaps ordenados alfabeticamente por artigo da base legal.
+- Nível de risco é função determinística: "alto" se >=2 gaps com urgência=imediata; "medio" se 1 gap imediata; "baixo" apenas se 0 gap imediata.
+
+REGRA CRÍTICA — INCONSISTÊNCIAS vs LIMITAÇÕES (fix N2 UAT 2026-04-20):
+- "inconsistencias" = APENAS contradições diretas entre duas respostas (ex: "Sim" em P1 + "Não" em P2 para temas correlatos).
+- "inconsistencias" NUNCA deve incluir: "falta de informação", "ausência de resposta", "impossibilidade de aferir", "não informado", "sem dados detalhados" — TUDO ISSO vai em "confidence_score.limitacoes".
+- Se a única "contradição" detectada é que o usuário não respondeu, NÃO liste como inconsistência. Liste como limitação.
+- Array "inconsistencias" pode ser vazio [] — e isso é saudável.
+
 ${regulatoryContext}
 
 ${OC}`,
@@ -2369,7 +2394,8 @@ Gere o Briefing estruturado em JSON:
           },
         ],
         BriefingStructuredSchema,
-        { temperature: 0.2, context: "generateBriefingFromDiagnostic" }
+        // fix(T1 UAT 2026-04-20): alinhado com generateBriefing — temperatura 0.
+        { temperature: 0, context: "generateBriefingFromDiagnostic" }
       );
 
       const { buildBriefingMarkdown } = await import("./routers-fluxo-v3").then(m => ({


### PR DESCRIPTION
## Escopo

6 fixes aprovados pelo P.O. após auditoria E2E do briefing (sessão 2026-04-20) + extensão dos botões de prefix para Q. Produtos (NCM) e Q. Serviços (NBS).

**Zero schema change. Zero UPDATE/INSERT em tabelas.** Apenas prompt tuning + frontend.

## Motivação (evidência)

Análise de 4 PDFs baseline do projeto "Transportadora Combustíveis Perigosos":

| Baseline | Versão | Inconsistências |
|---|---|---|
| exportacao | 1 | 2 genéricas |
| 1 | 2 | 1 ("Impossibilidade de aferir...") |
| 2 | 3 | 2 específicas |
| 4 | pós-aprov | 1 específica (código de serviço) |

Variabilidade 2→1→2→1 inesperada para temperatura=0.2. Inconsistência "Impossibilidade de aferir" não deveria existir (é limitação, não contradição).

## Fixes

### Briefing — determinismo

- **T1** — `temperature: 0.2 → 0` nos 2 generateBriefing
- **N1b** — Prompt reforça determinismo (ordem alfabética, regras objetivas)
- **N2** — Prompt separa inconsistências (contradições) vs limitações (falta de dados)

### Briefing — UX

- **N5** — Banner "Diagnóstico incompleto" escondido quando status é pós-aprovação (matriz_riscos, aprovado, etc.)
- **UX2** — Botão "Regenerar" desabilitado + loader durante mutation

### Extensão prefix buttons

- **NCM/NBS** — Mesmo padrão Sim/Não/Não se aplica aplicado em `QuestionarioProduto.tsx` + `QuestionarioServico.tsx`

## Arquivos

- `server/routers-fluxo-v3.ts` (T1 + N1b + N2)
- `client/src/pages/BriefingV3.tsx` (N5 + UX2)
- `client/src/pages/QuestionarioProduto.tsx` (NCM prefix)
- `client/src/pages/QuestionarioServico.tsx` (NBS prefix)

## Escopo

- [x] Bugfix + Feature UX
- [x] Backend (prompt) + Frontend
- [x] Baixo risco

## Declaração de escopo

- [x] NÃO altera schema
- [x] NÃO toca getDiagnosticSource
- [x] NÃO impacta RAG (apenas temperatura LLM)
- [x] NÃO ativa DIAGNOSTIC_READ_MODE=new
- [x] NÃO executa DROP COLUMN
- [x] NÃO UPDATE/INSERT em tabelas

## Validação

`pnpm check` — 0 erros.

```json
{
  "head": "5f84abb",
  "branch": "fix/briefing-determinismo-e-prefix-buttons-ncm-nbs",
  "arquivos": ["server/routers-fluxo-v3.ts", "client/src/pages/BriefingV3.tsx", "client/src/pages/QuestionarioProduto.tsx", "client/src/pages/QuestionarioServico.tsx"],
  "tests_passed": 0,
  "typescript_errors": 0,
  "risk_level": "low",
  "data_integrity": true,
  "regression": false,
  "rag_impact": false,
  "unexpected_behavior": false
}
```

## Classificação

- [x] Nível 1 — Seguro

## Auto-auditoria Q1–Q7

```
Q1 Tipos nulos:         [ OK ] — isAlreadyApproved com fallback status ?? ''
Q2 SQL TiDB:            [ N/A ] — sem queries
Q3 Filtros NULL/'':     [ OK ]
Q4 Endpoint registrado: [ N/A ] — reusa procedures existentes
Q5 isError != vazio:    [ OK ] — isGenerating/isPending guards
Q6 Retorno explícito:   [ N/A ] — apenas prompt tuning
Q7 Driver único:        [ N/A ]
R9 Evento estruturado:  [ N/A ]
S6 Rollback declarado:  [ OK ] — revert do commit

Risk score: low
Resultado: APTO PARA COMMIT
```

## Auto-auditoria Q1–5

- Q1 OK · Q2 N/A · Q3 OK · Q4 N/A · Q5 OK · Q8 OK
- **Resultado: APTO PARA COMMIT**

## Pós-deploy — esperado

| Teste | Antes | Depois |
|---|---|---|
| Regerar briefing 3x seguidas | Inconsistências variam 2→1→2 | Estável (T=0 + prompt rígido) |
| Inconsistência "falta de dados" | Aparece em badge vermelho | Vai para "limitações" (não badge) |
| Banner pós-aprovação | "Diagnóstico incompleto" aparece | Escondido |
| Click Regenerar | Botão reclicável durante geração | Desabilitado + "Gerando..." |
| Questionário NCM (Produtos) | Textarea plain | Botões Sim/Não/N.A. + placeholder |
| Questionário NBS (Serviços) | Textarea plain | Botões Sim/Não/N.A. + placeholder |

## Checklist final

- [x] Código revisado
- [x] Evidência JSON preenchida
- [x] Sem arquivos fora do escopo
- [x] Documentação não exige atualização
- [x] Feature flag N/A

## Declaração final

Pacote pragmático coeso — melhora determinismo do briefing sem tocar schema e padroniza UX dos 4 questionários (Solaris/IaGen/NCM/NBS).