### PR TITLE
fix(briefing): consolidar gaps com mesmo artigo+parágrafo — #780 item 1

### DIFF
--- a/server/lib/consolidate-gaps.test.ts
+++ b/server/lib/consolidate-gaps.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import {
+  consolidateGapsByArticle,
+  normalizeEvidenciaKey,
+  type BriefingGap,
+} from "./consolidate-gaps";
+
+describe("normalizeEvidenciaKey", () => {
+  it("extrai Art. N sem parágrafo", () => {
+    expect(normalizeEvidenciaKey("Art. 14 LC 214/2025")).toBe("art. 14");
+    expect(normalizeEvidenciaKey("art.14LC214/2025")).toBe("art. 14");
+  });
+
+  it("extrai Art. N §M com normalização", () => {
+    expect(normalizeEvidenciaKey("Art. 21 §1º LC 214/2025")).toBe("art. 21 §1");
+    expect(normalizeEvidenciaKey("art.21 § 1° LC214/2025")).toBe("art. 21 §1");
+    expect(normalizeEvidenciaKey("ART. 21 §1ª LC 214/2025")).toBe("art. 21 §1");
+  });
+
+  it("distingue parágrafos diferentes do mesmo artigo", () => {
+    const k1 = normalizeEvidenciaKey("Art. 21 §1º LC 214/2025");
+    const k2 = normalizeEvidenciaKey("Art. 21 §2º LC 214/2025");
+    const k3 = normalizeEvidenciaKey("Art. 21 LC 214/2025");
+    expect(k1).not.toBe(k2);
+    expect(k1).not.toBe(k3);
+    expect(k2).not.toBe(k3);
+  });
+
+  it("retorna vazio para input vazio/null", () => {
+    expect(normalizeEvidenciaKey("")).toBe("");
+    expect(normalizeEvidenciaKey(undefined)).toBe("");
+    expect(normalizeEvidenciaKey(null)).toBe("");
+  });
+});
+
+describe("consolidateGapsByArticle", () => {
+  it("passa direto quando há 0 ou 1 gap", () => {
+    expect(consolidateGapsByArticle([])).toEqual([]);
+    const one: BriefingGap[] = [{ gap: "X", evidencia_regulatoria: "Art. 14 LC 214/2025" }];
+    expect(consolidateGapsByArticle(one)).toEqual(one);
+  });
+
+  it("não consolida gaps com artigos diferentes", () => {
+    const gaps: BriefingGap[] = [
+      { gap: "G1", evidencia_regulatoria: "Art. 14 LC 214/2025", urgencia: "imediata" },
+      { gap: "G2", evidencia_regulatoria: "Art. 15 LC 214/2025", urgencia: "imediata" },
+      { gap: "G3", evidencia_regulatoria: "Art. 21 §1º LC 214/2025", urgencia: "media" },
+    ];
+    expect(consolidateGapsByArticle(gaps)).toHaveLength(3);
+  });
+
+  it("consolida 3 gaps com mesmo Art. 21 §1º em 1 gap", () => {
+    const gaps: BriefingGap[] = [
+      { gap: "Controles automatizados", causa_raiz: "sistema X", evidencia_regulatoria: "Art. 21 §1º LC 214/2025", urgencia: "imediata" },
+      { gap: "ERP não parametrizado", causa_raiz: "ERP Y", evidencia_regulatoria: "Art. 21 §1º LC 214/2025", urgencia: "imediata" },
+      { gap: "Mecanismos preventivos", causa_raiz: "processo Z", evidencia_regulatoria: "art.21 § 1° LC 214/2025", urgencia: "media" },
+    ];
+    const out = consolidateGapsByArticle(gaps);
+    expect(out).toHaveLength(1);
+    expect(out[0].gap).toContain("Controles automatizados");
+    expect(out[0].gap).toContain("Também cobre:");
+    expect(out[0].gap).toContain("ERP não parametrizado");
+    expect(out[0].gap).toContain("Mecanismos preventivos");
+    expect(out[0].causa_raiz).toBe("sistema X | ERP Y | processo Z");
+    // Urgência mais alta (imediata) vence
+    expect(out[0].urgencia).toBe("imediata");
+  });
+
+  it("preserva ordem de aparição", () => {
+    const gaps: BriefingGap[] = [
+      { gap: "A", evidencia_regulatoria: "Art. 14 LC 214/2025" },
+      { gap: "B1", evidencia_regulatoria: "Art. 21 §1º LC 214/2025" },
+      { gap: "C", evidencia_regulatoria: "Art. 15 LC 214/2025" },
+      { gap: "B2", evidencia_regulatoria: "Art. 21 §1º LC 214/2025" },
+    ];
+    const out = consolidateGapsByArticle(gaps);
+    // Esperado: [A, merged-B, C] — B aparece na posição do primeiro B1
+    expect(out).toHaveLength(3);
+    expect(out[0].gap).toBe("A");
+    expect(out[1].gap).toContain("B1");
+    expect(out[1].gap).toContain("B2");
+    expect(out[2].gap).toBe("C");
+  });
+
+  it("não consolida quando parágrafos diferem", () => {
+    const gaps: BriefingGap[] = [
+      { gap: "G1", evidencia_regulatoria: "Art. 21 §1º LC 214/2025" },
+      { gap: "G2", evidencia_regulatoria: "Art. 21 §2º LC 214/2025" },
+      { gap: "G3", evidencia_regulatoria: "Art. 21 LC 214/2025" },
+    ];
+    expect(consolidateGapsByArticle(gaps)).toHaveLength(3);
+  });
+
+  it("gaps sem evidencia_regulatoria nunca são consolidados entre si", () => {
+    const gaps: BriefingGap[] = [
+      { gap: "G1" },
+      { gap: "G2" },
+    ];
+    expect(consolidateGapsByArticle(gaps)).toHaveLength(2);
+  });
+
+  it("prefere urgência imediata como primary no merge", () => {
+    const gaps: BriefingGap[] = [
+      { gap: "baixa-first", urgencia: "baixa", evidencia_regulatoria: "Art. 14 LC 214/2025" },
+      { gap: "imediata-second", urgencia: "imediata", evidencia_regulatoria: "Art. 14 LC 214/2025" },
+    ];
+    const out = consolidateGapsByArticle(gaps);
+    expect(out).toHaveLength(1);
+    expect(out[0].urgencia).toBe("imediata");
+    // Primary = o de maior urgência
+    expect(out[0].gap?.startsWith("imediata-second")).toBe(true);
+    // Outro entra na lista "Também cobre"
+    expect(out[0].gap).toContain("baixa-first");
+  });
+});

