### PR TITLE
feat(briefing): resumo WhatsApp por área da empresa — Closes #767

### DIFF
--- a/client/src/components/ShareBriefingModal.tsx
+++ b/client/src/components/ShareBriefingModal.tsx
@@ -1,0 +1,162 @@
+/**
+ * ShareBriefingModal — #767 feat(ux)
+ *
+ * Modal com 6 tabs (genérico/fiscal/TI/contabilidade/legal/gestão) exibindo
+ * o resumo do briefing formatado para WhatsApp, com botão "Copiar" por área.
+ *
+ * Classificação determinística (client-side) via briefing-areas.ts — zero LLM.
+ */
+import { useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Copy, Check, Share2 } from "lucide-react";
+import { toast } from "sonner";
+import {
+  AREA_META,
+  AREA_ORDER,
+  groupBriefingByArea,
+  formatWhatsAppSummary,
+  type BriefingArea,
+  type BriefingLite,
+} from "@/lib/briefing-areas";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  structured: BriefingLite | null | undefined;
+  projectName: string;
+}
+
+export function ShareBriefingModal({ open, onOpenChange, structured, projectName }: Props) {
+  const [copiedArea, setCopiedArea] = useState<BriefingArea | null>(null);
+  const [activeTab, setActiveTab] = useState<BriefingArea>("generico");
+
+  const buckets = useMemo(() => groupBriefingByArea(structured), [structured]);
+
+  const texts = useMemo<Record<BriefingArea, string>>(() => {
+    const out = {} as Record<BriefingArea, string>;
+    if (!structured) {
+      AREA_ORDER.forEach((a) => (out[a] = ""));
+      return out;
+    }
+    AREA_ORDER.forEach((a) => {
+      out[a] = formatWhatsAppSummary({
+        projectName,
+        area: a,
+        bucket: buckets[a],
+        structured,
+      });
+    });
+    return out;
+  }, [buckets, projectName, structured]);
+
+  const totalItems = (area: BriefingArea): number => {
+    const b = buckets[area];
+    return b.gaps.length + b.oportunidades.length + b.recomendacoes.length + b.inconsistencias.length;
+  };
+
+  const handleCopy = async (area: BriefingArea) => {
+    try {
+      await navigator.clipboard.writeText(texts[area]);
+      setCopiedArea(area);
+      toast.success(`Resumo de ${AREA_META[area].label} copiado para a área de transferência.`);
+      setTimeout(() => setCopiedArea(null), 2500);
+    } catch {
+      toast.error("Falha ao copiar. Selecione o texto manualmente.");
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-w-3xl max-h-[85vh] flex flex-col"
+        data-testid="modal-resumo-whatsapp"
+      >
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Share2 className="h-5 w-5" />
+            Compartilhar Resumo (WhatsApp)
+          </DialogTitle>
+          <DialogDescription>
+            Resumos do briefing separados por área da empresa. Copie o texto e compartilhe
+            no grupo de WhatsApp correspondente.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Tabs
+          value={activeTab}
+          onValueChange={(v) => setActiveTab(v as BriefingArea)}
+          className="flex-1 min-h-0 flex flex-col"
+        >
+          <TabsList className="flex w-full flex-wrap h-auto justify-start">
+            {AREA_ORDER.map((area) => {
+              const count = totalItems(area);
+              return (
+                <TabsTrigger
+                  key={area}
+                  value={area}
+                  className="gap-1.5"
+                  data-testid={`tab-area-${area}`}
+                >
+                  <span>{AREA_META[area].emoji}</span>
+                  <span>{AREA_META[area].label}</span>
+                  {count > 0 && area !== "generico" && (
+                    <Badge variant="secondary" className="h-4 px-1 text-[10px] font-mono">
+                      {count}
+                    </Badge>
+                  )}
+                </TabsTrigger>
+              );
+            })}
+          </TabsList>
+
+          {AREA_ORDER.map((area) => (
+            <TabsContent
+              key={area}
+              value={area}
+              className="flex-1 min-h-0 flex flex-col gap-3 mt-4"
+            >
+              <pre
+                className="flex-1 min-h-0 overflow-auto rounded-lg border bg-muted/30 p-4 text-xs whitespace-pre-wrap font-mono"
+                data-testid={`resumo-preview-${area}`}
+              >
+                {texts[area]}
+              </pre>
+              <div className="flex justify-between items-center">
+                <p className="text-xs text-muted-foreground">
+                  {texts[area].length.toLocaleString("pt-BR")} caracteres
+                </p>
+                <Button
+                  onClick={() => handleCopy(area)}
+                  size="sm"
+                  className="gap-2"
+                  data-testid={`btn-copy-resumo-${area}`}
+                >
+                  {copiedArea === area ? (
+                    <>
+                      <Check className="h-4 w-4" />
+                      Copiado!
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="h-4 w-4" />
+                      Copiar resumo {AREA_META[area].label}
+                    </>
+                  )}
+                </Button>
+              </div>
+            </TabsContent>
+          ))}
+        </Tabs>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/lib/briefing-areas.test.ts
+++ b/client/src/lib/briefing-areas.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyItemByArea,
+  groupBriefingByArea,
+  formatWhatsAppSummary,
+  type BriefingLite,
+} from "./briefing-areas";
+
+describe("classifyItemByArea", () => {
+  it("classifica fiscal por IBS/CBS/alíquota", () => {
+    expect(classifyItemByArea("Aplicação incorreta da alíquota de IBS nas operações interestaduais")).toBe("fiscal");
+    expect(classifyItemByArea("Base de cálculo da CBS")).toBe("fiscal");
+    expect(classifyItemByArea("Crédito tributário não apurado")).toBe("fiscal");
+  });
+
+  it("classifica TI por ERP/Sped/NFe", () => {
+    expect(classifyItemByArea("Parametrização do ERP para novos tributos")).toBe("ti");
+    expect(classifyItemByArea("Integração com Sped Fiscal")).toBe("ti");
+    expect(classifyItemByArea("Validação de campos em NF-e")).toBe("ti");
+  });
+
+  it("classifica contabilidade por escrituração/fato gerador", () => {
+    expect(classifyItemByArea("Escrituração contábil da operação")).toBe("contabilidade");
+    expect(classifyItemByArea("Reconhecimento contábil do passivo tributário")).toBe("contabilidade");
+    expect(classifyItemByArea("Segregação contábil IBS/CBS")).toBe("contabilidade");
+  });
+
+  it("classifica legal por parecer/LC/Art.", () => {
+    expect(classifyItemByArea("Parecer sobre interpretação do Art. 12")).toBe("legal");
+    expect(classifyItemByArea("Contencioso administrativo em andamento")).toBe("legal");
+    expect(classifyItemByArea("Aplicação de benefício fiscal municipal")).toBe("legal");
+    expect(classifyItemByArea("LC 214/2025 exige cadastro")).toBe("legal");
+  });
+
+  it("classifica gestão por fluxo de caixa/estratégia", () => {
+    expect(classifyItemByArea("Impacto no fluxo de caixa mensal")).toBe("gestao");
+    expect(classifyItemByArea("Perda de competitividade no mercado atacadista")).toBe("gestao");
+    expect(classifyItemByArea("Alinhamento estratégico com a diretoria")).toBe("gestao");
+  });
+
+  it("cai em genérico quando nenhuma keyword bate", () => {
+    expect(classifyItemByArea("Texto genérico sem palavras-chave")).toBe("generico");
+    expect(classifyItemByArea("")).toBe("generico");
+  });
+});
+
+describe("groupBriefingByArea", () => {
+  const structured: BriefingLite = {
+    nivel_risco_geral: "alto",
+    principais_gaps: [
+      { gap: "Alíquota IBS incorreta", causa_raiz: "não parametrizado", urgencia: "imediata" },
+      { gap: "Escrituração contábil defasada", causa_raiz: "sistema sem módulo" },
+      { gap: "Parecer jurídico pendente", causa_raiz: "Art. 15 LC 214/2025" },
+    ],
+    oportunidades: ["Revisar ERP para suportar CBS"],
+    recomendacoes_prioritarias: [
+      "Treinamento fiscal sobre IBS",
+      "Análise de fluxo de caixa pós-reforma",
+    ],
+    inconsistencias: [],
+  };
+
+  it("agrupa gaps por área", () => {
+    const b = groupBriefingByArea(structured);
+    expect(b.fiscal.gaps).toHaveLength(1);
+    expect(b.contabilidade.gaps).toHaveLength(1);
+    expect(b.legal.gaps).toHaveLength(1);
+  });
+
+  it("agrupa recomendações por área", () => {
+    const b = groupBriefingByArea(structured);
+    expect(b.fiscal.recomendacoes).toHaveLength(1);
+    expect(b.gestao.recomendacoes).toHaveLength(1);
+  });
+
+  it("retorna buckets vazios quando structured é null", () => {
+    const b = groupBriefingByArea(null);
+    expect(b.generico.gaps).toHaveLength(0);
+    expect(b.fiscal.gaps).toHaveLength(0);
+  });
+});
+
+describe("formatWhatsAppSummary", () => {
+  const structured: BriefingLite = {
+    nivel_risco_geral: "alto",
+    resumo_executivo: "Empresa apresenta riscos fiscais significativos.",
+    principais_gaps: [
+      { gap: "Alíquota IBS incorreta", evidencia_regulatoria: "Art. 14 LC 214/2025", urgencia: "imediata" },
+    ],
+    recomendacoes_prioritarias: ["Treinamento fiscal"],
+    confidence_score: { nivel_confianca: 80, limitacoes: ["Sem dados financeiros"], recomendacao: "Revisão por advogado tributarista recomendada" },
+  };
+
+  it("inclui risco no cabeçalho", () => {
+    const buckets = groupBriefingByArea(structured);
+    const txt = formatWhatsAppSummary({ projectName: "Teste", area: "fiscal", bucket: buckets.fiscal, structured });
+    expect(txt).toMatch(/\*Risco Geral:\* Alto/);
+    expect(txt).toMatch(/80% confiança/);
+  });
+
+  it("inclui resumo executivo só na área Genérica", () => {
+    const buckets = groupBriefingByArea(structured);
+    const generic = formatWhatsAppSummary({ projectName: "Teste", area: "generico", bucket: buckets.generico, structured });
+    const fiscal = formatWhatsAppSummary({ projectName: "Teste", area: "fiscal", bucket: buckets.fiscal, structured });
+    expect(generic).toContain("Resumo Executivo");
+    expect(fiscal).not.toContain("Resumo Executivo");
+  });
+
+  it("marca área vazia com mensagem explícita (exceto genérico)", () => {
+    const buckets = groupBriefingByArea(structured);
+    const ti = formatWhatsAppSummary({ projectName: "Teste", area: "ti", bucket: buckets.ti, structured });
+    expect(ti).toContain("Nenhum item específico de T.I.");
+  });
+
+  it("usa asteriscos para negrito (compatível WhatsApp)", () => {
+    const buckets = groupBriefingByArea(structured);
+    const txt = formatWhatsAppSummary({ projectName: "Teste", area: "fiscal", bucket: buckets.fiscal, structured });
+    expect(txt).toMatch(/\*IA SOLARIS/);
+    expect(txt).toMatch(/\*Projeto:\*/);
+  });
+});

--- a/client/src/lib/briefing-areas.ts
+++ b/client/src/lib/briefing-areas.ts
@@ -1,0 +1,255 @@
+/**
+ * briefing-areas.ts — #767 feat(ux): resumo do briefing formato WhatsApp
+ *
+ * Classificador determinístico + formatador por área da empresa.
+ *
+ * 6 áreas: generico / fiscal / ti / contabilidade / legal / gestao
+ *
+ * Classificação: keywords regex. Zero LLM, zero custo extra, determinístico.
+ * Mesmo pattern usado em classifyInconsistenciaImpacto (server/routers-fluxo-v3.ts).
+ */
+
+export type BriefingArea =
+  | "generico"
+  | "fiscal"
+  | "ti"
+  | "contabilidade"
+  | "legal"
+  | "gestao";
+
+export const AREA_META: Record<BriefingArea, { label: string; emoji: string }> = {
+  generico:      { label: "Genérico",      emoji: "📊" },
+  fiscal:        { label: "Fiscal",        emoji: "💼" },
+  ti:            { label: "T.I.",          emoji: "💻" },
+  contabilidade: { label: "Contabilidade", emoji: "📚" },
+  legal:         { label: "Legal",         emoji: "⚖️" },
+  gestao:        { label: "Gestão",        emoji: "🎯" },
+};
+
+export const AREA_ORDER: BriefingArea[] = [
+  "generico",
+  "fiscal",
+  "ti",
+  "contabilidade",
+  "legal",
+  "gestao",
+];
+
+// ─── Classificação por keywords ──────────────────────────────────────────────
+
+// Patterns apertados — evitam colisões cross-área.
+// Ex.: "parametriza[çc][ãa]o" sem ERP NÃO cai em TI (palavra também aparece em fiscal).
+const PATTERNS: Record<Exclude<BriefingArea, "generico">, RegExp[]> = {
+  contabilidade: [
+    /\b(escritura[çc][ãa]o|reconhecimento cont[áa]bil|segrega[çc][ãa]o cont[áa]bil)\b/i,
+    /\b(lan[çc]amento cont[áa]bil|plano de contas|balancete|concilia[çc][ãa]o cont[áa]bil)\b/i,
+    /\b(regime cont[áa]bil|compet[êe]ncia cont[áa]bil)\b/i,
+  ],
+  ti: [
+    /\b(ERP|Sped|NF-?e|EFD|CT-?e)\b/i,
+    /\b(banco de dados|API|webhook|automa[çc][ãa]o sist[êe]mica)\b/i,
+    /\b(infraestrutura de TI|integra[çc][ãa]o sist[êe]mica)\b/i,
+  ],
+  fiscal: [
+    /\b(IBS|CBS|Imposto Seletivo)\b/i,
+    /\b(al[íi]quota|base de c[áa]lculo|cr[ée]dito tribut|apura[çc][ãa]o)\b/i,
+    /\b(recolhimento|autua[çc][ãa]o|inscri[çc][ãa]o cadastral|retenc[ãa]o)\b/i,
+    /\b(partilha|interestadual|regime especial|al[íi]quota zero)\b/i,
+  ],
+  legal: [
+    /\b(parecer|conten[çc]ioso|litig[ií]o|processo administrativo)\b/i,
+    /\b(interpreta[çc][ãa]o|jurisprud[êe]ncia|entendimento)\b/i,
+    /\b(benef[íi]cio fiscal|isen[çc][ãa]o|imunidade)\b/i,
+    /\b(Art\.\s*\d+|LC\s*\d+|Lei Complementar|Decreto)\b/i,
+  ],
+  gestao: [
+    /\b(fluxo de caixa|estrat[ée]gi|competitividade|margem)\b/i,
+    /\b(stakeholder|diretoria|governan[çc]a corporativa|rentabilidade)\b/i,
+    /\b(impacto financeiro|or[çc]amento|invest(?:imento|ir))\b/i,
+  ],
+};
+
+// Ordem de classificação — mais específico primeiro.
+// Contabilidade + TI antes de Fiscal para evitar que "segregação contábil IBS/CBS"
+// seja classificado como fiscal por conta do "IBS/CBS".
+const CLASSIFY_ORDER: Array<Exclude<BriefingArea, "generico">> = [
+  "contabilidade",
+  "ti",
+  "fiscal",
+  "legal",
+  "gestao",
+];
+
+export function classifyItemByArea(texto: string): BriefingArea {
+  if (!texto) return "generico";
+  for (const area of CLASSIFY_ORDER) {
+    if (PATTERNS[area].some((p) => p.test(texto))) return area;
+  }
+  return "generico";
+}
+
+// ─── Tipagem mínima (espelha BriefingStructuredSchema) ──────────────────────
+
+export interface BriefingLite {
+  nivel_risco_geral?: string;
+  resumo_executivo?: string;
+  principais_gaps?: Array<{
+    gap?: string;
+    causa_raiz?: string;
+    evidencia_regulatoria?: string;
+    urgencia?: string;
+  }>;
+  oportunidades?: string[];
+  recomendacoes_prioritarias?: string[];
+  inconsistencias?: Array<{
+    pergunta_origem?: string;
+    contradicao_detectada?: string;
+    impacto?: string;
+  }>;
+  confidence_score?: {
+    nivel_confianca?: number;
+    limitacoes?: string[];
+    recomendacao?: string;
+  };
+}
+
+export interface AreaBucket {
+  gaps: NonNullable<BriefingLite["principais_gaps"]>;
+  oportunidades: string[];
+  recomendacoes: string[];
+  inconsistencias: NonNullable<BriefingLite["inconsistencias"]>;
+}
+
+function emptyBucket(): AreaBucket {
+  return { gaps: [], oportunidades: [], recomendacoes: [], inconsistencias: [] };
+}
+
+export function groupBriefingByArea(
+  structured: BriefingLite | null | undefined
+): Record<BriefingArea, AreaBucket> {
+  const buckets: Record<BriefingArea, AreaBucket> = {
+    generico:      emptyBucket(),
+    fiscal:        emptyBucket(),
+    ti:            emptyBucket(),
+    contabilidade: emptyBucket(),
+    legal:         emptyBucket(),
+    gestao:        emptyBucket(),
+  };
+
+  if (!structured) return buckets;
+
+  (structured.principais_gaps ?? []).forEach((g) => {
+    const text = `${g.gap ?? ""} ${g.causa_raiz ?? ""} ${g.evidencia_regulatoria ?? ""}`;
+    const area = classifyItemByArea(text);
+    buckets[area].gaps.push(g);
+  });
+
+  (structured.oportunidades ?? []).forEach((o) => {
+    buckets[classifyItemByArea(o)].oportunidades.push(o);
+  });
+
+  (structured.recomendacoes_prioritarias ?? []).forEach((r) => {
+    buckets[classifyItemByArea(r)].recomendacoes.push(r);
+  });
+
+  (structured.inconsistencias ?? []).forEach((inc) => {
+    const text = `${inc.pergunta_origem ?? ""} ${inc.contradicao_detectada ?? ""}`;
+    buckets[classifyItemByArea(text)].inconsistencias.push(inc);
+  });
+
+  return buckets;
+}
+
+// ─── Formatador WhatsApp-friendly ────────────────────────────────────────────
+
+export interface FormatOptions {
+  projectName: string;
+  area: BriefingArea;
+  bucket: AreaBucket;
+  structured: BriefingLite;
+}
+
+export function formatWhatsAppSummary(opts: FormatOptions): string {
+  const { projectName, area, bucket, structured } = opts;
+  const meta = AREA_META[area];
+  const lines: string[] = [];
+
+  lines.push(`🏢 *IA SOLARIS — Resumo ${meta.label}*`);
+  lines.push(`${meta.emoji} *Projeto:* ${projectName}`);
+
+  // Risco geral (sempre no cabeçalho — orientador)
+  const nivelRisco = structured.nivel_risco_geral ?? "não informado";
+  const confianca = structured.confidence_score?.nivel_confianca;
+  const confLabel = typeof confianca === "number" ? ` (${confianca}% confiança)` : "";
+  const riscoEmoji = nivelRisco === "critico" ? "🔴" : nivelRisco === "alto" ? "🟠" : nivelRisco === "medio" ? "🟡" : "🟢";
+  lines.push(`${riscoEmoji} *Risco Geral:* ${capitalize(nivelRisco)}${confLabel}`);
+  lines.push("");
+
+  // Resumo executivo (só no Genérico)
+  if (area === "generico" && structured.resumo_executivo) {
+    lines.push(`📝 *Resumo Executivo:*`);
+    lines.push(structured.resumo_executivo);
+    lines.push("");
+  }
+
+  // Gaps
+  if (bucket.gaps.length > 0) {
+    lines.push(`📌 *${bucket.gaps.length} Gap${bucket.gaps.length !== 1 ? "s" : ""} de ${meta.label}:*`);
+    bucket.gaps.forEach((g, i) => {
+      lines.push(`${i + 1}. ${g.gap ?? "(sem descrição)"}`);
+      if (g.evidencia_regulatoria) {
+        const urg = g.urgencia ? ` · Urgência: ${g.urgencia}` : "";
+        lines.push(`   📖 ${g.evidencia_regulatoria}${urg}`);
+      }
+    });
+    lines.push("");
+  }
+
+  // Recomendações
+  if (bucket.recomendacoes.length > 0) {
+    lines.push(`✅ *Recomendações de ${meta.label}:*`);
+    bucket.recomendacoes.forEach((r) => lines.push(`• ${r}`));
+    lines.push("");
+  }
+
+  // Oportunidades
+  if (bucket.oportunidades.length > 0) {
+    lines.push(`💡 *Oportunidades:*`);
+    bucket.oportunidades.forEach((o) => lines.push(`• ${o}`));
+    lines.push("");
+  }
+
+  // Inconsistências (só menciona contagem, não detalhe — detalhe vai no genérico)
+  if (bucket.inconsistencias.length > 0) {
+    lines.push(`⚠️ *${bucket.inconsistencias.length} Inconsistência${bucket.inconsistencias.length !== 1 ? "s" : ""} detectada${bucket.inconsistencias.length !== 1 ? "s" : ""}.*`);
+    lines.push("");
+  }
+
+  // Vazio
+  if (
+    bucket.gaps.length === 0 &&
+    bucket.recomendacoes.length === 0 &&
+    bucket.oportunidades.length === 0 &&
+    bucket.inconsistencias.length === 0 &&
+    area !== "generico"
+  ) {
+    lines.push(`ℹ️ _Nenhum item específico de ${meta.label} identificado neste diagnóstico._`);
+    lines.push("");
+  }
+
+  // Limitações (só no Genérico)
+  if (area === "generico" && structured.confidence_score?.limitacoes && structured.confidence_score.limitacoes.length > 0) {
+    lines.push(`⚠️ *Limitações do diagnóstico:*`);
+    structured.confidence_score.limitacoes.forEach((l) => lines.push(`• ${l}`));
+    lines.push("");
+  }
+
+  lines.push(`_Gerado automaticamente pela IA SOLARIS. Revisão humana recomendada._`);
+
+  return lines.join("\n").trim();
+}
+
+function capitalize(s: string): string {
+  if (!s) return s;
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}

--- a/client/src/pages/BriefingV3.tsx
+++ b/client/src/pages/BriefingV3.tsx
@@ -17,7 +17,7 @@ import {
   ArrowLeft, ChevronRight, Loader2, Sparkles,
   CheckCircle2, RefreshCw, MessageSquare, ThumbsUp, Edit3, Info, Download,
   History, Clock, ChevronDown, ChevronUp, AlertTriangle, AlertCircle,
-  Layers, TrendingUp, BarChart3, Flame, StickyNote
+  Layers, TrendingUp, BarChart3, Flame, StickyNote, Share2
 } from "lucide-react";
 import { toast } from "sonner";
 import { Streamdown } from "@/components/MarkdownRenderer";
@@ -25,6 +25,8 @@ import StepComments from "@/components/StepComments";
 // V64: Alertas de inconsistência
 import AlertasInconsistencia, { InconsistenciaBadge } from "@/components/AlertasInconsistencia";
 import { ConfidenceBar } from "@/components/ConfidenceBar";
+// #767: Modal compartilhar resumo WhatsApp (6 áreas)
+import { ShareBriefingModal } from "@/components/ShareBriefingModal";
 
 // ── Componente: Painel de Diagnóstico de Entrada (3 Camadas) ─────────────────────────────────
 function DiagnosticoEntradaPanel({
@@ -189,6 +191,9 @@ export default function BriefingV3() {
   const inconsistencias = inconsistenciasData?.inconsistencias ?? [];
   // fix(UX1 UAT 2026-04-20): confidence_score para barra visual
   const confidenceScore = (inconsistenciasData as any)?.confidenceScore ?? null;
+  // #767: structured briefing para modal compartilhar resumo WhatsApp
+  const briefingStructuredForShare = (inconsistenciasData as any)?.structured ?? null;
+  const [shareModalOpen, setShareModalOpen] = useState(false);
 
   // fix(B2 UAT 2026-04-20): resolver inconsistência sem regerar briefing (LLM-free)
   const dismissInconsistencia = trpc.fluxoV3.dismissInconsistencia.useMutation();
@@ -825,7 +830,7 @@ export default function BriefingV3() {
                     </div>
                   </div>
                 )}
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3">
                   <Button size="lg" onClick={handleApprove} disabled={isApproving || !canApprove} className="gap-2">
                     {isApproving ? <Loader2 className="h-4 w-4 animate-spin" /> : <ThumbsUp className="h-4 w-4" />}
                     Aprovar Briefing
@@ -841,6 +846,18 @@ export default function BriefingV3() {
                   <Button variant="outline" size="lg" onClick={handleExportPDF} className="gap-2 border-blue-300 text-blue-700 hover:bg-blue-50">
                     <Download className="h-4 w-4" />
                     Exportar PDF
+                  </Button>
+                  {/* #767: Compartilhar resumo em formato WhatsApp por área */}
+                  <Button
+                    variant="outline"
+                    size="lg"
+                    onClick={() => setShareModalOpen(true)}
+                    disabled={!briefingStructuredForShare}
+                    className="gap-2 border-green-300 text-green-700 hover:bg-green-50"
+                    data-testid="btn-compartilhar-resumo"
+                  >
+                    <Share2 className="h-4 w-4" />
+                    Compartilhar Resumo
                   </Button>
                 </div>
               </div>
@@ -894,6 +911,14 @@ export default function BriefingV3() {
           title="Anotações da Equipe — Briefing"
         />
       </div>
+
+      {/* #767: Modal compartilhar resumo WhatsApp (6 áreas) */}
+      <ShareBriefingModal
+        open={shareModalOpen}
+        onOpenChange={setShareModalOpen}
+        structured={briefingStructuredForShare}
+        projectName={projectName}
+      />
     </ComplianceLayout>
   );
 }

--- a/server/routers-fluxo-v3.ts
+++ b/server/routers-fluxo-v3.ts
@@ -2109,7 +2109,7 @@ Gere o veredito final em JSON:
       if (!isOwner && !isTeam) throw new TRPCError({ code: "FORBIDDEN" });
 
       const bs = (project as any).briefingStructured;
-      if (!bs) return { inconsistencias: [], totalCount: 0, hasAlerts: false, confidenceScore: null };
+      if (!bs) return { inconsistencias: [], totalCount: 0, hasAlerts: false, confidenceScore: null, structured: null };
 
       try {
         const parsed = typeof bs === "string" ? JSON.parse(bs) : bs;
@@ -2127,9 +2127,20 @@ Gere o veredito final em JSON:
             baixo: inconsistencias.filter((i: any) => i.impacto === "baixo").length,
           },
           confidenceScore,
+          // fix(#767 UAT 2026-04-20): expor briefing estruturado completo para
+          // o modal "Compartilhar Resumo WhatsApp" consumir no cliente.
+          structured: {
+            nivel_risco_geral: parsed?.nivel_risco_geral ?? null,
+            resumo_executivo: parsed?.resumo_executivo ?? null,
+            principais_gaps: Array.isArray(parsed?.principais_gaps) ? parsed.principais_gaps : [],
+            oportunidades: Array.isArray(parsed?.oportunidades) ? parsed.oportunidades : [],
+            recomendacoes_prioritarias: Array.isArray(parsed?.recomendacoes_prioritarias) ? parsed.recomendacoes_prioritarias : [],
+            inconsistencias,
+            confidence_score: confidenceScore,
+          },
         };
       } catch {
-        return { inconsistencias: [], totalCount: 0, hasAlerts: false, confidenceScore: null };
+        return { inconsistencias: [], totalCount: 0, hasAlerts: false, confidenceScore: null, structured: null };
       }
     }),
 


