### PR TITLE
fix(briefing): confidence determinístico server-side — Closes #771

### DIFF
--- a/server/lib/calculate-briefing-confidence.test.ts
+++ b/server/lib/calculate-briefing-confidence.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { calculateBriefingConfidence, type BriefingConfidenceSignals } from "./calculate-briefing-confidence";
+
+const ZERO: BriefingConfidenceSignals = {
+  solarisAnswersCount: 0,
+  iagenAnswersCount: 0,
+  productAnswersCount: 0,
+  serviceAnswersCount: 0,
+  cnaeAnswersCount: 0,
+  ncmCodesCount: 0,
+  nbsCodesCount: 0,
+};
+
+describe("calculateBriefingConfidence", () => {
+  it("retorna 30 quando total == 0 (sem respostas)", () => {
+    expect(calculateBriefingConfidence(ZERO)).toBe(30);
+  });
+
+  it("retorna 55 quando total < 5 (1-4 respostas)", () => {
+    expect(calculateBriefingConfidence({ ...ZERO, solarisAnswersCount: 1 })).toBe(55);
+    expect(calculateBriefingConfidence({ ...ZERO, solarisAnswersCount: 2, iagenAnswersCount: 2 })).toBe(55);
+  });
+
+  it("retorna 70 quando total 5-14", () => {
+    expect(calculateBriefingConfidence({ ...ZERO, solarisAnswersCount: 5 })).toBe(70);
+    expect(calculateBriefingConfidence({ ...ZERO, solarisAnswersCount: 10, iagenAnswersCount: 4 })).toBe(70);
+  });
+
+  it("retorna 80 quando total 15-29", () => {
+    expect(calculateBriefingConfidence({ ...ZERO, solarisAnswersCount: 15 })).toBe(80);
+    expect(calculateBriefingConfidence({ ...ZERO, solarisAnswersCount: 20, iagenAnswersCount: 9 })).toBe(80);
+  });
+
+  it("retorna 85 quando total >= 30 sem NCM/NBS", () => {
+    expect(calculateBriefingConfidence({ ...ZERO, solarisAnswersCount: 30 })).toBe(85);
+    expect(calculateBriefingConfidence({ ...ZERO, solarisAnswersCount: 50, iagenAnswersCount: 20 })).toBe(85);
+  });
+
+  it("retorna 90 quando total >= 30 com NCM cadastrado", () => {
+    expect(calculateBriefingConfidence({ ...ZERO, solarisAnswersCount: 30, ncmCodesCount: 3 })).toBe(90);
+  });
+
+  it("retorna 90 quando total >= 30 com NBS cadastrado", () => {
+    expect(calculateBriefingConfidence({ ...ZERO, solarisAnswersCount: 30, nbsCodesCount: 2 })).toBe(90);
+  });
+
+  it("NCM/NBS sem respostas suficientes não altera faixa (ainda depende de total)", () => {
+    expect(calculateBriefingConfidence({ ...ZERO, ncmCodesCount: 5 })).toBe(30);
+    expect(calculateBriefingConfidence({ ...ZERO, solarisAnswersCount: 4, ncmCodesCount: 5 })).toBe(55);
+  });
+
+  it("valores negativos são tratados como 0", () => {
+    expect(calculateBriefingConfidence({ ...ZERO, solarisAnswersCount: -5 })).toBe(30);
+  });
+
+  it("boundary: exatamente 5 → 70 · exatamente 15 → 80 · exatamente 30 → 85/90", () => {
+    expect(calculateBriefingConfidence({ ...ZERO, solarisAnswersCount: 4 })).toBe(55);
+    expect(calculateBriefingConfidence({ ...ZERO, solarisAnswersCount: 5 })).toBe(70);
+    expect(calculateBriefingConfidence({ ...ZERO, solarisAnswersCount: 14 })).toBe(70);
+    expect(calculateBriefingConfidence({ ...ZERO, solarisAnswersCount: 15 })).toBe(80);
+    expect(calculateBriefingConfidence({ ...ZERO, solarisAnswersCount: 29 })).toBe(80);
+    expect(calculateBriefingConfidence({ ...ZERO, solarisAnswersCount: 30 })).toBe(85);
+    expect(calculateBriefingConfidence({ ...ZERO, solarisAnswersCount: 30, ncmCodesCount: 1 })).toBe(90);
+  });
+});

