### PR TITLE
fix(briefing): hotfix P0 — useMemo não importado (crash 'Algo deu errado')

### DIFF
--- a/client/src/pages/BriefingV3.tsx
+++ b/client/src/pages/BriefingV3.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useAutoSave, loadTempData, clearTempData } from "@/hooks/usePersistenceV3";
 import { ResumeBanner } from "@/components/ResumeBanner";
 import { useParams, useLocation, useSearch } from "wouter";


### PR DESCRIPTION
## Summary

**Hotfix P0** — crash no /briefing-v3 após completar CNAE.

## Sintoma

Projeto 1683274 (NCMs 1006.40.00 / 1507.90.11 / 2202.10.00) — usuário completa QCNAE, é redirecionado para `/projetos/:id/briefing-v3` → tela branca com:

> Algo deu errado
> Ocorreu um erro inesperado. Por favor, recarregue a página.

## Root cause

PR #781 (gate de aprovação com ressalva) adicionou:

```tsx
const lastBriefingSources = useMemo(() => {
  const entry = (lastBriefingAudit?.entries ?? [])...
}, [lastBriefingAudit]);
```

Mas **não incluiu `useMemo` no import** de `"react"` no topo do arquivo:

```tsx
// Antes
import { useState, useEffect, useCallback } from "react";
```

Em runtime: `useMemo` é `undefined` → `TypeError: undefined is not a function` → Error Boundary global captura → tela branca.

## Mesma classe de bug do #778 (projectName)

`BriefingV3.tsx` tem `// @ts-nocheck` na linha 1 que suprime a detecção estática. `tsc --noEmit` não pega. Segunda vez em 24h que um símbolo não-importado passou para produção.

## Fix

1 palavra no import:

```diff
- import { useState, useEffect, useCallback } from "react";
+ import { useState, useEffect, useCallback, useMemo } from "react";
```

## Follow-up obrigatório (próximo sprint)

Remover `// @ts-nocheck` de `BriefingV3.tsx`. Vai exigir algum trabalho de tipagem (arquivo tem ~1000 linhas com muitos `any`), mas previne essa classe de bug permanentemente.

Sugiro abrir issue separada de **tech-debt** com prioridade alta.

## Test plan

- [x] `pnpm check` — zero erros.
- [ ] UAT: abrir projeto qualquer → ir para /briefing-v3 → página carrega sem crash.
- [ ] UAT: completar CNAE → redirect para briefing-v3 → gera briefing normalmente.
- [ ] UAT projeto 1683274 → repetir cenário reportado pelo P.O. → briefing com os 3 NCMs cita Art. 9 (cesta básica — arroz e óleo) + Art. 2 (IS — bebidas açucaradas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)