### PR TITLE
feat(audit): Trilha de Auditoria — página dedicada com timeline unificada — Closes #766

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -29,6 +29,7 @@ import MatrizRiscos from "@/pages/MatrizRiscos";
 import MatrizRiscosGlobal from "@/pages/MatrizRiscosGlobal";
 import ProjetoDetalhes from "./pages/ProjetoDetalhes";
 import ProjetoDetalhesV2 from "./pages/ProjetoDetalhesV2";
+import ProjectHistoryTimeline from "./pages/ProjectHistoryTimeline";
 import GerenciarAcoes from "./pages/GerenciarAcoes";
 import VisualizadorAuditoria from "./pages/VisualizadorAuditoria";
 import NotFound from "./pages/NotFound";
@@ -85,6 +86,7 @@ function Router() {
       <Route path="/projetos" component={Projetos} />
       <Route path="/projetos/novo" component={NovoProjeto} />
       <Route path="/projetos/:id" component={ProjetoDetalhesV2} />
+      <Route path="/projetos/:id/historico" component={ProjectHistoryTimeline} />
       <Route path="/clientes" component={Clientes} />
       <Route path="/clientes/novo" component={NovoCliente} />
       <Route path="/projetos/:id/avaliacao/fase1" component={AvaliacaoFase1} />

--- a/client/src/pages/ProjectHistoryTimeline.tsx
+++ b/client/src/pages/ProjectHistoryTimeline.tsx
@@ -1,0 +1,607 @@
+/**
+ * ProjectHistoryTimeline — #766 Trilha de Auditoria do projeto
+ *
+ * Página dedicada em /projetos/:id/historico.
+ * Exibe a timeline unificada (auditLog camelCase + audit_log snake) consolidada
+ * pela procedure `trpc.audit.getProjectTimeline`.
+ *
+ * Decisões de UX:
+ * - Página dedicada (não tab) porque a Reforma Tributária corre até 2031 e o
+ *   volume de eventos crescerá. Tab sobrecarregaria a tela de projeto.
+ * - Agrupamento por DIA com cabeçalho legível ("Hoje", "Ontem", "18/04/2026").
+ * - Filtros inline no topo: busca texto, categorias como pills, período preset.
+ * - Banner de stats compacto (total, usuários únicos, período coberto).
+ * - Cada entrada: ícone colorido por categoria, texto humanizado, horário
+ *   relativo ("há 5 min"), expansão para ver metadata bruta.
+ * - Export CSV (auditoria formal exige).
+ */
+import { useMemo, useState } from "react";
+import { useParams, useLocation, Link } from "wouter";
+import ComplianceLayout from "@/components/ComplianceLayout";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import {
+  ArrowLeft,
+  Search,
+  Download,
+  Clock,
+  FileText,
+  Shield,
+  AlertTriangle,
+  ListChecks,
+  CheckSquare,
+  FolderKanban,
+  KeyRound,
+  MessageSquare,
+  ChevronDown,
+  ChevronRight,
+  RefreshCw,
+  Calendar,
+  Users,
+  Activity,
+} from "lucide-react";
+import { trpc } from "@/lib/trpc";
+import { cn } from "@/lib/utils";
+
+type Category =
+  | "projeto"
+  | "briefing"
+  | "risco"
+  | "plano"
+  | "tarefa"
+  | "pergunta"
+  | "permissao"
+  | "outro";
+
+interface TimelineEntry {
+  id: string;
+  timestamp: number;
+  userId: number | null;
+  userName: string;
+  userRole?: string | null;
+  projectId: number;
+  category: Category;
+  entity: string;
+  entityId: string;
+  actionLabel: string;
+  description: string;
+  rawAction: string;
+  event?: string | null;
+  changes?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
+  reason?: string | null;
+  source: "auditLog" | "audit_log";
+}
+
+// ─── Metadados de categoria ──────────────────────────────────────────────────
+
+const CATEGORY_META: Record<
+  Category,
+  { label: string; Icon: typeof FileText; colorClass: string; bgClass: string; borderClass: string }
+> = {
+  projeto: {
+    label: "Projeto",
+    Icon: FolderKanban,
+    colorClass: "text-slate-700 dark:text-slate-300",
+    bgClass: "bg-slate-100 dark:bg-slate-800",
+    borderClass: "border-slate-300 dark:border-slate-700",
+  },
+  briefing: {
+    label: "Briefing",
+    Icon: FileText,
+    colorClass: "text-blue-700 dark:text-blue-300",
+    bgClass: "bg-blue-50 dark:bg-blue-950/40",
+    borderClass: "border-blue-300 dark:border-blue-800",
+  },
+  risco: {
+    label: "Riscos",
+    Icon: AlertTriangle,
+    colorClass: "text-amber-700 dark:text-amber-300",
+    bgClass: "bg-amber-50 dark:bg-amber-950/40",
+    borderClass: "border-amber-300 dark:border-amber-800",
+  },
+  plano: {
+    label: "Planos",
+    Icon: ListChecks,
+    colorClass: "text-violet-700 dark:text-violet-300",
+    bgClass: "bg-violet-50 dark:bg-violet-950/40",
+    borderClass: "border-violet-300 dark:border-violet-800",
+  },
+  tarefa: {
+    label: "Tarefas",
+    Icon: CheckSquare,
+    colorClass: "text-emerald-700 dark:text-emerald-300",
+    bgClass: "bg-emerald-50 dark:bg-emerald-950/40",
+    borderClass: "border-emerald-300 dark:border-emerald-800",
+  },
+  pergunta: {
+    label: "Questionários",
+    Icon: MessageSquare,
+    colorClass: "text-cyan-700 dark:text-cyan-300",
+    bgClass: "bg-cyan-50 dark:bg-cyan-950/40",
+    borderClass: "border-cyan-300 dark:border-cyan-800",
+  },
+  permissao: {
+    label: "Permissões",
+    Icon: KeyRound,
+    colorClass: "text-rose-700 dark:text-rose-300",
+    bgClass: "bg-rose-50 dark:bg-rose-950/40",
+    borderClass: "border-rose-300 dark:border-rose-800",
+  },
+  outro: {
+    label: "Outros",
+    Icon: Shield,
+    colorClass: "text-zinc-700 dark:text-zinc-300",
+    bgClass: "bg-zinc-100 dark:bg-zinc-800",
+    borderClass: "border-zinc-300 dark:border-zinc-700",
+  },
+};
+
+const CATEGORY_ORDER: Category[] = [
+  "projeto", "briefing", "risco", "plano", "tarefa", "pergunta", "permissao", "outro",
+];
+
+type PeriodPreset = "24h" | "7d" | "30d" | "6m" | "all";
+
+const PERIOD_PRESETS: Array<{ key: PeriodPreset; label: string; ms: number | null }> = [
+  { key: "24h", label: "24 horas", ms: 24 * 60 * 60 * 1000 },
+  { key: "7d",  label: "7 dias",   ms: 7 * 24 * 60 * 60 * 1000 },
+  { key: "30d", label: "30 dias",  ms: 30 * 24 * 60 * 60 * 1000 },
+  { key: "6m",  label: "6 meses",  ms: 180 * 24 * 60 * 60 * 1000 },
+  { key: "all", label: "Tudo",     ms: null },
+];
+
+// ─── Agrupamento por dia ────────────────────────────────────────────────────
+
+function startOfDay(ts: number): number {
+  const d = new Date(ts);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+function dayLabel(dayStart: number): string {
+  const now = new Date();
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const yesterday = today.getTime() - 24 * 60 * 60 * 1000;
+
+  if (dayStart === today.getTime()) return "Hoje";
+  if (dayStart === yesterday) return "Ontem";
+
+  const d = new Date(dayStart);
+  const sameYear = d.getFullYear() === now.getFullYear();
+  return d.toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "long",
+    ...(sameYear ? {} : { year: "numeric" }),
+    weekday: "long",
+  });
+}
+
+function relativeTime(ts: number): string {
+  const diff = Date.now() - ts;
+  if (diff < 60_000) return "agora";
+  if (diff < 3_600_000) return `há ${Math.floor(diff / 60_000)} min`;
+  if (diff < 86_400_000) return `há ${Math.floor(diff / 3_600_000)}h`;
+  return new Date(ts).toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" });
+}
+
+function formatTimeOfDay(ts: number): string {
+  return new Date(ts).toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" });
+}
+
+// ─── CSV export ─────────────────────────────────────────────────────────────
+
+function exportCsv(entries: TimelineEntry[], projectName: string) {
+  const rows = [
+    ["timestamp_iso", "data_hora_br", "usuario", "categoria", "entidade", "acao", "descricao", "event", "entity_id", "source"],
+    ...entries.map((e) => [
+      new Date(e.timestamp).toISOString(),
+      new Date(e.timestamp).toLocaleString("pt-BR"),
+      e.userName,
+      CATEGORY_META[e.category].label,
+      e.entity,
+      e.rawAction,
+      e.description.replace(/"/g, '""'),
+      e.event ?? "",
+      e.entityId,
+      e.source,
+    ]),
+  ];
+  const csv = rows
+    .map((row) => row.map((c) => `"${String(c ?? "").replace(/"/g, '""')}"`).join(","))
+    .join("\r\n");
+  const bom = "\uFEFF"; // BOM para Excel detectar UTF-8
+  const blob = new Blob([bom + csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `trilha-auditoria-${projectName.replace(/\s+/g, "_")}-${new Date().toISOString().slice(0, 10)}.csv`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+// ─── Componente principal ──────────────────────────────────────────────────
+
+export default function ProjectHistoryTimeline() {
+  const params = useParams<{ id: string }>();
+  const projectId = parseInt(params?.id ?? "0", 10);
+  const [, navigate] = useLocation();
+
+  const [searchText, setSearchText] = useState("");
+  const [selectedCategories, setSelectedCategories] = useState<Set<Category>>(new Set());
+  const [period, setPeriod] = useState<PeriodPreset>("30d");
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+
+  const fromTimestamp = useMemo(() => {
+    const preset = PERIOD_PRESETS.find((p) => p.key === period);
+    if (!preset || preset.ms === null) return undefined;
+    return Date.now() - preset.ms;
+  }, [period]);
+
+  const { data: projectData } = trpc.projects.getById.useQuery(
+    { id: projectId },
+    { enabled: projectId > 0 }
+  );
+  const projectName = (projectData as any)?.name ?? `Projeto #${projectId}`;
+
+  const { data: timeline, isLoading, refetch } = trpc.audit.getProjectTimeline.useQuery(
+    {
+      projectId,
+      categories: selectedCategories.size > 0 ? Array.from(selectedCategories) : undefined,
+      fromTimestamp,
+      searchText: searchText.trim() || undefined,
+      limit: 500,
+    },
+    { enabled: projectId > 0 }
+  );
+
+  const entries = (timeline?.entries ?? []) as TimelineEntry[];
+  const stats = timeline?.stats;
+
+  // Agrupar por dia
+  const groupedByDay = useMemo(() => {
+    const map = new Map<number, TimelineEntry[]>();
+    for (const e of entries) {
+      const key = startOfDay(e.timestamp);
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(e);
+    }
+    return Array.from(map.entries()).sort((a, b) => b[0] - a[0]);
+  }, [entries]);
+
+  const toggleCategory = (cat: Category) => {
+    setSelectedCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(cat)) next.delete(cat);
+      else next.add(cat);
+      return next;
+    });
+  };
+
+  const toggleExpanded = (id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <ComplianceLayout>
+      <div className="container mx-auto px-4 py-6 space-y-5 max-w-5xl">
+        {/* Header */}
+        <div className="flex items-start justify-between gap-4 flex-wrap">
+          <div className="space-y-1">
+            <Link
+              href={`/projetos/${projectId}`}
+              className="text-xs text-muted-foreground hover:text-foreground inline-flex items-center gap-1"
+            >
+              <ArrowLeft className="h-3 w-3" /> Voltar ao projeto
+            </Link>
+            <h1 className="text-2xl font-bold flex items-center gap-2">
+              <Clock className="h-6 w-6" /> Trilha de Auditoria
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Histórico permanente de todas as alterações em <strong>{projectName}</strong>.
+              Registros imutáveis para conformidade com a Reforma Tributária.
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => refetch()}
+              disabled={isLoading}
+              data-testid="btn-refresh-timeline"
+              className="gap-1.5"
+            >
+              <RefreshCw className={cn("h-4 w-4", isLoading && "animate-spin")} />
+              Atualizar
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => exportCsv(entries, projectName)}
+              disabled={entries.length === 0}
+              data-testid="btn-export-timeline-csv"
+              className="gap-1.5"
+            >
+              <Download className="h-4 w-4" /> Exportar CSV
+            </Button>
+          </div>
+        </div>
+
+        {/* Stats banner */}
+        {stats && (
+          <Card className="border-slate-200 dark:border-slate-800">
+            <CardContent className="p-4 grid grid-cols-2 md:grid-cols-4 gap-4">
+              <StatBox
+                icon={Activity}
+                label="Eventos registrados"
+                value={stats.totalEntries.toLocaleString("pt-BR")}
+                subtitle={
+                  timeline!.totalBeforeFilter !== stats.totalEntries
+                    ? `${timeline!.totalBeforeFilter.toLocaleString("pt-BR")} no total`
+                    : "no período selecionado"
+                }
+              />
+              <StatBox
+                icon={Users}
+                label="Usuários ativos"
+                value={stats.uniqueUsers.toString()}
+                subtitle={stats.uniqueUsers === 1 ? "pessoa" : "pessoas"}
+              />
+              <StatBox
+                icon={Calendar}
+                label="Primeiro registro"
+                value={stats.firstTimestamp ? new Date(stats.firstTimestamp).toLocaleDateString("pt-BR") : "—"}
+                subtitle={stats.firstTimestamp ? relativeTime(stats.firstTimestamp) : ""}
+              />
+              <StatBox
+                icon={Clock}
+                label="Último registro"
+                value={stats.lastTimestamp ? new Date(stats.lastTimestamp).toLocaleDateString("pt-BR") : "—"}
+                subtitle={stats.lastTimestamp ? relativeTime(stats.lastTimestamp) : ""}
+              />
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Filtros */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm">Filtros</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {/* Busca */}
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                value={searchText}
+                onChange={(e) => setSearchText(e.target.value)}
+                placeholder="Buscar por usuário, descrição, ação..."
+                className="pl-9"
+                data-testid="input-timeline-search"
+              />
+            </div>
+
+            {/* Categorias */}
+            <div className="flex flex-wrap gap-1.5" data-testid="filter-categories">
+              {CATEGORY_ORDER.map((cat) => {
+                const meta = CATEGORY_META[cat];
+                const active = selectedCategories.has(cat);
+                const count = stats?.byCategory?.[cat] ?? 0;
+                const Icon = meta.Icon;
+                return (
+                  <button
+                    key={cat}
+                    onClick={() => toggleCategory(cat)}
+                    data-testid={`filter-category-${cat}`}
+                    className={cn(
+                      "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium transition",
+                      active
+                        ? cn(meta.bgClass, meta.colorClass, meta.borderClass)
+                        : "border-border bg-background text-muted-foreground hover:bg-muted"
+                    )}
+                  >
+                    <Icon className="h-3 w-3" />
+                    {meta.label}
+                    {count > 0 && (
+                      <Badge variant="secondary" className="h-4 px-1 text-[10px] font-mono">
+                        {count}
+                      </Badge>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* Período */}
+            <div className="flex flex-wrap gap-1.5" data-testid="filter-period">
+              <span className="text-xs text-muted-foreground self-center mr-1">Período:</span>
+              {PERIOD_PRESETS.map((p) => (
+                <button
+                  key={p.key}
+                  onClick={() => setPeriod(p.key)}
+                  data-testid={`filter-period-${p.key}`}
+                  className={cn(
+                    "rounded-full border px-3 py-1 text-xs transition",
+                    period === p.key
+                      ? "bg-primary text-primary-foreground border-primary"
+                      : "border-border bg-background text-muted-foreground hover:bg-muted"
+                  )}
+                >
+                  {p.label}
+                </button>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Timeline */}
+        {isLoading ? (
+          <div className="py-12 text-center text-muted-foreground">
+            <RefreshCw className="h-6 w-6 animate-spin mx-auto mb-2" />
+            Carregando trilha...
+          </div>
+        ) : groupedByDay.length === 0 ? (
+          <Card>
+            <CardContent className="py-12 text-center text-muted-foreground space-y-2">
+              <Shield className="h-10 w-10 mx-auto opacity-30" />
+              <p className="text-sm">
+                {searchText || selectedCategories.size > 0 || period !== "all"
+                  ? "Nenhum evento encontrado com os filtros aplicados."
+                  : "Ainda não há eventos registrados neste projeto."}
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-6" data-testid="timeline-content">
+            {groupedByDay.map(([dayStart, dayEntries]) => (
+              <div key={dayStart} className="space-y-2" data-testid={`timeline-day-${dayStart}`}>
+                <div className="sticky top-0 z-10 bg-background/95 backdrop-blur py-1 flex items-baseline gap-2 border-b">
+                  <h3 className="text-sm font-semibold capitalize">{dayLabel(dayStart)}</h3>
+                  <span className="text-xs text-muted-foreground">
+                    {dayEntries.length} {dayEntries.length === 1 ? "evento" : "eventos"}
+                  </span>
+                </div>
+                <div className="space-y-1.5 pl-1">
+                  {dayEntries.map((entry) => (
+                    <TimelineEntryRow
+                      key={entry.id}
+                      entry={entry}
+                      expanded={expandedIds.has(entry.id)}
+                      onToggle={() => toggleExpanded(entry.id)}
+                    />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </ComplianceLayout>
+  );
+}
+
+// ─── Sub-componentes ────────────────────────────────────────────────────────
+
+function StatBox({
+  icon: Icon,
+  label,
+  value,
+  subtitle,
+}: {
+  icon: typeof Activity;
+  label: string;
+  value: string;
+  subtitle?: string;
+}) {
+  return (
+    <div className="space-y-0.5">
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <Icon className="h-3 w-3" />
+        {label}
+      </div>
+      <div className="text-2xl font-bold tabular-nums">{value}</div>
+      {subtitle && <div className="text-xs text-muted-foreground">{subtitle}</div>}
+    </div>
+  );
+}
+
+function TimelineEntryRow({
+  entry,
+  expanded,
+  onToggle,
+}: {
+  entry: TimelineEntry;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const meta = CATEGORY_META[entry.category];
+  const Icon = meta.Icon;
+  const hasDetails =
+    (entry.metadata && Object.keys(entry.metadata).length > 0) ||
+    (entry.changes && Object.keys(entry.changes).length > 0) ||
+    !!entry.reason;
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border transition",
+        meta.borderClass,
+        expanded ? meta.bgClass : "bg-card hover:bg-muted/30"
+      )}
+      data-testid={`timeline-entry-${entry.id}`}
+    >
+      <button
+        onClick={hasDetails ? onToggle : undefined}
+        disabled={!hasDetails}
+        className={cn(
+          "w-full text-left px-3 py-2 flex items-start gap-3",
+          hasDetails && "cursor-pointer"
+        )}
+      >
+        <div className={cn("mt-0.5 rounded p-1.5", meta.bgClass, meta.colorClass)}>
+          <Icon className="h-3.5 w-3.5" />
+        </div>
+        <div className="flex-1 min-w-0 space-y-0.5">
+          <div className="flex items-baseline gap-2 flex-wrap">
+            <span className="text-sm leading-snug">{entry.description}</span>
+            {entry.event && (
+              <Badge variant="outline" className="text-[10px] font-mono h-4 px-1">
+                {entry.event}
+              </Badge>
+            )}
+          </div>
+          <div className="text-[11px] text-muted-foreground flex items-center gap-2 flex-wrap">
+            <span>{formatTimeOfDay(entry.timestamp)}</span>
+            <span>·</span>
+            <span>{relativeTime(entry.timestamp)}</span>
+            <span>·</span>
+            <span>{meta.label}</span>
+            <span>·</span>
+            <span className="font-mono text-[10px] opacity-70">{entry.entity}#{entry.entityId}</span>
+          </div>
+        </div>
+        {hasDetails && (
+          <span className={cn("mt-1 shrink-0", meta.colorClass)}>
+            {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+          </span>
+        )}
+      </button>
+      {expanded && hasDetails && (
+        <div className="px-3 pb-3 pt-0 space-y-2 border-t border-border/50 mt-0" data-testid={`timeline-details-${entry.id}`}>
+          {entry.reason && (
+            <div className="pt-2">
+              <div className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wide mb-0.5">Motivo</div>
+              <div className="text-xs">{entry.reason}</div>
+            </div>
+          )}
+          {entry.changes && Object.keys(entry.changes).length > 0 && (
+            <div className="pt-2">
+              <div className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wide mb-0.5">Alterações</div>
+              <pre className="text-[11px] bg-muted/50 rounded p-2 overflow-auto max-h-48">
+                {JSON.stringify(entry.changes, null, 2)}
+              </pre>
+            </div>
+          )}
+          {entry.metadata && Object.keys(entry.metadata).length > 0 && (
+            <div className="pt-2">
+              <div className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wide mb-0.5">Metadata</div>
+              <pre className="text-[11px] bg-muted/50 rounded p-2 overflow-auto max-h-64">
+                {JSON.stringify(entry.metadata, null, 2)}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/ProjetoDetalhesV2.tsx
+++ b/client/src/pages/ProjetoDetalhesV2.tsx
@@ -29,6 +29,7 @@ import {
   Users,
   Edit3,
   Tag,
+  History,
 } from "lucide-react";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useAuth } from "@/_core/hooks/useAuth";
@@ -380,7 +381,16 @@ export default function ProjetoDetalhesV2() {
                     <Clock className="w-3.5 h-3.5" />
                     Atualizado {new Date(summary.updatedAt).toLocaleDateString("pt-BR")}
                   </span>
-
+                  {/* #766: Trilha de Auditoria — acesso permanente (Reforma até 2031) */}
+                  <button
+                    type="button"
+                    onClick={() => setLocation(`/projetos/${projectId}/historico`)}
+                    data-testid="btn-trilha-auditoria"
+                    className="flex items-center gap-1 text-xs hover:text-foreground underline-offset-2 hover:underline transition-colors"
+                  >
+                    <History className="w-3.5 h-3.5" />
+                    Trilha de Auditoria
+                  </button>
                 </div>
               </div>
             </div>

--- a/server/lib/project-timeline.ts
+++ b/server/lib/project-timeline.ts
@@ -1,0 +1,325 @@
+/**
+ * project-timeline.ts — #766 feat(ux) Trilha de Auditoria
+ *
+ * Consolida as duas tabelas de audit (auditLog camelCase + audit_log snake_case)
+ * em uma timeline unificada do projeto, com humanização determinística dos eventos.
+ *
+ * Por que duas tabelas?
+ * - auditLog (camelCase)   — projeto, briefing, tarefa, comentário, perguntas, permissões.
+ *                            Metadados ricos via `metadata.event`.
+ * - audit_log (snake_case) — engine v4 de riscos/planos/tarefas (soft-delete com cascade,
+ *                            aprovações, restore). Padrão RN-RISK-* / RN-AP-*.
+ *
+ * Os consumers da UI devem tratar as entries como imutáveis e só usar os campos
+ * públicos exportados aqui (não os rows brutos do DB).
+ */
+
+import { desc, eq } from "drizzle-orm";
+import { getDb } from "../db";
+import { auditLog } from "../../drizzle/schema";
+import { getProjectAuditLog } from "./db-queries-risks-v4";
+
+// ─── Tipos públicos ─────────────────────────────────────────────────────────
+
+export type TimelineCategory =
+  | "projeto"
+  | "briefing"
+  | "risco"
+  | "plano"
+  | "tarefa"
+  | "pergunta"
+  | "permissao"
+  | "outro";
+
+export interface TimelineEntry {
+  /** Chave composta única: `${source}-${id}` */
+  id: string;
+  /** ms epoch, ordenação DESC */
+  timestamp: number;
+  userId: number | null;
+  userName: string;
+  userRole?: string | null;
+  projectId: number;
+  /** Categoria de alto nível (para agrupamento na UI) */
+  category: TimelineCategory;
+  /** Entidade bruta (risk, action_plan, task, project, ...) */
+  entity: string;
+  /** ID da entidade afetada (string para UUIDs do engine v4, number stringified p/ camelCase) */
+  entityId: string;
+  /** Ação humanizada em PT-BR curto (ex: "aprovou", "criou", "excluiu em cascata") */
+  actionLabel: string;
+  /** Texto humanizado completo da entrada (ex: "Briefing gerado com 3 fontes ativas") */
+  description: string;
+  /** Ação técnica original (p/ filtros e export) */
+  rawAction: string;
+  /** Se metadata.event estiver presente, expõe aqui — ex: "briefing_generated" */
+  event?: string | null;
+  /** Changes estruturado (auditLog camelCase) */
+  changes?: Record<string, unknown> | null;
+  /** Metadata bruta (ambas as tabelas) */
+  metadata?: Record<string, unknown> | null;
+  /** Motivo textual (audit_log snake) */
+  reason?: string | null;
+  /** Qual tabela originou (debug/export) */
+  source: "auditLog" | "audit_log";
+}
+
+// ─── Humanização ────────────────────────────────────────────────────────────
+
+const ENTITY_TO_CATEGORY: Record<string, TimelineCategory> = {
+  project:               "projeto",
+  risk:                  "risco",
+  action_plan:           "plano",
+  task:                  "tarefa",
+  comment:               "outro",
+  corporate_assessment:  "projeto",
+  branch_assessment:     "projeto",
+  corporate_question:    "pergunta",
+  branch_question:       "pergunta",
+  permission:            "permissao",
+};
+
+const ENTITY_LABEL: Record<string, string> = {
+  project:               "Projeto",
+  risk:                  "Risco",
+  action_plan:           "Plano de ação",
+  task:                  "Tarefa",
+  comment:               "Comentário",
+  corporate_assessment:  "Questionário corporativo",
+  branch_assessment:     "Questionário de ramo",
+  corporate_question:    "Pergunta corporativa",
+  branch_question:       "Pergunta de ramo",
+  permission:            "Permissão",
+};
+
+const ACTION_LABEL: Record<string, string> = {
+  create:          "criou",
+  created:         "criou",
+  update:          "atualizou",
+  updated:         "atualizou",
+  delete:          "excluiu",
+  deleted:         "excluiu",
+  deleted_cascade: "excluiu em cascata",
+  restored:        "restaurou",
+  approved:        "aprovou",
+  rejected:        "rejeitou",
+  status_change:   "alterou o status",
+  completed:       "concluiu",
+};
+
+const EVENT_LABEL: Record<string, string> = {
+  briefing_generated:                 "Briefing regenerado",
+  briefing_generated_from_diagnostic: "Briefing gerado (diagnóstico completo)",
+  briefing_approved:                  "Briefing aprovado",
+  inconsistencia_dismissed:           "Inconsistência resolvida no briefing",
+};
+
+function categoryForEntity(entity: string, event?: string | null): TimelineCategory {
+  if (event && event.startsWith("briefing_")) return "briefing";
+  if (event === "inconsistencia_dismissed") return "briefing";
+  return ENTITY_TO_CATEGORY[entity] ?? "outro";
+}
+
+function humanizeAction(rawAction: string): string {
+  return ACTION_LABEL[rawAction] ?? rawAction;
+}
+
+function describeEntry(opts: {
+  entity: string;
+  rawAction: string;
+  event?: string | null;
+  metadata?: Record<string, any> | null;
+  changes?: Record<string, any> | null;
+  userName: string;
+}): string {
+  const { entity, rawAction, event, metadata, userName } = opts;
+
+  // 1) Prioridade: eventos conhecidos de briefing
+  if (event && EVENT_LABEL[event]) {
+    let base = EVENT_LABEL[event];
+    if (event === "briefing_generated" || event === "briefing_generated_from_diagnostic") {
+      const sources = metadata?.sources as Record<string, any> | undefined;
+      if (sources) {
+        const usedList = Object.entries(sources)
+          .filter(([, v]: any) => v?.used)
+          .map(([k]) => humanizeSourceKey(k));
+        if (usedList.length > 0) {
+          base += ` — fontes: ${usedList.join(", ")}`;
+        } else {
+          base += ` — sem respostas em nenhuma fonte`;
+        }
+      }
+      const risco = metadata?.output?.nivel_risco;
+      const conf  = metadata?.output?.confidence;
+      if (risco || typeof conf === "number") {
+        const parts: string[] = [];
+        if (risco) parts.push(`risco ${risco}`);
+        if (typeof conf === "number") parts.push(`${conf}% confiança`);
+        base += ` (${parts.join(", ")})`;
+      }
+    }
+    return `${userName} — ${base}`;
+  }
+
+  // 2) Fallback: "Entidade — ação"
+  const entityLabel = ENTITY_LABEL[entity] ?? entity;
+  const actionLabel = humanizeAction(rawAction);
+  return `${userName} ${actionLabel} ${entityLabel.toLowerCase()}`;
+}
+
+function humanizeSourceKey(key: string): string {
+  const m: Record<string, string> = {
+    solaris_onda1:                "SOLARIS Onda 1",
+    iagen_onda2:                  "IA Gen Onda 2",
+    q_produtos_ncm:               "Q.Produtos (NCM)",
+    q_servicos_nbs:               "Q.Serviços (NBS)",
+    qcnae_especializado:          "QCNAE",
+    qcnae_especializado_struct:   "QCNAE especializado",
+  };
+  return m[key] ?? key;
+}
+
+// ─── Fetcher principal ──────────────────────────────────────────────────────
+
+export async function getProjectTimelineEntries(
+  projectId: number,
+  limit: number = 300
+): Promise<TimelineEntry[]> {
+  const db = await getDb();
+  const entries: TimelineEntry[] = [];
+
+  // Tabela 1: auditLog (camelCase) — projeto/briefing/tarefa/pergunta
+  if (db) {
+    const safeLimit = Math.max(1, Math.min(1000, Math.floor(limit)));
+    const camelRows = await db
+      .select()
+      .from(auditLog)
+      .where(eq(auditLog.projectId, projectId))
+      .orderBy(desc(auditLog.timestamp))
+      .limit(safeLimit);
+
+    for (const row of camelRows) {
+      const metadata = (row.metadata ?? null) as Record<string, any> | null;
+      const event = (metadata?.event as string | undefined) ?? null;
+      const category = categoryForEntity(row.entityType, event);
+      const ts = row.timestamp instanceof Date
+        ? row.timestamp.getTime()
+        : Number(row.timestamp ?? 0);
+
+      entries.push({
+        id: `auditLog-${row.id}`,
+        timestamp: ts,
+        userId: row.userId,
+        userName: row.userName,
+        projectId: row.projectId,
+        category,
+        entity: row.entityType,
+        entityId: String(row.entityId),
+        actionLabel: humanizeAction(row.action),
+        rawAction: row.action,
+        event,
+        description: describeEntry({
+          entity: row.entityType,
+          rawAction: row.action,
+          event,
+          metadata,
+          changes: (row.changes ?? null) as Record<string, any> | null,
+          userName: row.userName,
+        }),
+        changes: (row.changes ?? null) as Record<string, any> | null,
+        metadata,
+        source: "auditLog",
+      });
+    }
+  }
+
+  // Tabela 2: audit_log (snake_case) — engine v4 (risk, action_plan, task)
+  const safeLimit = Math.max(1, Math.min(1000, Math.floor(limit)));
+  const snakeRows = await getProjectAuditLog(projectId, safeLimit);
+  for (const row of snakeRows) {
+    const ts = row.created_at instanceof Date
+      ? row.created_at.getTime()
+      : Number(row.created_at ?? 0);
+    const entity = row.entity;
+    const category = categoryForEntity(entity, null);
+    const description = describeEntry({
+      entity,
+      rawAction: row.action,
+      event: null,
+      metadata: null,
+      changes: null,
+      userName: row.user_name,
+    });
+
+    entries.push({
+      id: `audit_log-${row.id}`,
+      timestamp: ts,
+      userId: row.user_id,
+      userName: row.user_name,
+      userRole: row.user_role,
+      projectId: row.project_id,
+      category,
+      entity,
+      entityId: row.entity_id,
+      actionLabel: humanizeAction(row.action),
+      rawAction: row.action,
+      event: null,
+      description,
+      changes: null,
+      metadata: {
+        before_state: row.before_state,
+        after_state: row.after_state,
+      },
+      reason: row.reason,
+      source: "audit_log",
+    });
+  }
+
+  // Ordena DESC global
+  entries.sort((a, b) => b.timestamp - a.timestamp);
+
+  return entries;
+}
+
+// ─── Filtros aplicáveis em memória ──────────────────────────────────────────
+
+export interface TimelineFilters {
+  categories?: TimelineCategory[];
+  userIds?: number[];
+  fromTimestamp?: number;
+  toTimestamp?: number;
+  searchText?: string;
+}
+
+export function filterTimelineEntries(
+  entries: TimelineEntry[],
+  filters: TimelineFilters
+): TimelineEntry[] {
+  const searchLower = (filters.searchText ?? "").trim().toLowerCase();
+  const categoriesSet = filters.categories && filters.categories.length > 0
+    ? new Set(filters.categories)
+    : null;
+  const userIdsSet = filters.userIds && filters.userIds.length > 0
+    ? new Set(filters.userIds)
+    : null;
+
+  return entries.filter((e) => {
+    if (categoriesSet && !categoriesSet.has(e.category)) return false;
+    if (userIdsSet && (e.userId == null || !userIdsSet.has(e.userId))) return false;
+    if (filters.fromTimestamp && e.timestamp < filters.fromTimestamp) return false;
+    if (filters.toTimestamp && e.timestamp > filters.toTimestamp) return false;
+    if (searchLower) {
+      const blob = [
+        e.description,
+        e.userName,
+        e.entity,
+        e.entityId,
+        e.rawAction,
+        e.event ?? "",
+        e.reason ?? "",
+      ].join(" ").toLowerCase();
+      if (!blob.includes(searchLower)) return false;
+    }
+    return true;
+  });
+}

--- a/server/routers-audit.ts
+++ b/server/routers-audit.ts
@@ -3,6 +3,12 @@ import { eq, and, desc } from "drizzle-orm";
 import { protectedProcedure, router } from "./_core/trpc";
 import { getDb } from "./db";
 import { auditLog, InsertAuditLog } from "../drizzle/schema";
+import {
+  getProjectTimelineEntries,
+  filterTimelineEntries,
+  type TimelineEntry,
+  type TimelineCategory,
+} from "./lib/project-timeline";
 
 // ============================================================================
 // AUDIT ROUTER - Sistema de Histórico de Auditoria
@@ -84,6 +90,62 @@ export const auditRouter = router({
         .where(eq(auditLog.userId, input.userId))
         .orderBy(desc(auditLog.timestamp))
         .limit(input.limit);
+    }),
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // #766 Trilha de Auditoria — timeline unificada (auditLog + audit_log)
+  // ───────────────────────────────────────────────────────────────────────────
+  getProjectTimeline: protectedProcedure
+    .input(z.object({
+      projectId: z.number(),
+      // Filtros opcionais
+      categories: z.array(z.enum([
+        "projeto", "briefing", "risco", "plano",
+        "tarefa", "pergunta", "permissao", "outro",
+      ])).optional(),
+      userIds: z.array(z.number()).optional(),
+      fromTimestamp: z.number().optional(),
+      toTimestamp: z.number().optional(),
+      searchText: z.string().max(200).optional(),
+      // Paginação
+      limit: z.number().min(1).max(500).default(300),
+    }))
+    .query(async ({ input }) => {
+      const raw = await getProjectTimelineEntries(input.projectId, input.limit);
+      const filtered = filterTimelineEntries(raw, {
+        categories: input.categories as TimelineCategory[] | undefined,
+        userIds: input.userIds,
+        fromTimestamp: input.fromTimestamp,
+        toTimestamp: input.toTimestamp,
+        searchText: input.searchText,
+      });
+
+      // Estatísticas computadas server-side (para banner)
+      const uniqueUsers = new Set(
+        filtered.map((e) => e.userId).filter((x): x is number => x !== null)
+      );
+      const byCategory: Record<string, number> = {};
+      filtered.forEach((e) => {
+        byCategory[e.category] = (byCategory[e.category] ?? 0) + 1;
+      });
+      const firstTimestamp = filtered.length > 0
+        ? filtered[filtered.length - 1].timestamp
+        : null;
+      const lastTimestamp = filtered.length > 0
+        ? filtered[0].timestamp
+        : null;
+
+      return {
+        entries: filtered,
+        stats: {
+          totalEntries: filtered.length,
+          uniqueUsers: uniqueUsers.size,
+          byCategory,
+          firstTimestamp,
+          lastTimestamp,
+        },
+        totalBeforeFilter: raw.length,
+      };
     }),
 });
 


### PR DESCRIPTION
## Summary

**Closes #766.** Nova página `/projetos/:id/historico` consolidando as duas tabelas de audit em timeline única com filtros, agrupamento por dia e export CSV.

**Por que página dedicada (não tab):** plataforma em uso até 2031 → histórico vai crescer indefinidamente → tab sobrecarregaria o detalhe do projeto. Link permanente e bookmarkable.

## 22 eventos humanizados

| Categoria | Eventos |
|---|---|
| **Projeto** | update · status_change |
| **Briefing** | gerado (com fontes usadas) · gerado completo · aprovado · inconsistência resolvida |
| **Riscos** | criado · aprovado · excluído · restaurado · excluído em cascata |
| **Planos** | criado · aprovado · excluído · restaurado · excluído em cascata |
| **Tarefas** | criada (manual/LLM) · atualizada · status alterado · excluída · restaurada · excluída em cascata |
| **Questionários** | CRUD em perguntas corporativas e de ramo |
| **Permissões** | gestão de roles |

Descrição enriquecida para `briefing_generated` inclui **lista de fontes efetivamente usadas** (via metadata do PR #772): ex: _"Ana Souza — Briefing regenerado — fontes: SOLARIS Onda 1, Q.Produtos (NCM) (risco alto, 85% confiança)"_.

## UX criativa (8 categorias com cor própria)

- **Banner de stats:** eventos / usuários ativos / primeiro / último registro
- **Filtros inline:** busca livre, pills de categoria com contagem, presets de período (24h / 7d / 30d / 6m / tudo)
- **Timeline agrupada por dia:** cabeçalho contextual (_Hoje_, _Ontem_, _segunda, 18 de abril_)
- **Cada entrada:** ícone colorido, descrição humanizada PT-BR, horário relativo (_há 5 min_), entidade#id, badge do event technical
- **Expand details:** metadata JSON + changes + reason (para auditoria profunda)
- **Export CSV** com BOM UTF-8 (Excel detecta acentos) — crucial para auditoria formal

## Arquitetura

```
server/lib/project-timeline.ts
  ├─ getProjectTimelineEntries() — lê ambas tabelas e unifica
  ├─ filterTimelineEntries()     — filtros em memória
  ├─ humanização                 — ENTITY_LABEL, ACTION_LABEL, EVENT_LABEL

server/routers-audit.ts::getProjectTimeline
  ├─ input: categories[] · userIds[] · from/to · searchText · limit<=500
  └─ output: entries + stats (total, uniqueUsers, byCategory, first/last)

client/src/pages/ProjectHistoryTimeline.tsx
  ├─ Banner + Filtros + Timeline
  ├─ Agrupamento por startOfDay com labels contextuais
  └─ Export CSV client-side
```

## Arquivos

- `server/lib/project-timeline.ts` (+325 L, novo)
- `server/routers-audit.ts` (+62 L)
- `client/src/pages/ProjectHistoryTimeline.tsx` (+607 L, novo)
- `client/src/pages/ProjetoDetalhesV2.tsx` (+12 L — botão)
- `client/src/App.tsx` (+2 L — rota)

## Data-testid (Bloco 9)

- `btn-trilha-auditoria` (entry em ProjetoDetalhesV2)
- `btn-refresh-timeline` · `btn-export-timeline-csv`
- `input-timeline-search`
- `filter-categories` · `filter-category-{cat}` · `filter-period` · `filter-period-{key}`
- `timeline-content` · `timeline-day-{timestamp}`
- `timeline-entry-{id}` · `timeline-details-{id}`

## Test plan

- [x] `pnpm check` — zero erros.
- [ ] UAT: abrir `/projetos/:id` → ver link "Trilha de Auditoria" na linha de metadados.
- [ ] UAT: clicar → abre página com banner + filtros + timeline.
- [ ] UAT: gerar briefing → voltar ao histórico → aparecer entrada "briefing_generated" com fontes listadas.
- [ ] UAT: filtros por categoria, busca, período funcionam.
- [ ] UAT: export CSV abre no Excel com acentos corretos.
- [ ] UAT: expand entrada → mostra metadata JSON (fontes do briefing, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)