### PR TITLE
fix(briefing): NCM/NBS agora chegam ao prompt do LLM

### DIFF
--- a/client/src/pages/QuestionarioProduto.tsx
+++ b/client/src/pages/QuestionarioProduto.tsx
@@ -115,11 +115,15 @@ export default function QuestionarioProduto() {
   const isLast = currentIndex === total - 1;
 
   const handleFinalize = () => {
+    // fix(briefing 2026-04-20): persistir pergunta_texto + ncm_code para que o briefing LLM
+    // receba o texto real das perguntas NCM (antes apenas pergunta_id chegava ao prompt).
     const respostas = perguntas.map((p) => ({
       pergunta_id: p.id,
+      pergunta_texto: (p as any).texto ?? (p as any).pergunta ?? "",
+      ncm_code: (p as any).ncm ?? undefined,
       resposta: answers[p.id] ?? "",
-      fonte_ref: "NCM",
-      lei_ref: "LC 214/2025",
+      fonte_ref: (p as any).fonte_ref ?? "NCM",
+      lei_ref: (p as any).lei_ref ?? "LC 214/2025",
     }));
     completeMutation.mutate({ projectId, respostas });
   };

--- a/client/src/pages/QuestionarioServico.tsx
+++ b/client/src/pages/QuestionarioServico.tsx
@@ -112,11 +112,15 @@ export default function QuestionarioServico() {
   const isLast = currentIndex === total - 1;
 
   const handleFinalize = () => {
+    // fix(briefing 2026-04-20): persistir pergunta_texto + nbs_code para que o briefing LLM
+    // receba o texto real das perguntas NBS (antes apenas pergunta_id chegava ao prompt).
     const respostas = perguntas.map((p) => ({
       pergunta_id: p.id,
+      pergunta_texto: (p as any).texto ?? (p as any).pergunta ?? "",
+      nbs_code: (p as any).nbs ?? undefined,
       resposta: answers[p.id] ?? "",
-      fonte_ref: "NBS",
-      lei_ref: "LC 214/2025",
+      fonte_ref: (p as any).fonte_ref ?? "NBS",
+      lei_ref: (p as any).lei_ref ?? "LC 214/2025",
     }));
     completeMutation.mutate({ projectId, respostas });
   };

--- a/server/diagnostic-consolidator.ts
+++ b/server/diagnostic-consolidator.ts
@@ -443,30 +443,38 @@ export function buildProductServiceLayers(
 ): DiagnosticLayer[] {
   const layers: DiagnosticLayer[] = [];
 
-  const toQuestions = (answers: any): DiagnosticAnswer[] => {
+  // fix(briefing 2026-04-20): aceita pergunta_texto (novo formato Z-02 pós-fix)
+  // e encoda NCM/NBS no prefixo da pergunta para alimentar o prompt do LLM.
+  const prefixWithCode = (text: string, code?: string): string => {
+    const t = (text ?? "").trim();
+    if (!code) return t;
+    return `[${code}] ${t}`;
+  };
+
+  const toQuestions = (answers: any, codeField: "ncm_code" | "nbs_code"): DiagnosticAnswer[] => {
     if (!answers) return [];
     // TrackedAnswer[] — formato Z-02
     if (Array.isArray(answers)) {
       return answers
-        .filter((a: any) => a && (a.pergunta || a.question) && (a.resposta || a.answer))
+        .filter((a: any) => a && (a.pergunta_texto || a.pergunta || a.question) && (a.resposta || a.answer))
         .map((a: any) => ({
-          question: a.pergunta ?? a.question ?? "",
-          answer: a.resposta ?? a.answer ?? "",
+          question: prefixWithCode(a.pergunta_texto ?? a.pergunta ?? a.question ?? "", a[codeField]),
+          answer: String(a.resposta ?? a.answer ?? ""),
         }));
     }
     // Objeto com campo 'perguntas' (formato Z-01 legado)
     if (answers.perguntas && Array.isArray(answers.perguntas)) {
       return answers.perguntas
-        .filter((a: any) => a && (a.pergunta || a.question))
+        .filter((a: any) => a && (a.pergunta_texto || a.pergunta || a.question))
         .map((a: any) => ({
-          question: a.pergunta ?? a.question ?? "",
-          answer: a.resposta ?? a.answer ?? "Não respondido",
+          question: prefixWithCode(a.pergunta_texto ?? a.pergunta ?? a.question ?? "", a[codeField]),
+          answer: String(a.resposta ?? a.answer ?? "Não respondido"),
         }));
     }
     return [];
   };
 
-  const productQs = toQuestions(productAnswers);
+  const productQs = toQuestions(productAnswers, "ncm_code");
   if (productQs.length > 0) {
     layers.push({
       cnaeCode: "NCM_PRODUTO",
@@ -476,7 +484,7 @@ export function buildProductServiceLayers(
     });
   }
 
-  const serviceQs = toQuestions(serviceAnswers);
+  const serviceQs = toQuestions(serviceAnswers, "nbs_code");
   if (serviceQs.length > 0) {
     layers.push({
       cnaeCode: "NBS_SERVICO",

--- a/server/routers-fluxo-v3.ts
+++ b/server/routers-fluxo-v3.ts
@@ -1081,9 +1081,27 @@ Gere as perguntas no formato:
       const primaryCnae = confirmedCnaes[0]
         ? `${confirmedCnaes[0].code} — ${(confirmedCnaes[0] as any).description || confirmedCnaes[0].code}`
         : (input.allAnswers[0]?.cnaeCode ?? "não informado");
+
+      // fix(briefing 2026-04-20): inclui NCMs e NBS do operationProfile no perfil da empresa,
+      // para que o LLM considere alíquota zero/Imposto Seletivo/regime diferenciado por produto/serviço.
+      const opProfile = projectAnyBriefing.operationProfile as {
+        principaisProdutos?: Array<{ ncm_code?: string; descricao?: string }>;
+        principaisServicos?: Array<{ nbs_code?: string; descricao?: string }>;
+      } | null | undefined;
+      const produtosList = (opProfile?.principaisProdutos ?? [])
+        .filter((p) => p?.ncm_code)
+        .map((p) => `  - NCM ${p.ncm_code}${p.descricao ? ` — ${p.descricao}` : ""}`)
+        .join("\n");
+      const servicosList = (opProfile?.principaisServicos ?? [])
+        .filter((s) => s?.nbs_code)
+        .map((s) => `  - NBS ${s.nbs_code}${s.descricao ? ` — ${s.descricao}` : ""}`)
+        .join("\n");
+      const produtosBlock = produtosList ? `\n- Principais Produtos (NCM):\n${produtosList}` : "";
+      const servicosBlock = servicosList ? `\n- Principais Serviços (NBS):\n${servicosList}` : "";
+
       const companyProfileBlock = cp
-        ? `## Perfil da Empresa\n- Razão Social: ${project.name}\n- CNAE Principal: ${primaryCnae}\n- Porte: ${cp.companySize ?? "não informado"}\n- Regime Tributário: ${cp.taxRegime ?? "não informado"}\n- Faturamento Anual: ${cp.annualRevenueRange ?? "não informado"}`
-        : `## Perfil da Empresa\n- Razão Social: ${project.name}\n- CNAE Principal: ${primaryCnae}\n- Porte: não informado\n- Regime Tributário: não informado`;
+        ? `## Perfil da Empresa\n- Razão Social: ${project.name}\n- CNAE Principal: ${primaryCnae}\n- Porte: ${cp.companySize ?? "não informado"}\n- Regime Tributário: ${cp.taxRegime ?? "não informado"}\n- Faturamento Anual: ${cp.annualRevenueRange ?? "não informado"}${produtosBlock}${servicosBlock}`
+        : `## Perfil da Empresa\n- Razão Social: ${project.name}\n- CNAE Principal: ${primaryCnae}\n- Porte: não informado\n- Regime Tributário: não informado${produtosBlock}${servicosBlock}`;
 
       // V60: Geração com retry + temperatura 0.2 + schema estruturado
       // fix(UX3 UAT 2026-04-20): contador de retries para propagar ao frontend
@@ -2298,6 +2316,31 @@ Gere o veredito final em JSON:
       // Montar bloco de texto adicional para o userPrompt
       const additionalContext: string[] = [];
 
+      // fix(briefing 2026-04-20): inclui NCMs e NBS do operationProfile, para que o LLM
+      // considere alíquota zero, Imposto Seletivo e regime diferenciado por produto/serviço.
+      const opProfileForBriefing = p.operationProfile as {
+        principaisProdutos?: Array<{ ncm_code?: string; descricao?: string }>;
+        principaisServicos?: Array<{ nbs_code?: string; descricao?: string }>;
+      } | null | undefined;
+      const ncmItens = (opProfileForBriefing?.principaisProdutos ?? []).filter((p) => p?.ncm_code);
+      const nbsItens = (opProfileForBriefing?.principaisServicos ?? []).filter((s) => s?.nbs_code);
+      if (ncmItens.length > 0 || nbsItens.length > 0) {
+        additionalContext.push('<perfil_produtos_servicos>');
+        if (ncmItens.length > 0) {
+          additionalContext.push('Principais Produtos (NCM):');
+          ncmItens.forEach((p) => {
+            additionalContext.push(`- NCM ${p.ncm_code}${p.descricao ? ` — ${p.descricao}` : ''}`);
+          });
+        }
+        if (nbsItens.length > 0) {
+          additionalContext.push('Principais Serviços (NBS):');
+          nbsItens.forEach((s) => {
+            additionalContext.push(`- NBS ${s.nbs_code}${s.descricao ? ` — ${s.descricao}` : ''}`);
+          });
+        }
+        additionalContext.push('</perfil_produtos_servicos>');
+      }
+
       if (specializedCnaeAnswers) {
         additionalContext.push('<qcnae_especializado>');
         additionalContext.push(JSON.stringify(specializedCnaeAnswers, null, 2));
@@ -3126,6 +3169,9 @@ confidence_score entre 0.7 e 1.0 para perguntas de alta qualidade.`;
       projectId: z.number().int().positive(),
       respostas: z.array(z.object({
         pergunta_id: z.string(),
+        // fix(briefing 2026-04-20): texto da pergunta + NCM agora persistidos para alimentar buildProductServiceLayers/briefing LLM.
+        pergunta_texto: z.string().optional(),
+        ncm_code: z.string().optional(),
         resposta: z.union([z.string(), z.boolean(), z.number()]),
         fonte_ref: z.string().min(1, 'fonte_ref obrigatório — Contrato DEC-M3-05 Parte 1'),
         lei_ref:   z.string().min(1, 'lei_ref obrigatório — Contrato DEC-M3-05 Parte 1'),
@@ -3165,6 +3211,9 @@ confidence_score entre 0.7 e 1.0 para perguntas de alta qualidade.`;
       projectId: z.number().int().positive(),
       respostas: z.array(z.object({
         pergunta_id: z.string(),
+        // fix(briefing 2026-04-20): texto da pergunta + NBS agora persistidos para alimentar buildProductServiceLayers/briefing LLM.
+        pergunta_texto: z.string().optional(),
+        nbs_code: z.string().optional(),
         resposta: z.union([z.string(), z.boolean(), z.number()]),
         fonte_ref: z.string().min(1, 'fonte_ref obrigatório — Contrato DEC-M3-05 Parte 1'),
         lei_ref:   z.string().min(1, 'lei_ref obrigatório — Contrato DEC-M3-05 Parte 1'),


### PR DESCRIPTION
## Summary

- Questionário de Produtos (NCM) e Serviços (NBS) agora persistem **pergunta_texto + código NCM/NBS** — antes gravavam apenas `pergunta_id` + `fonte_ref` genérica.
- `buildProductServiceLayers` usa o texto real da pergunta e prefixa `[NCM xxxxxxxx]` / `[NBS xxxxxxxx]` na pergunta enviada ao LLM.
- `generateBriefing.companyProfileBlock` inclui NCMs e NBS do `operationProfile`.
- `generateBriefingFromDiagnostic.additionalContext` inclui bloco `<perfil_produtos_servicos>` com NCMs/NBS.

**Root cause (UAT 2026-04-20):** briefing não analisava alíquota zero, Imposto Seletivo ou regime diferenciado porque os códigos NCM/NBS nunca chegavam ao prompt.

**Sem schema change** — apenas nova estrutura dentro das colunas JSON `productAnswers` / `serviceAnswers` existentes.

## Arquivos

- `server/routers-fluxo-v3.ts` — `completeProductQuestionnaire`, `completeServiceQuestionnaire`, `generateBriefing`, `generateBriefingFromDiagnostic`.
- `server/diagnostic-consolidator.ts` — `buildProductServiceLayers`.
- `client/src/pages/QuestionarioProduto.tsx` — `handleFinalize`.
- `client/src/pages/QuestionarioServico.tsx` — `handleFinalize`.

## Test plan

- [x] `pnpm check` — zero erros.
- [ ] UAT: responder Q.Produtos + Q.Serviços → verificar no briefing se alíquota zero / Imposto Seletivo / regime diferenciado aparece citando NCM/NBS específicos.
- [ ] UAT: projeto sem NCM/NBS → briefing continua genérico (sem bloco perfil_produtos_servicos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)