### PR TITLE
fix(briefing): campo 'Corrigir' também ignorado pelo LLM — mesma causa raiz do #779

### DIFF
--- a/server/routers-fluxo-v3.ts
+++ b/server/routers-fluxo-v3.ts
@@ -1228,12 +1228,12 @@ REGRA CRÍTICA — INCONSISTÊNCIAS vs LIMITAÇÕES (fix N2 UAT 2026-04-20):
 - Se a única "contradição" detectada é que o usuário não respondeu, NÃO liste como inconsistência. Liste como limitação.
 - Array "inconsistencias" pode ser vazio [] — e isso é saudável.
 
-REGRA CRÍTICA — FATOS ADICIONAIS DECLARADOS PELO USUÁRIO (fix UAT 2026-04-20):
-- Toda informação presente em "FATOS ADICIONAIS SOBRE A EMPRESA" é FATO declarado pelo usuário, equivalente ao perfil corporativo.
+REGRA CRÍTICA — FATOS ADICIONAIS e CORREÇÃO DECLARADOS PELO USUÁRIO (fix UAT 2026-04-20):
+- Toda informação presente em "FATOS ADICIONAIS SOBRE A EMPRESA" OU "CORREÇÃO SOLICITADA PELO USUÁRIO" é FATO declarado pelo usuário, equivalente ao perfil corporativo.
 - Trate esses fatos como VERDADE sobre a empresa — NÃO ignore, NÃO trate como "respondido no questionário", e NÃO descarte por "não haver respostas ao questionário".
-- Exemplos: se o usuário declara "fazemos exportação", você DEVE gerar análise específica sobre imunidade em exportação (Art. 8 LC 214/2025) e obrigações acessórias correlatas.
-- Se o usuário declara "operamos em regime especial", você DEVE citar o artigo pertinente e gaps específicos desse regime.
-- Cada fato adicional deve gerar pelo menos um gap OU uma oportunidade específica no briefing.
+- CORREÇÃO tem prioridade máxima: descreve algo que o briefing atual errou OU informação nova que invalida/estende o diagnóstico anterior. Reflita a correção explicitamente (cite o item corrigido no resumo executivo).
+- Exemplos: "fazemos exportação" → análise de imunidade (Art. 8 LC 214/2025). "também transportamos óleo vegetal" → incluir análise para esse tipo de carga. "operamos em regime especial" → citar artigo pertinente.
+- Cada fato adicional e cada correção deve gerar pelo menos um gap OU uma oportunidade específica no briefing.
 
 ${regulatoryContext}
 