--- a/server/lib/calculate-briefing-confidence.ts
+++ b/server/lib/calculate-briefing-confidence.ts
@@ -1,0 +1,49 @@
+/**
+ * calculate-briefing-confidence.ts — fix #771 UAT 2026-04-20
+ *
+ * Função determinística server-side que calcula o nível de confiança do briefing
+ * a partir da soma de respostas das fontes disponíveis.
+ *
+ * Motivação: o LLM estava retornando 85% mesmo quando "Ausência total de respostas
+ * ao questionário" aparecia como limitação — contradição óbvia e recorrente na UAT.
+ * A classificação passa a ser função pura das contagens, igual ao pattern usado em
+ * `classifyInconsistenciaImpacto`.
+ *
+ * Regras (faixas fixas):
+ *   Total == 0                          → 30 (baixa)
+ *   Total < 5                           → 55 (baixa)
+ *   Total 5-14                          → 70 (média)
+ *   Total 15-29                         → 80 (média-alta)
+ *   Total >= 30 e NCM/NBS cadastrados   → 90 (alta)
+ *   Total >= 30 sem NCM/NBS             → 85 (alta)
+ */
+
+export interface BriefingConfidenceSignals {
+  solarisAnswersCount: number;   // Onda 1
+  iagenAnswersCount: number;     // Onda 2
+  productAnswersCount: number;   // Q.Produtos (NCM)
+  serviceAnswersCount: number;   // Q.Serviços (NBS)
+  cnaeAnswersCount: number;      // QCNAE especializado
+  ncmCodesCount: number;         // operationProfile.principaisProdutos
+  nbsCodesCount: number;         // operationProfile.principaisServicos
+}
+
+export function calculateBriefingConfidence(
+  signals: BriefingConfidenceSignals
+): number {
+  const total =
+    Math.max(0, signals.solarisAnswersCount) +
+    Math.max(0, signals.iagenAnswersCount) +
+    Math.max(0, signals.productAnswersCount) +
+    Math.max(0, signals.serviceAnswersCount) +
+    Math.max(0, signals.cnaeAnswersCount);
+
+  const hasCodes =
+    Math.max(0, signals.ncmCodesCount) + Math.max(0, signals.nbsCodesCount) > 0;
+
+  if (total === 0) return 30;
+  if (total < 5) return 55;
+  if (total < 15) return 70;
+  if (total < 30) return 80;
+  return hasCodes ? 90 : 85;
+}

--- a/server/routers-fluxo-v3.ts
+++ b/server/routers-fluxo-v3.ts
@@ -1191,6 +1191,47 @@ Gere o Briefing estruturado em JSON:
         }));
       }
 