--- a/server/lib/consolidate-gaps.ts
+++ b/server/lib/consolidate-gaps.ts
@@ -1,0 +1,141 @@
+/**
+ * consolidate-gaps.ts — issue #780 item 1
+ *
+ * Consolida gaps do briefing que citam o mesmo dispositivo legal.
+ * Pós-processamento determinístico após LLM retornar — mesmo pattern
+ * de `classifyInconsistenciaImpacto`.
+ *
+ * Motivação UAT 2026-04-20: LLM produzia 3 gaps distintos todos com
+ * `evidencia_regulatoria = "Art. 21 §1º LC 214/2025"` — inflava contagem
+ * de gaps e confundia o cliente. Agora agrupa em 1 gap com múltiplas
+ * sub-recomendações quando o artigo (com parágrafo) é o mesmo.
+ */
+
+export interface BriefingGap {
+  gap?: string;
+  causa_raiz?: string;
+  evidencia_regulatoria?: string;
+  urgencia?: string;
+  [key: string]: unknown;
+}
+
+const URGENCY_RANK: Record<string, number> = {
+  imediata: 4,
+  curta:    3,
+  media:    2,
+  baixa:    1,
+};
+
+/**
+ * Normaliza `evidencia_regulatoria` para chave de agrupamento.
+ * Preserva "Art. N §M" mas descarta diferenças de formatação (espaços,
+ * caso, LC/Lei). Dois gaps só são consolidados se tiverem o MESMO artigo
+ * com o MESMO parágrafo.
+ *
+ * Exemplos:
+ *   "Art. 21 §1º LC 214/2025"     → "art. 21 §1"
+ *   "art.21 § 1° LC214/2025"      → "art. 21 §1"
+ *   "Art. 21 LC 214/2025"         → "art. 21"       (diferente de §1)
+ *   "Art. 21 §2º LC 214/2025"     → "art. 21 §2"    (diferente de §1)
+ */
+export function normalizeEvidenciaKey(ev: string | undefined | null): string {
+  if (!ev) return "";
+  const s = String(ev).toLowerCase();
+  // Captura "art." seguido de número e parágrafo opcional
+  const match = s.match(/art\.?\s*(\d+)(?:\s*§\s*(\d+)[º°ª]?)?/i);
+  if (!match) return s.trim();
+  const artigo = match[1];
+  const paragrafo = match[2] ? ` §${match[2]}` : "";
+  return `art. ${artigo}${paragrafo}`;
+}
+
+function pickUrgencyRank(u: string | undefined): number {
+  if (!u) return 0;
+  return URGENCY_RANK[u.toLowerCase()] ?? 0;
+}
+
+/**
+ * Consolida gaps que compartilham o mesmo artigo+parágrafo.
+ *
+ * Estratégia:
+ *   - Agrupa por `normalizeEvidenciaKey(evidencia_regulatoria)`.
+ *   - Grupos com 1 gap → passa direto.
+ *   - Grupos com 2+ gaps → merge:
+ *     • primary = gap com maior `urgencia` (empate: primeiro do array).
+ *     • `gap` = texto do primary + seção "Também cobre" com bullets dos outros.
+ *     • `causa_raiz` = concat dos causa_raiz não vazios com separador " | ".
+ *     • `urgencia` = maior urgência do grupo.
+ *     • `evidencia_regulatoria` = preserva o texto do primary (inclui "LC...").
+ *
+ * Preserva a ordem original dos primeiros gaps de cada grupo.
+ */
+export function consolidateGapsByArticle(gaps: BriefingGap[] | undefined | null): BriefingGap[] {
+  if (!Array.isArray(gaps) || gaps.length <= 1) return gaps ?? [];
+
+  type Bucket = { key: string; items: BriefingGap[]; firstIndex: number };
+  const buckets: Map<string, Bucket> = new Map();
+  let orderCounter = 0;
+
+  for (const g of gaps) {
+    const key = normalizeEvidenciaKey(g?.evidencia_regulatoria);
+    if (!key) {
+      // Sem chave normalizável → chave única para não consolidar
+      const uniqueKey = `__no_key_${orderCounter}__`;
+      buckets.set(uniqueKey, { key: uniqueKey, items: [g], firstIndex: orderCounter });
+      orderCounter++;
+      continue;
+    }
+    const existing = buckets.get(key);
+    if (existing) {
+      existing.items.push(g);
+    } else {
+      buckets.set(key, { key, items: [g], firstIndex: orderCounter });
+    }
+    orderCounter++;
+  }
+
+  // Ordena buckets pela firstIndex (preserva ordem original dos gaps)
+  const ordered = Array.from(buckets.values()).sort((a, b) => a.firstIndex - b.firstIndex);
+
+  return ordered.map((bucket) => {
+    if (bucket.items.length === 1) return bucket.items[0];
+
+    // Pick primary: maior urgência; empate → primeiro
+    const primary = bucket.items.reduce(
+      (best, cur) => (pickUrgencyRank(cur.urgencia) > pickUrgencyRank(best.urgencia) ? cur : best),
+      bucket.items[0]
+    );
+    const others = bucket.items.filter((x) => x !== primary);
+
+    // Construção do texto do gap consolidado
+    const gapParts: string[] = [];
+    if (primary.gap) gapParts.push(primary.gap);
+    if (others.length > 0) {
+      gapParts.push("\n\nTambém cobre:");
+      others.forEach((o) => {
+        if (o.gap) gapParts.push(`• ${o.gap}`);
+      });
+    }
+
+    // Causas raiz concatenadas
+    const causasRaiz = bucket.items
+      .map((i) => i.causa_raiz)
+      .filter((c): c is string => typeof c === "string" && c.trim().length > 0);
+    const causaRaizMerged = causasRaiz.length > 0 ? causasRaiz.join(" | ") : undefined;
+
+    // Maior urgência
+    const maxUrgencia = bucket.items.reduce(
+      (best, cur) => (pickUrgencyRank(cur.urgencia) > pickUrgencyRank(best) ? (cur.urgencia ?? best) : best),
+      primary.urgencia ?? ""
+    );
+
+    return {
+      ...primary,
+      gap: gapParts.join("\n"),
+      causa_raiz: causaRaizMerged,
+      urgencia: maxUrgencia,
+      evidencia_regulatoria: primary.evidencia_regulatoria,
+      // Preserva qualquer campo extra do primary
+    };
+  });
+}