@@ -1241,10 +1241,11 @@ ${OUTPUT_CONTRACT}`,
           },
           {
             role: "user",
-            // fix(UAT 2026-04-20): fatos adicionais declarados pelo usuário vão DEPOIS do perfil
-            // corporativo e ANTES das respostas do questionário — para que o LLM os trate como
-            // primeira classe (equivalente ao perfil), não como nota de rodapé que pode ignorar.
-            content: `${companyProfileBlock}${complementContext}${additionalSourcesText}\n\nPROJETO: ${project.name}\nDESCRIÇÃO: ${(project as any).description || ""}\n\nRESPOSTAS DO QUESTIONÁRIO CNAE:\n${answersText}\n${correctionContext}
+            // fix(UAT 2026-04-20): fatos adicionais E correção declarados pelo usuário vão DEPOIS
+            // do perfil corporativo e ANTES das respostas do questionário — LLM trata como
+            // primeira classe. Correção antes do complement porque descreve algo que o briefing
+            // atual ignorou/errou (maior prioridade semântica).
+            content: `${companyProfileBlock}${correctionContext}${complementContext}${additionalSourcesText}\n\nPROJETO: ${project.name}\nDESCRIÇÃO: ${(project as any).description || ""}\n\nRESPOSTAS DO QUESTIONÁRIO CNAE:\n${answersText}
 
 Gere o Briefing estruturado em JSON:
 {
@@ -2800,11 +2801,12 @@ REGRA CRÍTICA — INCONSISTÊNCIAS vs LIMITAÇÕES (fix N2 UAT 2026-04-20):
 - Se a única "contradição" detectada é que o usuário não respondeu, NÃO liste como inconsistência. Liste como limitação.
 - Array "inconsistencias" pode ser vazio [] — e isso é saudável.
 
-REGRA CRÍTICA — FATOS ADICIONAIS DECLARADOS PELO USUÁRIO (fix UAT 2026-04-20):
-- Toda informação presente em "FATOS ADICIONAIS SOBRE A EMPRESA" é FATO declarado pelo usuário, equivalente ao perfil corporativo.
-- Trate como VERDADE sobre a empresa — NÃO ignore, NÃO trate como "respondido no questionário", e NÃO descarte por "não haver respostas".
-- Exemplos: "fazemos exportação" → gerar análise de imunidade (Art. 8 LC 214/2025). "operamos em regime especial" → citar artigo específico.
-- Cada fato adicional deve gerar pelo menos um gap OU uma oportunidade específica.
+REGRA CRÍTICA — FATOS ADICIONAIS e CORREÇÃO DECLARADOS PELO USUÁRIO (fix UAT 2026-04-20):
+- Toda informação presente em "FATOS ADICIONAIS SOBRE A EMPRESA" OU "CORREÇÃO SOLICITADA PELO USUÁRIO" é FATO declarado pelo usuário, equivalente ao perfil corporativo.
+- Trate como VERDADE — NÃO ignore, NÃO trate como "respondido no questionário", e NÃO descarte por "não haver respostas".
+- CORREÇÃO tem prioridade máxima: algo que o briefing atual errou ou informação nova que invalida/estende o diagnóstico. Reflita explicitamente (cite no resumo executivo).
+- Exemplos: "fazemos exportação" → análise de imunidade (Art. 8 LC 214/2025). "transportamos óleo vegetal" → incluir esse tipo de carga. "operamos em regime especial" → citar artigo específico.
+- Cada fato adicional e cada correção deve gerar pelo menos um gap OU uma oportunidade específica.
 
 ${regulatoryContext}
 
@@ -2812,12 +2814,11 @@ ${OC}`,
           },
           {
             role: "user",
-            // fix(UAT 2026-04-20): complement logo após projeto/descrição, antes do diagnóstico.
+            // fix(UAT 2026-04-20): correção e complement logo após projeto/descrição, antes do diagnóstico.
             content: `PROJETO: ${project.name}
-DESCRIÇÃO: ${p.description || ""}${complementContext}
+DESCRIÇÃO: ${p.description || ""}${correctionContext}${complementContext}
 ${additionalContextText}DIAGNÓSTICO CONSOLIDADO (3 CAMADAS):
 ${answersText}
-${correctionContext}
 
 Gere o Briefing estruturado em JSON:
 {


### PR DESCRIPTION
## Summary

**UAT 2026-04-20** — usuário escreveu em "O que precisa ser corrigido":

> "além de combustível para a shell, fazemos transporte de óleo vegetal de milho"

Briefing regenerado (v3) **ignorou completamente** — nenhuma menção a óleo vegetal, milho, ou transporte de alimentos.

## Root cause

PR #779 moveu **apenas `complementContext`** para o início do prompt, deixando `correctionContext` no fim (depois do `answersText`). É o **mesmo bug original** que o próprio #779 teoricamente corrigia — mas só para um dos dois campos.

Além disso, a REGRA CRÍTICA _"FATOS ADICIONAIS → trate como verdade"_ cobria apenas `complement`. `correction` não tinha instrução específica → LLM deprioriza.

## Fix em 2 partes

### 1. Reposicionamento no userPrompt

```diff
- ${companyProfileBlock}${complementContext}${additionalSourcesText}...
-   ...RESPOSTAS DO QUESTIONÁRIO CNAE:\n${answersText}\n${correctionContext}
+ ${companyProfileBlock}${correctionContext}${complementContext}${additionalSourcesText}...
+   ...RESPOSTAS DO QUESTIONÁRIO CNAE:\n${answersText}
```

`correctionContext` vai antes de `complementContext` — correção tem prioridade semântica ainda maior porque descreve algo que o briefing atual **errou**.

### 2. System prompt — regra expandida

```diff
- REGRA CRÍTICA — FATOS ADICIONAIS DECLARADOS PELO USUÁRIO:
- - Toda informação presente em "FATOS ADICIONAIS SOBRE A EMPRESA" é FATO...
+ REGRA CRÍTICA — FATOS ADICIONAIS e CORREÇÃO DECLARADOS PELO USUÁRIO:
+ - Toda informação em "FATOS ADICIONAIS" OU "CORREÇÃO SOLICITADA" é FATO...
+ - CORREÇÃO tem prioridade máxima: reflita explicitamente no resumo executivo.
+ - Exemplos: "transportamos óleo vegetal" → incluir esse tipo de carga.
+ - Cada fato adicional E cada correção deve gerar pelo menos 1 gap OU oportunidade.
```

Aplicado em **ambos** os paths (`generateBriefing` + `generateBriefingFromDiagnostic`).

## Relação com outras issues/PRs

- **Resolve:** bug reportado nesta UAT (correction ignorado).
- **Complementa #779:** PR #779 corrigiu só `complement`; este PR corrige `correction` do mesmo jeito.
- **Não resolve #785:** issue #785 trata da falha do RAG quando termos não-jurídicos. Este PR é sobre posicionamento no prompt, independente do RAG.

## Test plan

- [x] `pnpm check` — zero erros.
- [ ] UAT: usar "Corrigir" com _"também transportamos óleo vegetal de milho"_ → briefing deve:
  - [ ] Citar óleo vegetal no resumo executivo.
  - [ ] Gerar gap sobre classificação fiscal de cargas mistas (combustível + alimentos).
  - [ ] Ou citar Art. 14 LC 214/2025 (alíquota zero para cesta básica, se NCMs apropriados).
- [ ] Briefing sem correção/complement: continua funcionando normalmente (regressão zero).

🤖 Generated with [Claude Code](https://claude.com/claude-code)