### PR TITLE
fix(briefing): hotfix ReferenceError em BriefingV3 (projectName fora de escopo)

### DIFF
--- a/client/src/pages/BriefingV3.tsx
+++ b/client/src/pages/BriefingV3.tsx
@@ -913,11 +913,14 @@ export default function BriefingV3() {
       </div>
 
       {/* #767: Modal compartilhar resumo WhatsApp (6 áreas) */}
+      {/* fix(hotfix 2026-04-20): usar project?.name diretamente em vez de `projectName`.
+          A variável `projectName` só existia no escopo de handleExportPDF — render
+          JSX quebrava com ReferenceError, causando tela branca ao entrar na página. */}
       <ShareBriefingModal
         open={shareModalOpen}
         onOpenChange={setShareModalOpen}
         structured={briefingStructuredForShare}
-        projectName={projectName}
+        projectName={project?.name || "Briefing de Compliance"}
       />
     </ComplianceLayout>
   );


### PR DESCRIPTION
## Summary

**Hotfix P0** — toda entrada em `/projetos/:id/briefing-v3` quebrava com tela branca após merge do PR #776 (resumo WhatsApp).

**Root cause:** PR #776 referenciou `projectName` no JSX do `ShareBriefingModal`, mas essa variável existe APENAS dentro de `handleExportPDF` (linha 329). Não está no escopo do render.

**Por que tsc não pegou:** `BriefingV3.tsx` tem `// @ts-nocheck` no topo (linha 1), suprimindo checagem estática de tipos/escopo.

**Sintoma** (reportado na UAT 2026-04-20):
- Projeto 1681835 · usuário clicou "Pular questionário CNAE"
- Redirecionamento para `/briefing-v3` → `ReferenceError: projectName is not defined`
- Error Boundary exibe "Algo deu errado. Por favor, recarregue a página."

## Fix (1 linha)

```diff
- projectName={projectName}
+ projectName={project?.name || "Briefing de Compliance"}
```

`project` é do `useQuery(trpc.fluxoV3.getProjectStep1)` em linha 164 — está no escopo correto do render do componente.

## Follow-up

Considerar remover `// @ts-nocheck` de `BriefingV3.tsx` em sprint separada — seria um fix de governança que pegaria essa classe de bug em compile time. Fora do escopo deste hotfix P0.

## Test plan

- [x] `pnpm check` — zero erros.
- [ ] UAT: abrir `/projetos/1681835/briefing-v3` → página carrega sem tela branca.
- [ ] UAT: clicar botão "Compartilhar Resumo" → modal abre com nome do projeto no header.
- [ ] UAT: "Pular questionário CNAE" → redireciona sem crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)