### PR TITLE
fix(briefing): parse operationProfile quando chega como string (pós-#768)

### DIFF
--- a/server/routers-fluxo-v3.ts
+++ b/server/routers-fluxo-v3.ts
@@ -1084,10 +1084,25 @@ Gere as perguntas no formato:
 
       // fix(briefing 2026-04-20): inclui NCMs e NBS do operationProfile no perfil da empresa,
       // para que o LLM considere alíquota zero/Imposto Seletivo/regime diferenciado por produto/serviço.
-      const opProfile = projectAnyBriefing.operationProfile as {
+      // fix-of-fix(briefing 2026-04-20 pós-#768): operationProfile pode chegar como string em alguns
+      // fluxos (B-Z13.5-001). Aplica parse defensivo antes de ler principaisProdutos/principaisServicos.
+      const opProfileRaw = projectAnyBriefing.operationProfile;
+      const opProfile: {
         principaisProdutos?: Array<{ ncm_code?: string; descricao?: string }>;
         principaisServicos?: Array<{ nbs_code?: string; descricao?: string }>;
-      } | null | undefined;
+      } = (() => {
+        if (!opProfileRaw) return {};
+        if (typeof opProfileRaw === "string") {
+          try {
+            const parsed = JSON.parse(opProfileRaw);
+            return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+          } catch { return {}; }
+        }
+        if (typeof opProfileRaw === "object" && !Array.isArray(opProfileRaw)) {
+          return opProfileRaw as any;
+        }
+        return {};
+      })();
       const produtosList = (opProfile?.principaisProdutos ?? [])
         .filter((p) => p?.ncm_code)
         .map((p) => `  - NCM ${p.ncm_code}${p.descricao ? ` — ${p.descricao}` : ""}`)
@@ -2318,10 +2333,24 @@ Gere o veredito final em JSON:
 
       // fix(briefing 2026-04-20): inclui NCMs e NBS do operationProfile, para que o LLM
       // considere alíquota zero, Imposto Seletivo e regime diferenciado por produto/serviço.
-      const opProfileForBriefing = p.operationProfile as {
+      // fix-of-fix(briefing 2026-04-20 pós-#768): operationProfile pode chegar como string (B-Z13.5-001).
+      const opProfileRawFB = p.operationProfile;
+      const opProfileForBriefing: {
         principaisProdutos?: Array<{ ncm_code?: string; descricao?: string }>;
         principaisServicos?: Array<{ nbs_code?: string; descricao?: string }>;
-      } | null | undefined;
+      } = (() => {
+        if (!opProfileRawFB) return {};
+        if (typeof opProfileRawFB === "string") {
+          try {
+            const parsed = JSON.parse(opProfileRawFB);
+            return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+          } catch { return {}; }
+        }
+        if (typeof opProfileRawFB === "object" && !Array.isArray(opProfileRawFB)) {
+          return opProfileRawFB as any;
+        }
+        return {};
+      })();
       const ncmItens = (opProfileForBriefing?.principaisProdutos ?? []).filter((p) => p?.ncm_code);
       const nbsItens = (opProfileForBriefing?.principaisServicos ?? []).filter((s) => s?.nbs_code);
       if (ncmItens.length > 0 || nbsItens.length > 0) {


### PR DESCRIPTION
## Summary

**Fix-of-fix do PR #768.** No UAT 2026-04-20, o P.O. cadastrou 3 NCMs no projeto e regenerou o briefing — mas o output foi idêntico ao teste sem NCMs (nenhum código NCM citado).

**Root cause:** em alguns fluxos (documentado em post-mortem B-Z13.5-001), a coluna JSON `operationProfile` chega ao backend como **string crua**, não como objeto parseado. O PR #768 fez acesso direto `projectAnyBriefing.operationProfile?.principaisProdutos` — que retorna `undefined` silenciosamente quando a coluna é string.

## Fix

Parse defensivo inline (mesmo padrão já usado em `specializedCnaeAnswers` linha 2305-2308):
- `typeof string` → `JSON.parse` com try/catch
- `typeof object` → usa direto
- fallback → `{}`

## Arquivos

- `server/routers-fluxo-v3.ts` — `generateBriefing` (linha ~1084) + `generateBriefingFromDiagnostic` (linha ~2336).

## Test plan

- [x] `pnpm check` — zero erros.
- [ ] UAT: regenerar briefing em projeto com 3 NCMs cadastrados → verificar citação de `[NCM xxxxxxxx]` nos gaps.

Closes gap do UAT 2026-04-20 reportado pelo P.O.

🤖 Generated with [Claude Code](https://claude.com/claude-code)