### PR TITLE
cleanup: docs + tipo apontam calculateGlobalScore (legada) em vez de calculateComplianceScore (ativa) — Closes #800

### DIFF
--- a/client/src/components/ExposicaoRiscoBadge.tsx
+++ b/client/src/components/ExposicaoRiscoBadge.tsx
@@ -2,11 +2,21 @@ import { Shield, ShieldAlert, ShieldCheck, ShieldQuestion } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 /**
- * Forma do `projects.scoringData` (engine v4 — calculateGlobalScore em server/ai-helpers.ts).
- * Mantido aqui para tipar a leitura sem importar do server (preserva isolamento client/server).
+ * Forma do `projects.scoringData`.
+ *
+ * Em produção: gravado por `calculateComplianceScore` em
+ * `server/lib/compliance-score-v4.ts` (via `trpc.risksV4.calculateAndSaveScore`,
+ * hot swap Z-12 / ADR-0022) — campo principal é `score`.
+ *
+ * Compat: registros antigos gravados pela função legada `calculateGlobalScore`
+ * (ai-helpers.ts — V61, desativada) usam `score_global`. Mantemos leitura de
+ * ambos os campos para projetos que foram calculados antes do hot swap.
+ *
+ * Issue #800 documenta a inconsistência histórica.
  */
 type ScoringData = {
-  score_global?: number;
+  score?: number;          // calculateComplianceScore (ativa)
+  score_global?: number;   // calculateGlobalScore (legada — compat)
   nivel?: "baixo" | "medio" | "alto" | "critico";
   [k: string]: unknown;
 };
