### PR TITLE
fix(briefing): enriquecer generateBriefing com Onda 1/2/Q.Produtos/Q.Serviços — Closes #774

### DIFF
--- a/server/routers-fluxo-v3.ts
+++ b/server/routers-fluxo-v3.ts
@@ -1118,6 +1118,73 @@ Gere as perguntas no formato:
         ? `## Perfil da Empresa\n- Razão Social: ${project.name}\n- CNAE Principal: ${primaryCnae}\n- Porte: ${cp.companySize ?? "não informado"}\n- Regime Tributário: ${cp.taxRegime ?? "não informado"}\n- Faturamento Anual: ${cp.annualRevenueRange ?? "não informado"}${produtosBlock}${servicosBlock}`
         : `## Perfil da Empresa\n- Razão Social: ${project.name}\n- CNAE Principal: ${primaryCnae}\n- Porte: não informado\n- Regime Tributário: não informado${produtosBlock}${servicosBlock}`;
 
+      // fix(#774 UAT 2026-04-20): enriquece o prompt com as 4 fontes que o path atual
+      // não lia: SOLARIS Onda 1, IA Gen Onda 2, Q.Produtos e Q.Serviços. Mitigação do
+      // gap arquitetural descoberto (BriefingV3.tsx usa generateBriefing e não
+      // generateBriefingFromDiagnostic). Zero mudança de gates/status — apenas leitura
+      // adicional do DB + injeção no userPrompt.
+      const additionalSourcesContext: string[] = [];
+
+      const solarisAnswersForPrompt = await db.getOnda1Answers(input.projectId);
+      if (Array.isArray(solarisAnswersForPrompt) && solarisAnswersForPrompt.length > 0) {
+        additionalSourcesContext.push('<respostas_solaris_onda1>');
+        solarisAnswersForPrompt
+          .filter((a: any) => a?.resposta)
+          .forEach((a: any) => {
+            additionalSourcesContext.push(`${a.codigo}: ${a.resposta}`);
+          });
+        additionalSourcesContext.push('</respostas_solaris_onda1>');
+      }
+
+      const iagenAnswersForPrompt = await db.getOnda2Answers(input.projectId);
+      if (Array.isArray(iagenAnswersForPrompt) && iagenAnswersForPrompt.length > 0) {
+        additionalSourcesContext.push('<respostas_iagen_onda2>');
+        iagenAnswersForPrompt
+          .filter((a: any) => a?.resposta)
+          .forEach((a: any) => {
+            additionalSourcesContext.push(`Q: ${a.questionText ?? a.question ?? ''}\nR: ${a.resposta}`);
+          });
+        additionalSourcesContext.push('</respostas_iagen_onda2>');
+      }
+
+      const productAnswersArr = (() => {
+        const raw = projectAnyBriefing.productAnswers;
+        if (!raw) return [];
+        try { return typeof raw === 'string' ? JSON.parse(raw) : raw; } catch { return []; }
+      })();
+      if (Array.isArray(productAnswersArr) && productAnswersArr.length > 0) {
+        additionalSourcesContext.push('<respostas_q_produtos_ncm>');
+        productAnswersArr
+          .filter((a: any) => a && (a.pergunta_texto || a.pergunta) && a.resposta !== undefined && a.resposta !== null && a.resposta !== '')
+          .forEach((a: any) => {
+            const codePrefix = a.ncm_code ? `[NCM ${a.ncm_code}] ` : '';
+            const text = a.pergunta_texto ?? a.pergunta ?? '';
+            additionalSourcesContext.push(`${codePrefix}P: ${text}\nR: ${a.resposta}`);
+          });
+        additionalSourcesContext.push('</respostas_q_produtos_ncm>');
+      }
+
+      const serviceAnswersArr = (() => {
+        const raw = projectAnyBriefing.serviceAnswers;
+        if (!raw) return [];
+        try { return typeof raw === 'string' ? JSON.parse(raw) : raw; } catch { return []; }
+      })();
+      if (Array.isArray(serviceAnswersArr) && serviceAnswersArr.length > 0) {
+        additionalSourcesContext.push('<respostas_q_servicos_nbs>');
+        serviceAnswersArr
+          .filter((a: any) => a && (a.pergunta_texto || a.pergunta) && a.resposta !== undefined && a.resposta !== null && a.resposta !== '')
+          .forEach((a: any) => {
+            const codePrefix = a.nbs_code ? `[NBS ${a.nbs_code}] ` : '';
+            const text = a.pergunta_texto ?? a.pergunta ?? '';
+            additionalSourcesContext.push(`${codePrefix}P: ${text}\nR: ${a.resposta}`);
+          });
+        additionalSourcesContext.push('</respostas_q_servicos_nbs>');
+      }
+
+      const additionalSourcesText = additionalSourcesContext.length > 0
+        ? `\n\nDADOS ADICIONAIS DO CLIENTE:\n${additionalSourcesContext.join('\n')}\n`
+        : '';
+
       // V60: Geração com retry + temperatura 0.2 + schema estruturado
       // fix(UX3 UAT 2026-04-20): contador de retries para propagar ao frontend
       let llmRetries = 0;