--- a/server/routers-fluxo-v3.ts
+++ b/server/routers-fluxo-v3.ts
@@ -1312,6 +1312,13 @@ Gere o Briefing estruturado em JSON:
         }));
       }
 
+      // fix(#780 item 1 UAT 2026-04-20): consolida gaps com mesmo artigo+parágrafo
+      // (LLM fragmentava em 3+ gaps para Art. 21 §1º). Pós-processamento determinístico.
+      if (Array.isArray(structured.principais_gaps)) {
+        const { consolidateGapsByArticle } = await import("./lib/consolidate-gaps");
+        structured.principais_gaps = consolidateGapsByArticle(structured.principais_gaps) as any;
+      }
+
       // fix(BUG-1 UAT 2026-04-20): preservar inconsistências dismissed entre regenerações.
       // Se o usuário resolveu uma inconsistência na v1 e o LLM detecta a mesma na v2,
       // filtramos aqui para não reaparecer. Dismissed list persiste em briefingStructured.
@@ -3008,6 +3015,12 @@ Gere o Briefing estruturado em JSON:
           ...inc,
           impacto: classifyInconsistenciaImpacto(inc),
         }));
+      }
+
+      // fix(#780 item 1 UAT 2026-04-20): consolida gaps com mesmo artigo+parágrafo
+      if (Array.isArray(structured.principais_gaps)) {
+        const { consolidateGapsByArticle } = await import("./lib/consolidate-gaps");
+        structured.principais_gaps = consolidateGapsByArticle(structured.principais_gaps) as any;
       }
 
       // fix(BUG-1 UAT 2026-04-20): preserva dismissed_inconsistencias entre regenerações.


