### PR TITLE
fix(briefing): Histórico de Versões exibe motivo completo (expand)

### DIFF
--- a/client/src/pages/BriefingV3.tsx
+++ b/client/src/pages/BriefingV3.tsx
@@ -136,6 +136,8 @@ export default function BriefingV3() {
   const [versionHistory, setVersionHistory] = useState<BriefingVersion[]>([]);
   const [showHistory, setShowHistory] = useState(false);
   const [viewingVersion, setViewingVersion] = useState<BriefingVersion | null>(null);
+  // fix(UAT 2026-04-20): versões cujo motivo está expandido (texto completo visível).
+  const [expandedReasonVersions, setExpandedReasonVersions] = useState<Set<number>>(new Set());
 
   // Verificar rascunho local ao montar
   useEffect(() => {
@@ -275,11 +277,16 @@ export default function BriefingV3() {
     if (!project) return;
     // RF-3.06: Salvar versão atual no histórico antes de regenerar
     if (briefing && generationCount > 0) {
+      // fix(UAT 2026-04-20): armazenar texto completo — truncagem fica no render.
       const newVersion: BriefingVersion = {
         version: generationCount,
         content: briefing,
         timestamp: Date.now(),
-        reason: correction ? `Correção: ${correction.substring(0, 60)}...` : moreInfo ? `Complemento: ${moreInfo.substring(0, 60)}...` : "Regeneração manual",
+        reason: correction
+          ? `Correção: ${correction}`
+          : moreInfo
+            ? `Complemento: ${moreInfo}`
+            : "Regeneração manual",
       };
       setVersionHistory(prev => [...prev, newVersion]);
     }
@@ -645,25 +652,85 @@ export default function BriefingV3() {
                 <span className="text-xs text-muted-foreground">Versão mais recente</span>
               </button>
               {/* Versões anteriores (ordem decrescente) */}
-              {[...versionHistory].reverse().map((v) => (
-                <button
-                  key={v.version}
-                  className={`w-full flex items-center justify-between p-3 rounded-lg border-2 text-left transition-all ${
-                    viewingVersion?.version === v.version ? "border-primary bg-primary/5" : "border-border hover:border-primary/30"
-                  }`}
-                  onClick={() => setViewingVersion(v)}
-                >
-                  <div className="flex items-center gap-2">
-                    <Badge variant="outline" className="text-xs">v{v.version}</Badge>
-                    <span className="text-sm font-medium">Versão {v.version}</span>
-                    {v.reason && <span className="text-xs text-muted-foreground truncate max-w-[200px]">{v.reason}</span>}
+              {/* fix(UAT 2026-04-20): motivo completo visível — botão "ver mais" abre inline. */}
+              {[...versionHistory].reverse().map((v) => {
+                const REASON_THRESHOLD = 60;
+                const isLongReason = !!v.reason && v.reason.length > REASON_THRESHOLD;
+                const isExpanded = expandedReasonVersions.has(v.version);
+                const preview = isLongReason && !isExpanded
+                  ? `${v.reason!.slice(0, REASON_THRESHOLD)}…`
+                  : v.reason;
+                return (
+                  <div
+                    key={v.version}
+                    className={`w-full rounded-lg border-2 transition-all ${
+                      viewingVersion?.version === v.version ? "border-primary bg-primary/5" : "border-border hover:border-primary/30"
+                    }`}
+                    data-testid={`version-history-row-${v.version}`}
+                  >
+                    <button
+                      type="button"
+                      className="w-full flex items-center justify-between p-3 text-left"
+                      onClick={() => setViewingVersion(v)}
+                    >
+                      <div className="flex items-center gap-2 min-w-0">
+                        <Badge variant="outline" className="text-xs shrink-0">v{v.version}</Badge>
+                        <span className="text-sm font-medium shrink-0">Versão {v.version}</span>
+                        {v.reason && (
+                          <span
+                            className={`text-xs text-muted-foreground ${isExpanded ? "whitespace-normal break-words" : "truncate max-w-[200px]"}`}
+                            data-testid={`version-history-reason-${v.version}`}
+                          >
+                            {preview}
+                          </span>
+                        )}
+                      </div>
+                      <span className="text-xs text-muted-foreground flex items-center gap-1 shrink-0">
+                        <Clock className="h-3 w-3" />
+                        {new Date(v.timestamp).toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" })}
+                      </span>
+                    </button>
+                    {isLongReason && (
+                      <div className="px-3 pb-2 -mt-1">
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setExpandedReasonVersions(prev => {
+                              const next = new Set(prev);
+                              if (next.has(v.version)) next.delete(v.version);
+                              else next.add(v.version);
+                              return next;
+                            });
+                          }}
+                          className="text-xs text-primary hover:underline inline-flex items-center gap-1"
+                          data-testid={`btn-toggle-reason-${v.version}`}
+                        >
+                          {isExpanded ? (
+                            <>
+                              <ChevronUp className="h-3 w-3" />
+                              Ocultar motivo completo
+                            </>
+                          ) : (
+                            <>
+                              <ChevronDown className="h-3 w-3" />
+                              Ver motivo completo ({v.reason!.length} caracteres)
+                            </>
+                          )}
+                        </button>
+                        {isExpanded && (
+                          <div
+                            className="mt-2 rounded border bg-muted/30 p-2 text-xs whitespace-pre-wrap break-words"
+                            data-testid={`version-history-reason-full-${v.version}`}
+                          >
+                            {v.reason}
+                          </div>
+                        )}
+                      </div>
+                    )}
                   </div>
-                  <span className="text-xs text-muted-foreground flex items-center gap-1 shrink-0">
-                    <Clock className="h-3 w-3" />
-                    {new Date(v.timestamp).toLocaleTimeString("pt-BR", { hour: "2-digit", minute: "2-digit" })}
-                  </span>
-                </button>
-              ))}
+                );
+              })}
             </CardContent>
           </Card>
         )}


### PR DESCRIPTION
## Summary

**Bug UAT 2026-04-20:** usuário escreveu via "Mais Informações":

> "Além da shell faturamos outros clientes; fazemos também serviço de rondonopolis para la paz - bolivia"

O Histórico de Versões mostrou apenas:

> Complemento: Além da shell faturamos outros clientes; fazemos também serv**...**

**Causa raiz:** `handleGenerate` truncava o texto com `substring(0, 60)` + `"..."` na **armazenagem** — a informação completa era perdida para sempre, não só escondida. Não havia UX para expandir porque o texto completo nem existia mais.

## Fix em 2 partes

### 1. Armazenar texto completo

```diff
- reason: correction ? `Correção: ${correction.substring(0, 60)}...` : ...
+ reason: correction ? `Correção: ${correction}` : ...
```

### 2. Render expansível

Preview de 60 chars + botão **"Ver motivo completo (N caracteres)"** aparece quando texto > 60 chars. Clique alterna para texto completo em bloco `whitespace-pre-wrap` que preserva quebras de linha.

## Observação relacionada (fora do escopo)

No mesmo teste o P.O. mencionou "fazemos serviço de rondonopolis para la paz - bolivia" (exportação internacional). Se PR #779 (complement→RAG/prompt) estiver deployado, a V2 gerada deveria citar **imunidade em exportação (Art. 8 LC 214/2025)**. Este PR aqui não trata disso — só o UX do histórico. Validação do #779 continua pendente.

## Data-testid (Bloco 9)

- `version-history-row-{N}`
- `version-history-reason-{N}` (preview truncado ou completo)
- `btn-toggle-reason-{N}`
- `version-history-reason-full-{N}` (bloco expandido)

## Test plan

- [x] `pnpm check` — zero erros.
- [ ] UAT: gerar v2 com complemento longo (>60 chars) → Histórico mostra preview + botão "Ver motivo completo".
- [ ] UAT: clicar botão → texto completo aparece em bloco com quebras de linha preservadas.
- [ ] UAT: clicar "Ocultar motivo completo" → volta ao preview.
- [ ] UAT: complemento curto (<60 chars) → sem botão (preview já é o texto completo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)