+      // fix(#771 UAT 2026-04-20): confidence.nivel_confianca agora é função determinística
+      // server-side das contagens de fontes. Elimina o bug de "85% com ausência total".
+      // Preserva limitações e recomendação do LLM (texto qualitativo segue sendo gerado).
+      const solarisCountForConf = await db.countOnda1Answers(input.projectId);
+      const iagenCountForConf = await db.countOnda2Answers(input.projectId);
+      const productAnswersForConf = (() => {
+        const raw = (project as any).productAnswers;
+        if (!raw) return [];
+        try { return typeof raw === "string" ? JSON.parse(raw) : raw; } catch { return []; }
+      })();
+      const serviceAnswersForConf = (() => {
+        const raw = (project as any).serviceAnswers;
+        if (!raw) return [];
+        try { return typeof raw === "string" ? JSON.parse(raw) : raw; } catch { return []; }
+      })();
+      const cnaeQuestionsCountForConf = input.allAnswers
+        .filter(l => l.cnaeCode !== "CORPORATIVO" && l.cnaeCode !== "OPERACIONAL")
+        .reduce((acc, l) => acc + (l.questions?.length ?? 0), 0);
+      const ncmCountForConf = (opProfile.principaisProdutos ?? []).filter(p => p?.ncm_code).length;
+      const nbsCountForConf = (opProfile.principaisServicos ?? []).filter(s => s?.nbs_code).length;
+
+      const { calculateBriefingConfidence } = await import("./lib/calculate-briefing-confidence");
+      const deterministicConfidence = calculateBriefingConfidence({
+        solarisAnswersCount: solarisCountForConf,
+        iagenAnswersCount: iagenCountForConf,
+        productAnswersCount: Array.isArray(productAnswersForConf) ? productAnswersForConf.length : 0,
+        serviceAnswersCount: Array.isArray(serviceAnswersForConf) ? serviceAnswersForConf.length : 0,
+        cnaeAnswersCount: cnaeQuestionsCountForConf,
+        ncmCodesCount: ncmCountForConf,
+        nbsCodesCount: nbsCountForConf,
+      });
+      if (structured.confidence_score && typeof structured.confidence_score === "object") {
+        structured.confidence_score.nivel_confianca = deterministicConfidence;
+      } else {
+        structured.confidence_score = {
+          nivel_confianca: deterministicConfidence,
+          limitacoes: [],
+          recomendacao: "Revisão por advogado tributarista recomendada",
+        };
+      }
+
       // Converter estruturado para Markdown (compatibilidade com UI existente)
       const briefingMarkdown = buildBriefingMarkdown(structured);
 
@@ -1212,22 +1253,15 @@ Gere o Briefing estruturado em JSON:
       // contribuíram ou não para o diagnóstico.
       try {
         const { logAudit } = await import("./routers-audit");
-        const solarisAnswersCount = await db.countOnda1Answers(input.projectId);
-        const iagenAnswersCount = await db.countOnda2Answers(input.projectId);
-        const productAnswersArr = (() => {
-          const raw = (project as any).productAnswers;
-          if (!raw) return [];
-          try { return typeof raw === "string" ? JSON.parse(raw) : raw; } catch { return []; }
-        })();
-        const serviceAnswersArr = (() => {
-          const raw = (project as any).serviceAnswers;
-          if (!raw) return [];
-          try { return typeof raw === "string" ? JSON.parse(raw) : raw; } catch { return []; }
-        })();
+        // Reaproveita contagens já calculadas para o confidence determinístico (evita query duplicada).
+        const solarisAnswersCount = solarisCountForConf;
+        const iagenAnswersCount = iagenCountForConf;
+        const productAnswersArr = productAnswersForConf;
+        const serviceAnswersArr = serviceAnswersForConf;
         const cnaeLayers = input.allAnswers.filter(l => l.cnaeCode !== "CORPORATIVO" && l.cnaeCode !== "OPERACIONAL");
-        const cnaeQuestionsCount = cnaeLayers.reduce((acc, l) => acc + (l.questions?.length ?? 0), 0);
-        const ncmCodesCount = (opProfile.principaisProdutos ?? []).filter(p => p?.ncm_code).length;
-        const nbsCodesCount = (opProfile.principaisServicos ?? []).filter(s => s?.nbs_code).length;
+        const cnaeQuestionsCount = cnaeQuestionsCountForConf;
+        const ncmCodesCount = ncmCountForConf;
+        const nbsCodesCount = nbsCountForConf;
 
         await logAudit({
           userId: ctx.user.id,
@@ -2549,6 +2583,35 @@ Gere o Briefing estruturado em JSON:
           ...inc,
           impacto: classifyInconsistenciaImpacto(inc),
         }));