### PR DESCRIPTION
## Summary

Implementa **item 1 da issue #780**: LLM fragmentava 3+ gaps para o mesmo artigo (Art. 21 §1º no UAT), inflando contagem e confundindo o cliente. Agora consolida server-side após LLM retornar.

## Estratégia

Nova função pura `consolidateGapsByArticle` em `server/lib/`:

1. **Normaliza** `evidencia_regulatoria` para chave (`"art. 21 §1"` — ignora case/espaços/LC).
2. **Agrupa** gaps por chave.
3. **Grupos com 2+**: merge com `primary = maior urgência`, texto combinado com "Também cobre:", `causa_raiz` concatenada com `" | "`, `urgencia = max`.
4. **Parágrafos diferentes NÃO consolidam** (Art. 21 §1 ≠ Art. 21 §2).
5. **Preserva ordem** original.

Padrão idêntico ao `classifyInconsistenciaImpacto` (heurística server-side após LLM).

## Unit tests (11/11 PASS)

Cobrem: grupos mistos, parágrafos diferentes, urgência, ordem preservada, input vazio, gaps sem evidência.

## Arquivos

- `server/lib/consolidate-gaps.ts` — função pura (+160 L)
- `server/lib/consolidate-gaps.test.ts` — 11 tests (+100 L)
- `server/routers-fluxo-v3.ts` — aplicação em `generateBriefing` + `generateBriefingFromDiagnostic`

Zero schema. Zero frontend change.

## Exemplo do UAT

**Antes (5 gaps):**
- Art. 21 §1º — Controles automatizados...
- Art. 21 §1º — ERP não parametrizado...
- Art. 21 §1º — Mecanismos preventivos...

**Depois (1 gap):**
- Art. 21 §1º — Controles automatizados...
  > Também cobre:
  > • ERP não parametrizado
  > • Mecanismos preventivos

Causa_raiz preserva todos os 3 originais separados por `" | "`.

## Test plan

- [x] `pnpm check` — zero erros.
- [x] `pnpm vitest run server/lib/consolidate-gaps.test.ts` — **11/11 PASS**.
- [ ] UAT: refazer teste NCM 1006.40.00 → briefing deve exibir 1 gap consolidado para Art. 21 §1º (em vez de 3).
- [ ] UAT: briefing com 5 artigos distintos continua mostrando 5 gaps (sem falsos agrupamentos).
- [ ] UAT: regra N1b (nível de risco) ajusta — menos gaps = pode baixar de "alto" para "medio" em alguns casos (esperado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)