@@ -63,7 +73,14 @@ export function ExposicaoRiscoBadge({
 }: ExposicaoRiscoBadgeProps) {
   const data = (scoringData ?? null) as ScoringData | null;
   const nivel = data?.nivel;
-  const score = typeof data?.score_global === "number" ? data.score_global : null;
+  // issue #800: prefere `score` (calculateComplianceScore — ativa) e cai para
+  // `score_global` em registros legados calculados pela calculateGlobalScore (V61).
+  const score =
+    typeof data?.score === "number"
+      ? data.score
+      : typeof data?.score_global === "number"
+        ? data.score_global
+        : null;
 
   const config = nivel && nivel in NIVEL_CONFIG ? NIVEL_CONFIG[nivel] : SEM_ANALISE_CONFIG;
   const Icon = config.icon;

--- a/docs/AS-IS-v1.0.md
+++ b/docs/AS-IS-v1.0.md
@@ -133,18 +133,23 @@ Esta é a etapa mais refinada do pipeline: usa RAG específico por área (não c
 
 ---
 
-### Scoring — `calculateGlobalScore` (Determinístico)
+### Scoring — `calculateGlobalScore` (Determinístico) — ⚠️ HISTÓRICO
+
+> **Nota (issue #800 · 2026-04-21):** esta seção documenta o estado AS-IS da V61.
+> A função foi **substituída** pelo hot swap Z-12 (ADR-0022). Função ativa em
+> produção hoje é `calculateComplianceScore` em `server/lib/compliance-score-v4.ts`.
+> `calculateGlobalScore` permanece como `@deprecated` para compat de testes.
 
 | Campo | Valor |
 |---|---|
-| **Função** | `calculateGlobalScore` |
+| **Função** | `calculateGlobalScore` (DEPRECATED) |
 | **Arquivo** | `server/ai-helpers.ts` |
 | **LLM** | Nenhum — cálculo 100% determinístico |
 | **Pesos por área** | Contabilidade e Fiscal: 30% / Jurídico: 30% / Negócio: 25% / TI: 15% |
 | **Pesos de severidade** | Crítica=9 / Alta=6 / Média=3 / Baixa=1 |
 | **Pesos de probabilidade** | Alta=3 / Média=2 / Baixa=1 |
 
-O scoring é calculado no servidor sem chamada LLM, garantindo determinismo e rastreabilidade. O resultado alimenta o `ScoringDataSchema` com `score_global` (0-100), `nivel` (baixo/medio/alto/critico), `impacto_estimado`, `custo_inacao` e contagem de riscos por severidade.
+O scoring era calculado no servidor sem chamada LLM, garantindo determinismo e rastreabilidade. O resultado alimenta o `ScoringDataSchema` com `score_global` (0-100), `nivel` (baixo/medio/alto/critico), `impacto_estimado`, `custo_inacao` e contagem de riscos por severidade.
 
 ---
 

--- a/docs/DOCUMENTACAO-IA-GENERATIVA-v4.md
+++ b/docs/DOCUMENTACAO-IA-GENERATIVA-v4.md
@@ -175,7 +175,7 @@ O `generateDecision` produz o veredito final do diagnóstico: ação principal r
 
 ## 9. Scoring Determinístico — Cálculo do Risco Global
 
-O score de risco global é calculado **sem LLM** pela função `calculateGlobalScore()` em `ai-helpers.ts`. O cálculo usa pesos por área de risco (fiscal, trabalhista, societário, regulatório), severidade dos riscos identificados, e probabilidade de ocorrência. O resultado é um número de 0 a 100 com tradução financeira estimada. Por ser determinístico, o score é auditável e reprodutível — dois projetos com as mesmas respostas sempre produzem o mesmo score.
+O score de risco global é calculado **sem LLM** pela função `calculateComplianceScore()` em `server/lib/compliance-score-v4.ts` (hot swap Z-12 / ADR-0022). Chamada via `trpc.risksV4.calculateAndSaveScore`. Usa pesos por severidade do risco (alta=7, media=5, oportunidade=1) × confidence (com piso 0.5), sobre riscos aprovados, produzindo número de 0 a 100. Por ser determinístico, o score é auditável e reprodutível — dois projetos com as mesmas respostas sempre produzem o mesmo score. _Nota: a função anterior `calculateGlobalScore()` em `ai-helpers.ts` está deprecated (ver issue #800)._
 
 ---
 

--- a/docs/governance/DATA_DICTIONARY.md
+++ b/docs/governance/DATA_DICTIONARY.md
@@ -160,39 +160,47 @@ SELECT JSON_KEYS([campo_json]) FROM [tabela] WHERE [campo_json] IS NOT NULL LIMI
 
 ## projects.scoringData (v4)
 
-> **Verificado em Sprint Z-16 Gate 0 (2026-04-15)**
-> **Banco atual:** `scoringData = NULL` para projetos criados no fluxo v4 (nunca calculado)
-> **Calculado por:** `calculateGlobalScore()` em `server/ai-helpers.ts`
-> **Chamado em:** APENAS `server/routers-fluxo-v3.ts` — NAO chamado no fluxo v4 ainda
+> **Atualizado em Z-22 / issue #800 (2026-04-21)**
+> **Calculado por (ativa):** `calculateComplianceScore()` em `server/lib/compliance-score-v4.ts`
+> **Chamado em:** `trpc.risksV4.calculateAndSaveScore` — Sprint Z-16 PR #634, hot swap Z-12 ADR-0022
+> **Função legada (deprecated):** `calculateGlobalScore()` em `server/ai-helpers.ts` — Sprint V61, substituída
+
+### Campos gravados pela função ativa (`calculateComplianceScore`)
 
 | Campo | Tipo | Observacao |
 |---|---|---|
-| score_global | number | 0-100 — formula: `round(sum(SEVERIDADE_SCORE_MAP[r.severidade]) / (n × 9) × 100)` |
+| score | number | 0-100 — fórmula abaixo |
 | nivel | string | `'baixo'` \| `'medio'` \| `'alto'` \| `'critico'` |
-| impacto_estimado | string | ex: `'R$ 120k/ano em risco fiscal estimado'` |
-| custo_inacao | string | descricao qualitativa |
-| prioridade | string | descricao qualitativa |
-| total_riscos | number | |
-| riscos_criticos | number | |
-| riscos_altos | number | |
+| total_riscos_aprovados | number | count de `approved_at != NULL` |
+| total_alta | number | count severidade=alta |
+| total_media | number | count severidade=media |
+| formula_version | string | `'v4.0'` — identifica versão da fórmula |
+| snapshots | array | histórico dos cálculos (RN-CV4-10) |
 
-**Formula de nivel:**
-- `score >= 70 OU riscos_criticos >= 2` → `'critico'`
-- `score >= 45 OU riscos_criticos >= 1` → `'alto'`
+**Fórmula ativa:**
+```
+score = round( Σ(peso × max(confidence, 0.5)) / (n × 9) × 100 )
+  peso = { alta: 7, media: 5, oportunidade: 1 }
+  n    = count(approved AND type != 'opportunity')
+```
+
+**Classificação de nivel:**
+- `score >= 75` → `'critico'`
+- `score >= 50` → `'alto'`
 - `score >= 25` → `'medio'`
 - else → `'baixo'`
 
-**SEVERIDADE_SCORE_MAP (deterministico — NUNCA LLM):**
+### Campos legados (gravados pela função deprecated em projetos antigos)
 
-| Severidade | Score |
-|---|---|
-| Crítica | 9 |
-| Alta | 7 |
-| Média | 5 |
-| Baixa | 3 |
-| Oportunidade | 1 |
-
-**Para Z-16:** A procedure `risksV4.calculateAndSaveScore(projectId)` deve calcular este score a partir de `risks_v4` (nao de `riskMatricesDataV3`) e persistir em `projects.scoringData`.
+| Campo | Tipo | Observacao |
+|---|---|---|
+| score_global | number | **Legado V61** — ainda presente em projetos antigos. Frontend lê este como fallback de `score` |
+| impacto_estimado | string | Legado V61 — tradução financeira |
+| custo_inacao | string | Legado V61 |
+| prioridade | string | Legado V61 |
+| total_riscos | number | Legado V61 (diferente de `total_riscos_aprovados`) |
+| riscos_criticos | number | Legado V61 |
+| riscos_altos | number | Legado V61 |
 
 ---
 

--- a/docs/governance/FLOW_DICTIONARY.md
+++ b/docs/governance/FLOW_DICTIONARY.md
@@ -84,7 +84,7 @@ Todas as features de UX fazem parte dele.
 - `projects.scoringData` (score calculado + historico de snapshots)
 
 **EFEITOS CASCATA:**
-- Imediato: score calculado via `calculateGlobalScore(risks_v4)` + snapshot salvo em `projects.scoringData`
+- Imediato: score calculado via `calculateComplianceScore(risks_v4)` (hot swap Z-12 / ADR-0022) + snapshot salvo em `projects.scoringData`
 - Cascata: PDF gerado sob demanda (jsPDF, client-side)
 - Formato: `ConsolidacaoV4Output` (ver DATA_DICTIONARY)
 - Navegacao: 4 botoes — PDF / Ver Projetos (`/projetos`) / Voltar (`/planos-v4`) / Ver Projeto (`/projetos/:id`)

--- a/docs/product/cpie-v2/produto/DOCUMENTACAO-IA-GENERATIVA-v5.md
+++ b/docs/product/cpie-v2/produto/DOCUMENTACAO-IA-GENERATIVA-v5.md
@@ -279,7 +279,7 @@ Temperatura: 0.35 (leve variação para linguagem mais natural e personalizada).
 
 ## 9. Scoring Determinístico — Cálculo do Risco Global
 
-O score de risco global é calculado **sem LLM** pela função `calculateGlobalScore()` em `server/ai-helpers.ts`. Por ser determinístico, o score é auditável e reprodutível — dois projetos com as mesmas respostas sempre produzem o mesmo score.
+O score de risco global é calculado **sem LLM** pela função `calculateComplianceScore()` em `server/lib/compliance-score-v4.ts` (hot swap Z-12 / ADR-0022). Por ser determinístico, o score é auditável e reprodutível — dois projetos com as mesmas respostas sempre produzem o mesmo score. _Nota: a função anterior `calculateGlobalScore()` em `ai-helpers.ts` está deprecated — ver issue #800 para o racional completo._
 
 O cálculo usa:
 

--- a/server/ai-helpers.ts
+++ b/server/ai-helpers.ts
@@ -170,8 +170,25 @@ export async function generateWithRetry<T extends z.ZodTypeAny>(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// SCORING GLOBAL COM TRADUÇÃO FINANCEIRA (Sprint V61)
+// SCORING GLOBAL COM TRADUÇÃO FINANCEIRA (Sprint V61) — @deprecated
 // ─────────────────────────────────────────────────────────────────────────────
+//
+// AVISO (issue #800): esta função NÃO é a calculadora de compliance score
+// ativa em produção. O hot swap do Z-12 (ADR-0022) moveu o cálculo para
+// `server/lib/compliance-score-v4.ts::calculateComplianceScore`, chamada via
+// `trpc.risksV4.calculateAndSaveScore`.
+//
+// `calculateGlobalScore` segue aqui apenas para:
+//   1. Compatibilidade com testes de integração V61 (sprint-v60-v63-e2e.test.ts)
+//   2. Rollback path do bloco legado em routers-fluxo-v3.ts:1961
+//
+// NÃO USE em código novo. Use `calculateComplianceScore`.
+//
+// Diferenças das duas funções:
+//   - pesos: legada (Baixa=2..Crítica=9) vs ativa (alta=7, media=5, oportunidade=1)
+//   - strings: legada capitalizada ("Alta") vs ativa lowercase ("alta")
+//   - ponderação: legada sem conf vs ativa × max(conf, 0.5)
+//   - output: legada grava `score_global` vs ativa grava `score`
 
 const SEVERIDADE_SCORE_MAP: Record<string, number> = {
   "Baixa": 2,
@@ -188,6 +205,12 @@ const FATOR_RISCO_MAP = {
 };
 
 /**
+ * @deprecated Use `calculateComplianceScore` em `server/lib/compliance-score-v4.ts`.
+ *
+ * Função legada da Sprint V61. Substituída pelo hot swap Z-12 (ADR-0022).
+ * Preservada apenas para compatibilidade com testes de integração V61 e
+ * rollback path do bloco legado em routers-fluxo-v3.ts:1961.
+ *
  * Calcula o score global de risco de forma determinística no servidor.
  * Nunca delegado à IA — garante auditabilidade e consistência.
  */


### PR DESCRIPTION
## Summary

Descoberto durante investigação do #796 — documentação e tipo do badge apontam para função legada V61 (`calculateGlobalScore`) enquanto produção usa a função ativa Z-16/v4 (`calculateComplianceScore`).

## Estratégia — deprecar, não remover

- Marcar função legada como `@deprecated` (testes V61 continuam passando)
- Atualizar 6 docs com nome correto
- Fix no tipo do badge + leitura com fallback

## Avaliação de Risco (ORQ-20)

- **Tier 1 trivial** — sem schema change · sem remoção · reversibilidade alta
- Gatilhos aplicados: cross-file (7 arquivos), engine determinística (tocou ai-helpers). Ambos mitigados por estratégia conservadora.

## Bônus

Badge `ExposicaoRiscoBadge` passa a **exibir o % no tooltip** quando `scoringData.score` existe (antes lia só `score_global` que não é gravado → sempre null).

## Test plan

- [x] `pnpm check` — zero erros
- [ ] UAT: tooltip do badge exibe % corretamente
- Pre-existing fail em sprint-v60-v63-e2e.test.ts (schema import) **não relacionado**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)