### PR TITLE
fix(briefing): BUG-4 — numeração de versão regride após reload

### DIFF
--- a/client/src/pages/BriefingV3.tsx
+++ b/client/src/pages/BriefingV3.tsx
@@ -263,7 +263,16 @@ export default function BriefingV3() {
     const savedBriefing = (project as any).briefingContentV3 || (project as any).briefingContent;
     if (savedBriefing && generationCount === 0) {
       setBriefing(savedBriefing);
-      setGenerationCount(1);
+      // fix(BUG-4 UAT 2026-04-20): preservar generationCount + versionHistory do auto-save
+      // quando disponíveis. Antes, hardcode `setGenerationCount(1)` fazia o contador
+      // regredir (v3 → v1) sempre que a página era recarregada — perdia numeração real.
+      const draft = loadTempData(projectId, 'etapa3');
+      const draftCount = draft?.data?.generationCount;
+      const nextCount = typeof draftCount === "number" && draftCount > 0 ? draftCount : 1;
+      setGenerationCount(nextCount);
+      if (Array.isArray(draft?.data?.versionHistory)) {
+        setVersionHistory(draft.data.versionHistory as BriefingVersion[]);
+      }
       setWasAlreadyApproved(true); // Sinaliza que este briefing já foi aprovado
       return;
     }


### PR DESCRIPTION
## Summary

**BUG-4** do Manus deploy report 2026-04-20: _"Numeração de versão do briefing regride após regeneração"_.

## Root cause

Em `BriefingV3.tsx`, useEffect que carrega `savedBriefing` do banco executava:

```ts
if (savedBriefing && generationCount === 0) {
  setBriefing(savedBriefing);
  setGenerationCount(1);  // ← HARDCODED
  ...
}
```

Cenário que reproduz:
1. Usuário gera v1, v2, v3. `useAutoSave` persiste `{ generationCount: 3, versionHistory: [...] }` em localStorage.
2. Usuário recarrega a página (F5).
3. State inicia com `generationCount=0`.
4. useEffect dispara → `savedBriefing` existe (v3 no banco) → `setGenerationCount(1)` regride.
5. ResumeBanner aparece pedindo pra restaurar, mas entre reload e clique o contador já caiu.

## Fix

Consulta `loadTempData` ANTES de setar o contador. Usa o maior valor entre 1 e draft:

```ts
const draft = loadTempData(projectId, 'etapa3');
const draftCount = draft?.data?.generationCount;
const nextCount = typeof draftCount === "number" && draftCount > 0 ? draftCount : 1;
setGenerationCount(nextCount);
if (Array.isArray(draft?.data?.versionHistory)) {
  setVersionHistory(draft.data.versionHistory);
}
```

Unifica automaticamente o que o botão "Resume Draft" já fazia manualmente.

## Arquivos

- `client/src/pages/BriefingV3.tsx` — +10 L, -1 L.

Zero backend change. Zero schema.

## Test plan

- [x] `pnpm check` — zero erros.
- [ ] UAT: gerar v1, v2, v3 → F5 → contador mostra **v3** (não v1).
- [ ] UAT: primeira visita ao briefing (sem draft) → contador = 1.
- [ ] UAT: clicar "Descartar" no ResumeBanner → próximo reload zera corretamente.

## Relacionado

- Resolve BUG-4 do Manus deploy report 2026-04-20.
- Independente dos outros 3 PRs (A = BUG-1/3, B = este, C = #785 F).

🤖 Generated with [Claude Code](https://claude.com/claude-code)