### PR DESCRIPTION
## Summary

**Closes #767.** Novo modal "Compartilhar Resumo" no briefing — 6 tabs separando itens por área (Genérico, Fiscal, T.I., Contabilidade, Legal, Gestão), texto formatado para WhatsApp, botão "Copiar" por tab.

Caso de uso: advogado/gestor copia texto e cola em grupos de WhatsApp específicos por área — cada destinatário recebe só o que é relevante para sua função.

## Implementação

| Camada | Arquivo | Tamanho |
|---|---|---|
| Classificador | `client/src/lib/briefing-areas.ts` | 255 L |
| Testes | `client/src/lib/briefing-areas.test.ts` | **13 tests PASS** |
| Modal | `client/src/components/ShareBriefingModal.tsx` | 162 L |
| Integração | `client/src/pages/BriefingV3.tsx` | +29 L |
| Backend expose | `server/routers-fluxo-v3.ts::getBriefingInconsistencias` | +15 L |

### Classificador — Opção B (determinística)

Regex por keywords + ordem de especificidade: **contabilidade → TI → fiscal → legal → gestão → genérico**. Essa ordem evita que "segregação contábil IBS/CBS" vire fiscal por causa do "IBS/CBS".

```ts
classifyItemByArea("Escrituração contábil defasada") → "contabilidade"
classifyItemByArea("Parametrização do ERP") → "ti"
classifyItemByArea("Alíquota IBS incorreta") → "fiscal"
classifyItemByArea("Parecer sobre interpretação Art. 12") → "legal"
classifyItemByArea("Impacto no fluxo de caixa mensal") → "gestao"
```