+      }
+
+      // fix(#771 UAT 2026-04-20): confidence determinístico server-side — mesma heurística de generateBriefing.
+      {
+        const productAnswersCount = Array.isArray(briefingProduct) ? briefingProduct.length : 0;
+        const serviceAnswersCount = Array.isArray(briefingService) ? briefingService.length : 0;
+        const cnaeQuestionsCountForConf = cnaeAnswers.reduce((acc: number, l: any) => acc + (l.questions?.length ?? 0), 0);
+        const ncmCountForConf = (opProfileForBriefing.principaisProdutos ?? []).filter(x => x?.ncm_code).length;
+        const nbsCountForConf = (opProfileForBriefing.principaisServicos ?? []).filter(x => x?.nbs_code).length;
+
+        const { calculateBriefingConfidence } = await import("./lib/calculate-briefing-confidence");
+        const deterministicConfidence = calculateBriefingConfidence({
+          solarisAnswersCount: solarisAnswersForBriefing.length,
+          iagenAnswersCount: iagenAnswersForBriefing.length,
+          productAnswersCount,
+          serviceAnswersCount,
+          cnaeAnswersCount: cnaeQuestionsCountForConf,
+          ncmCodesCount: ncmCountForConf,
+          nbsCodesCount: nbsCountForConf,
+        });
+        if (structured.confidence_score && typeof structured.confidence_score === "object") {
+          structured.confidence_score.nivel_confianca = deterministicConfidence;
+        } else {
+          structured.confidence_score = {
+            nivel_confianca: deterministicConfidence,
+            limitacoes: [],
+            recomendacao: "Revisão por advogado tributarista recomendada",
+          };
+        }
       }
 
       const { buildBriefingMarkdown } = await import("./routers-fluxo-v3").then(m => ({


### PR DESCRIPTION
## Summary

**Closes #771.** Elimina o bug da UAT 2026-04-20 (3 testes consecutivos): "Confiança 85%" exibido com "Ausência total de respostas ao questionário" como limitação.

## Fix

Nova função pura `calculateBriefingConfidence` (`server/lib/`) aplica faixa fixa determinística sobre a soma de respostas das 5 fontes, com bônus para NCM/NBS:

| Total de respostas | NCM/NBS | Confiança |
|---|---|---|
| 0 | — | **30** (baixa) |
| < 5 | — | **55** (baixa) |
| 5–14 | — | **70** (média) |
| 15–29 | — | **80** (média-alta) |
| ≥ 30 | não | **85** (alta) |
| ≥ 30 | sim | **90** (alta) |

Aplicado em **ambos os paths** (`generateBriefing` + `generateBriefingFromDiagnostic`) logo após o LLM retornar, sobrescrevendo `structured.confidence_score.nivel_confianca`. Pattern idêntico ao `classifyInconsistenciaImpacto` (PR #765).

Preserva `limitacoes[]` e `recomendacao` (texto qualitativo continua por LLM).

## Arquivos

- `server/lib/calculate-briefing-confidence.ts` — função pura + tipo `BriefingConfidenceSignals`.
- `server/lib/calculate-briefing-confidence.test.ts` — **10 unit tests** cobrindo 4 faixas + boundary 4/5, 14/15, 29/30 + NCM bonus + valores negativos.
- `server/routers-fluxo-v3.ts` — aplicação em `generateBriefing` (L1190) e `generateBriefingFromDiagnostic` (L2580).

## Test plan

- [x] `pnpm check` — zero erros.
- [x] `pnpm vitest run server/lib/calculate-briefing-confidence.test.ts` — **10/10 PASS**.
- [ ] UAT: regenerar briefing SEM respostas → ConfidenceBar deve exibir **30%** (vermelho/baixa).
- [ ] UAT: regenerar briefing com SOLARIS+IA Gen completos sem NCM → **80%** (âmbar/média-alta).
- [ ] UAT: regenerar briefing completo + NCM cadastrado → **90%** (verde/alta).
- [ ] Histórico (PR #772): `output.confidence` do audit reflete o valor determinístico.

🤖 Generated with [Claude Code](https://claude.com/claude-code)