@@ -1152,7 +1219,7 @@ ${OUTPUT_CONTRACT}`,
           },
           {
             role: "user",
-            content: `${companyProfileBlock}\n\nPROJETO: ${project.name}\nDESCRIÇÃO: ${(project as any).description || ""}\n\nRESPOSTAS DO QUESTIONÁRIO:\n${answersText}\n${correctionContext}\n${complementContext}
+            content: `${companyProfileBlock}${additionalSourcesText}\n\nPROJETO: ${project.name}\nDESCRIÇÃO: ${(project as any).description || ""}\n\nRESPOSTAS DO QUESTIONÁRIO CNAE:\n${answersText}\n${correctionContext}\n${complementContext}
 
 Gere o Briefing estruturado em JSON:
 {


### PR DESCRIPTION
## Summary

**Closes #774.** Mitigação do gap arquitetural descoberto na UAT Wave 2026-04-20: `BriefingV3.tsx` chama `generateBriefing` (path simples), mas esse path ignorava 4 fontes críticas. Agora todas as 8 fontes do diagnóstico chegam ao prompt.

## Fix (estratégia aceita pelo P.O.)

Em `server/routers-fluxo-v3.ts::generateBriefing` (L1121), adicionar leitura das 4 fontes do DB e injeção como bloco tagueado XML no `userPrompt`:

| Fonte | Origem | Tag no prompt |
|---|---|---|
| SOLARIS Onda 1 | `db.getOnda1Answers` | `<respostas_solaris_onda1>` |
| IA Gen Onda 2 | `db.getOnda2Answers` | `<respostas_iagen_onda2>` |
| Q.Produtos (NCM) | `projects.productAnswers` JSON | `<respostas_q_produtos_ncm>` com prefixo `[NCM xxx]` |
| Q.Serviços (NBS) | `projects.serviceAnswers` JSON | `<respostas_q_servicos_nbs>` com prefixo `[NBS xxx]` |

Quando qualquer fonte está vazia, o bloco correspondente é omitido — zero ruído. Cada item é filtrado (`resposta` truthy) antes de entrar no prompt.

## Por que NÃO trocamos o path

P.O. avaliou os 7 riscos de trocar `BriefingV3.tsx` para `generateBriefingFromDiagnostic`:

1. 🔴 Gate `isDiagnosticComplete` bloqueia regenerar
2. 🔴 Gate `countOnda1Answers > 0` bloqueia
3. 🟠 Muda status para `matriz_riscos` sem aviso
4. 🟠 E2E quebram
5. 🟡 Prompt diferente → output diferente
6. 🟢 +5 queries por regeneração
7. 🟠 Sem feature flag

Mitigação escolhida: zero mudança de gates/status, zero quebra de UX, **ganho de qualidade imediato**.

## Arquivos

- `server/routers-fluxo-v3.ts` — `generateBriefing` (+68 linhas, -1).

## Test plan

- [x] `pnpm check` — zero erros.
- [ ] UAT: projeto **sem respostas** + com NCM → briefing continua genérico (backward compat).
- [ ] UAT: projeto com **Onda 1 respondida** → briefing cita respostas específicas (ex: "conforme informado em SOL-012, ...").
- [ ] UAT: projeto com **Q.Produtos respondida** → briefing cita `[NCM xxx]` com análise específica do produto.
- [ ] Histórico (#772): audit log mostra `solaris_onda1.used=true`, `iagen_onda2.used=true` etc. quando respostas existem.
- [ ] Confidence (#771 deployado em v7.31): varia corretamente pela soma real de respostas.

## Follow-up

- [ ] `generateBriefingFromDiagnostic` fica código redundante — depreciar em sprint futura (nova issue).
- [ ] Bug lateral detectado: `generateBriefingFromDiagnostic` L2338 usa `a.answer` para IagenAnswer (campo correto é `a.resposta`) — filter elimina todas as respostas silenciosamente. Fora do escopo deste PR, mas vale issue separada se path for mantido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)