### Formato WhatsApp (exemplo)

```
🏢 *IA SOLARIS — Resumo Fiscal*
💼 *Projeto:* Distribuidora Alimentos Teste
🟠 *Risco Geral:* Alto (85% confiança)

📌 *2 Gaps de Fiscal:*
1. Ausência de alíquotas CBS/IBS por UF
   📖 Art. 14 e Art. 15 LC 214/2025 · Urgência: imediata
2. Enquadramento de Imposto Seletivo
   📖 Art. 2 LC 214/2025 · Urgência: imediata

✅ *Recomendações de Fiscal:*
• Levantar alíquotas vigentes em SP, RJ, MG
```

## Backend change (mínimo)

`getBriefingInconsistencias` agora retorna campo adicional `structured` com o briefing completo (já parseado de `briefingStructured` JSON). Backward compatible — consumidores existentes continuam funcionando.

## Data-testid (Bloco 9)

- `btn-compartilhar-resumo`
- `modal-resumo-whatsapp`
- `tab-area-{generico|fiscal|ti|contabilidade|legal|gestao}`
- `resumo-preview-{area}`
- `btn-copy-resumo-{area}`

## Test plan

- [x] `pnpm check` — zero erros.
- [x] `pnpm vitest run client/src/lib/briefing-areas.test.ts` — **13/13 PASS**.
- [ ] UAT: abrir briefing aprovado → clicar "Compartilhar Resumo" → modal aparece com 6 tabs.
- [ ] UAT: cada tab mostra texto formatado com emojis + *negrito*.
- [ ] UAT: botão "Copiar" copia para clipboard + toast de confirmação.
- [ ] UAT: tab Fiscal tem só itens fiscais (não contabilidade, não TI).
- [ ] UAT: tab Genérico mostra Resumo Executivo + Limitações + tudo classificado como genérico.

🤖 Generated with [Claude Code](https://claude.com/claude-code)