### PR TITLE
feat(exposicao): Limites Ideais (thresholds) + UX anti-erro + PDF — Closes #802

### DIFF
--- a/client/src/components/ExposicaoRiscoBadge.tsx
+++ b/client/src/components/ExposicaoRiscoBadge.tsx
@@ -1,50 +1,37 @@
 import { Shield, ShieldAlert, ShieldCheck, ShieldQuestion } from "lucide-react";
 import { cn } from "@/lib/utils";
+import {
+  classifyExposicao,
+  EXPOSICAO_CONFIG,
+  type ExposicaoLevel,
+} from "@/lib/exposicao-risco-thresholds";
 
 /**
  * Forma do `projects.scoringData`.
  *
- * Em produção: gravado por `calculateComplianceScore` em
- * `server/lib/compliance-score-v4.ts` (via `trpc.risksV4.calculateAndSaveScore`,
- * hot swap Z-12 / ADR-0022) — campo principal é `score`.
+ * Backend (calculateComplianceScore em server/lib/compliance-score-v4.ts) grava
+ * apenas `score` (número 0-100). Este componente classifica UX-side via
+ * `classifyExposicao` da lib `exposicao-risco-thresholds` — fonte única de verdade
+ * para thresholds (issue #802).
  *
- * Compat: registros antigos gravados pela função legada `calculateGlobalScore`
- * (ai-helpers.ts — V61, desativada) usam `score_global`. Mantemos leitura de
- * ambos os campos para projetos que foram calculados antes do hot swap.
- *
- * Issue #800 documenta a inconsistência histórica.
+ * Compat: registros legados V61 (calculateGlobalScore) ainda podem ter `score_global`.
+ * Fallback preservado — issue #800.
  */
 type ScoringData = {
   score?: number;          // calculateComplianceScore (ativa)
   score_global?: number;   // calculateGlobalScore (legada — compat)
-  nivel?: "baixo" | "medio" | "alto" | "critico";
   [k: string]: unknown;
 };
 
-const NIVEL_CONFIG = {
-  critico: {
-    label: "Crítica",
-    icon: ShieldAlert,
-    className: "text-red-700 bg-red-50 border-red-200 dark:bg-red-900/20 dark:text-red-400",
-  },
-  alto: {
-    label: "Alta",
-    icon: ShieldAlert,
-    className: "text-orange-700 bg-orange-50 border-orange-200 dark:bg-orange-900/20 dark:text-orange-400",
-  },
-  medio: {
-    label: "Média",
-    icon: Shield,
-    className: "text-amber-700 bg-amber-50 border-amber-200 dark:bg-amber-900/20 dark:text-amber-400",
-  },
-  baixo: {
-    label: "Baixa",
-    icon: ShieldCheck,
-    className: "text-emerald-700 bg-emerald-50 border-emerald-200 dark:bg-emerald-900/20 dark:text-emerald-400",
-  },
-} as const;
+// Ícones por nível (UX) — mapeamento local, não duplicado com a lib
+const ICONS: Record<ExposicaoLevel, typeof Shield> = {
+  critica: ShieldAlert,
+  alta: ShieldAlert,
+  moderada: Shield,
+  baixa: ShieldCheck,
+};
 
-const SEM_ANALISE_CONFIG = {
+const SEM_ANALISE = {
   label: "Sem análise",
   icon: ShieldQuestion,
   className: "text-muted-foreground bg-muted/40 border-border",
@@ -58,10 +45,15 @@ interface ExposicaoRiscoBadgeProps {
 }
 
 /**
- * Badge compacto exibindo o nível de Exposição ao Risco de Compliance do projeto,
- * lido de `projects.scoringData` (engine v4 determinístico — ADR-0022).
+ * Badge compacto exibindo o nível de Exposição ao Risco de Compliance do projeto.
  *
- * 5 estados: Crítica · Alta · Média · Baixa · Sem análise.
+ * 5 estados: Baixa · Moderada · Alta · Crítica · Sem análise.
+ *
+ * Thresholds (issue #802):
+ *   0–30  → Baixa
+ *   31–55 → Moderada
+ *   56–75 → Alta
+ *   76–100 → Crítica
  *
  * Substitui o antigo CpieScoreBadge (deletado na Sprint Z-22 Wave A.2+B · PR #737).
  */
@@ -72,9 +64,7 @@ export function ExposicaoRiscoBadge({
   className,
 }: ExposicaoRiscoBadgeProps) {
   const data = (scoringData ?? null) as ScoringData | null;
-  const nivel = data?.nivel;
-  // issue #800: prefere `score` (calculateComplianceScore — ativa) e cai para
-  // `score_global` em registros legados calculados pela calculateGlobalScore (V61).
+  // Prefere `score` (ativa); fallback para `score_global` em registros legados.
   const score =
     typeof data?.score === "number"
       ? data.score
@@ -82,12 +72,35 @@ export function ExposicaoRiscoBadge({
         ? data.score_global
         : null;
 
-  const config = nivel && nivel in NIVEL_CONFIG ? NIVEL_CONFIG[nivel] : SEM_ANALISE_CONFIG;
-  const Icon = config.icon;
+  // Sem score → estado "sem análise"
+  if (score === null) {
+    const Icon = SEM_ANALISE.icon;
+    const sizing =
+      size === "sm" ? "px-2 py-0.5 text-xs gap-1" : "px-2.5 py-1 text-sm gap-1.5";
+    const iconSize = size === "sm" ? "h-3 w-3" : "h-3.5 w-3.5";
+    return (
+      <span
+        className={cn(
+          "inline-flex items-center rounded-full border font-medium",
+          sizing,
+          SEM_ANALISE.className,
+          className
+        )}
+        data-testid="exposicao-risco-badge"
+        title="Exposição ao Risco de Compliance: Sem análise"
+      >
+        <Icon className={iconSize} />
+        <span>{SEM_ANALISE.label}</span>
+      </span>
+    );
+  }
 
-  const sizing = size === "sm"
-    ? "px-2 py-0.5 text-xs gap-1"
-    : "px-2.5 py-1 text-sm gap-1.5";
+  const level = classifyExposicao(score);
+  const cfg = EXPOSICAO_CONFIG[level];
+  const Icon = ICONS[level];
+
+  const sizing =
+    size === "sm" ? "px-2 py-0.5 text-xs gap-1" : "px-2.5 py-1 text-sm gap-1.5";
   const iconSize = size === "sm" ? "h-3 w-3" : "h-3.5 w-3.5";
 
   return (
@@ -95,19 +108,16 @@ export function ExposicaoRiscoBadge({
       className={cn(
         "inline-flex items-center rounded-full border font-medium",
         sizing,
-        config.className,
+        cfg.className,
         className
       )}
       data-testid="exposicao-risco-badge"
-      title={
-        score !== null
-          ? `Exposição ao Risco de Compliance: ${config.label} (${score}%)`
-          : `Exposição ao Risco de Compliance: ${config.label}`
-      }
+      data-level={level}
+      title={`Exposição ao Risco de Compliance: ${cfg.label} (${score}%) — ${cfg.interpretation}. Quanto menor, melhor.`}
     >
       <Icon className={iconSize} />
-      <span>{config.label}</span>
-      {showScore && score !== null && (
+      <span>{cfg.label}</span>
+      {showScore && (
         <span className="font-mono tabular-nums opacity-80">{score}%</span>
       )}
     </span>

--- a/client/src/components/ExposicaoRiscoBadge.tsx
+++ b/client/src/components/ExposicaoRiscoBadge.tsx
@@ -113,12 +113,12 @@ export function ExposicaoRiscoBadge({
       )}
       data-testid="exposicao-risco-badge"
       data-level={level}
-      title={`Exposição ao Risco de Compliance: ${cfg.label} (${score}%) — ${cfg.interpretation}. Quanto menor, melhor.`}
+      title={`Exposição ao Risco de Compliance: ${cfg.label} (${score}/100 pontos) — ${cfg.interpretation}. Quanto menor, melhor.`}
     >
       <Icon className={iconSize} />
       <span>{cfg.label}</span>
       {showScore && (
-        <span className="font-mono tabular-nums opacity-80">{score}%</span>
+        <span className="font-mono tabular-nums opacity-80">{score}/100</span>
       )}
     </span>
   );

--- a/client/src/lib/exposicao-risco-thresholds.test.ts
+++ b/client/src/lib/exposicao-risco-thresholds.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   classifyExposicao,
   getExposicaoConfig,
+  getMetaInfo,
+  META_EXPOSICAO,
   EXPOSICAO_CONFIG,
   EXPOSICAO_TEXTOS,
 } from "./exposicao-risco-thresholds";
@@ -93,6 +95,53 @@ describe("EXPOSICAO_CONFIG — sanidade estrutural", () => {
     const classes = Object.values(EXPOSICAO_CONFIG).map((c) => c.className);
     const unique = new Set(classes);
     expect(unique.size).toBe(4);
+  });
+});
+
+describe("getMetaInfo — distância até meta (anti-reflexo)", () => {
+  it("META_EXPOSICAO = 30", () => {
+    expect(META_EXPOSICAO).toBe(30);
+  });
+
+  it("score <= 30 indica meta atingida (distancia=0)", () => {
+    const info = getMetaInfo(25);
+    expect(info.atual).toBe(25);
+    expect(info.distancia).toBe(0);
+    expect(info.distanciaLabel).toContain("meta atingida");
+  });
+
+  it("score=30 (limite) também considera meta atingida", () => {
+    expect(getMetaInfo(30).distancia).toBe(0);
+  });
+
+  it("score=66 (alta) distância = 66-55 = 11 pontos para sair da faixa", () => {
+    const info = getMetaInfo(66);
+    expect(info.atual).toBe(66);
+    expect(info.distancia).toBe(11);
+    expect(info.distanciaLabel).toContain("sair da faixa alta");
+  });
+
+  it("score=45 (moderada) distância = 45-30 = 15 pontos para meta", () => {
+    const info = getMetaInfo(45);
+    expect(info.distancia).toBe(15);
+    expect(info.distanciaLabel).toContain("baixa exposição");
+  });
+
+  it("score=85 (crítica) distância = 85-75 = 10 pontos para sair da faixa", () => {
+    const info = getMetaInfo(85);
+    expect(info.distancia).toBe(10);
+    expect(info.distanciaLabel).toContain("sair da faixa crítica");
+  });
+
+  it("clampa valores inválidos", () => {
+    expect(getMetaInfo(-5).atual).toBe(0);
+    expect(getMetaInfo(150).atual).toBe(100);
+    expect(getMetaInfo(NaN).atual).toBe(0);
+  });
+
+  it("arredonda antes de calcular", () => {
+    expect(getMetaInfo(66.4).atual).toBe(66);
+    expect(getMetaInfo(66.5).atual).toBe(67);
   });
 });
 

--- a/client/src/lib/exposicao-risco-thresholds.test.ts
+++ b/client/src/lib/exposicao-risco-thresholds.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyExposicao,
+  getExposicaoConfig,
+  EXPOSICAO_CONFIG,
+  EXPOSICAO_TEXTOS,
+} from "./exposicao-risco-thresholds";
+
+describe("classifyExposicao — thresholds 0-30/31-55/56-75/76-100", () => {
+  it("baixa: 0 até 30 inclusive", () => {
+    expect(classifyExposicao(0)).toBe("baixa");
+    expect(classifyExposicao(15)).toBe("baixa");
+    expect(classifyExposicao(30)).toBe("baixa");
+  });
+
+  it("moderada: 31 até 55", () => {
+    expect(classifyExposicao(31)).toBe("moderada");
+    expect(classifyExposicao(45)).toBe("moderada");
+    expect(classifyExposicao(55)).toBe("moderada");
+  });
+
+  it("alta: 56 até 75", () => {
+    expect(classifyExposicao(56)).toBe("alta");
+    expect(classifyExposicao(66)).toBe("alta");
+    expect(classifyExposicao(75)).toBe("alta");
+  });
+
+  it("crítica: 76 até 100", () => {
+    expect(classifyExposicao(76)).toBe("critica");
+    expect(classifyExposicao(90)).toBe("critica");
+    expect(classifyExposicao(100)).toBe("critica");
+  });
+
+  it("clampa acima de 100 em 100 e retorna crítica", () => {
+    expect(classifyExposicao(150)).toBe("critica");
+  });
+
+  it("clampa abaixo de 0 em 0 e retorna baixa", () => {
+    expect(classifyExposicao(-10)).toBe("baixa");
+  });
+
+  it("arredonda antes de classificar", () => {
+    expect(classifyExposicao(30.4)).toBe("baixa");     // round → 30
+    expect(classifyExposicao(30.5)).toBe("moderada");  // round → 31
+    expect(classifyExposicao(55.4)).toBe("moderada");  // round → 55
+    expect(classifyExposicao(55.5)).toBe("alta");      // round → 56
+    expect(classifyExposicao(75.4)).toBe("alta");      // round → 75
+    expect(classifyExposicao(75.5)).toBe("critica");   // round → 76
+  });
+
+  it("NaN/Infinity retornam baixa (fallback seguro)", () => {
+    expect(classifyExposicao(NaN)).toBe("baixa");
+    expect(classifyExposicao(Infinity)).toBe("baixa");
+  });
+});
+
+describe("getExposicaoConfig", () => {
+  it("retorna null para input inválido", () => {
+    expect(getExposicaoConfig(null)).toBeNull();
+    expect(getExposicaoConfig(undefined)).toBeNull();
+    expect(getExposicaoConfig(NaN)).toBeNull();
+  });
+
+  it("retorna config com 4 campos obrigatórios", () => {
+    const cfg = getExposicaoConfig(66);
+    expect(cfg).not.toBeNull();
+    expect(cfg?.label).toBe("Alta exposição");
+    expect(cfg?.emoji).toBe("🟠");
+    expect(cfg?.action).toBeTruthy();
+    expect(cfg?.className).toBeTruthy();
+  });
+});
+
+describe("EXPOSICAO_CONFIG — sanidade estrutural", () => {
+  it("tem todas as 4 faixas", () => {
+    expect(Object.keys(EXPOSICAO_CONFIG).sort()).toEqual([
+      "alta", "baixa", "critica", "moderada",
+    ]);
+  });
+
+  it("ranges cobrem 0-100 sem gap ou overlap", () => {
+    const ranges = Object.values(EXPOSICAO_CONFIG)
+      .map((c) => c.range)
+      .sort((a, b) => a.min - b.min);
+    expect(ranges[0].min).toBe(0);
+    expect(ranges[ranges.length - 1].max).toBe(100);
+    for (let i = 0; i < ranges.length - 1; i++) {
+      expect(ranges[i + 1].min).toBe(ranges[i].max + 1);
+    }
+  });
+
+  it("cores distintas entre faixas", () => {
+    const classes = Object.values(EXPOSICAO_CONFIG).map((c) => c.className);
+    const unique = new Set(classes);
+    expect(unique.size).toBe(4);
+  });
+});
+
+describe("EXPOSICAO_TEXTOS — fonte única de verdade para copy", () => {
+  it("título canônico", () => {
+    expect(EXPOSICAO_TEXTOS.titulo).toBe("Exposição ao Risco de Compliance");
+  });
+
+  it("subtítulo usa 'indicador' (não 'score' — evita ambiguidade)", () => {
+    expect(EXPOSICAO_TEXTOS.subtitulo).toContain("indicador");
+    expect(EXPOSICAO_TEXTOS.subtitulo).not.toContain("score");
+  });
+
+  it("nota pedagógica menciona faixa 56-75 explicitamente", () => {
+    expect(EXPOSICAO_TEXTOS.nota_pedagogica).toContain("56");
+    expect(EXPOSICAO_TEXTOS.nota_pedagogica).toContain("75");
+    expect(EXPOSICAO_TEXTOS.nota_pedagogica).toContain("riscos aprovados");
+  });
+
+  it("alerta sinaliza MENOR = MELHOR", () => {
+    expect(EXPOSICAO_TEXTOS.alerta).toMatch(/MENOR.*MELHOR/);
+  });
+
+  it("frase final consolida", () => {
+    expect(EXPOSICAO_TEXTOS.frase_final).toContain("ponto de partida");
+  });
+});

--- a/client/src/lib/exposicao-risco-thresholds.ts
+++ b/client/src/lib/exposicao-risco-thresholds.ts
@@ -109,6 +109,66 @@ export function getExposicaoConfig(score: number | null | undefined): ExposicaoC
   return EXPOSICAO_CONFIG[classifyExposicao(score)];
 }
 
+// ─── Meta e distância (anti-reflexo de leitura — issue #802 ajuste 2) ───────
+
+/** Teto da faixa "baixa exposição" — meta canônica do produto. */
+export const META_EXPOSICAO = 30;
+
+export interface ExposicaoMetaInfo {
+  /** Valor atual (clampado 0-100) */
+  atual: number;
+  /** Meta teto ≤ 30 */
+  meta: number;
+  /** Pontos a reduzir para sair da faixa atual (0 se já está na meta) */
+  distancia: number;
+  /** Texto humano da distância: "sair da faixa alta" / "atingir a meta" */
+  distanciaLabel: string;
+}
+
+/**
+ * Calcula a distância entre o score atual e a meta de baixa exposição.
+ * Retorna o número de pontos a reduzir + rótulo contextual.
+ */
+export function getMetaInfo(score: number): ExposicaoMetaInfo {
+  const atual = Math.max(0, Math.min(100, Math.round(Number.isFinite(score) ? score : 0)));
+  if (atual <= META_EXPOSICAO) {
+    return {
+      atual,
+      meta: META_EXPOSICAO,
+      distancia: 0,
+      distanciaLabel: "meta atingida — manter monitoramento",
+    };
+  }
+  const level = classifyExposicao(atual);
+  // Ponto-alvo: sair da faixa atual (retornar para o teto da faixa anterior)
+  let alvoSairFaixa: number;
+  let labelSair: string;
+  switch (level) {
+    case "critica":
+      alvoSairFaixa = 75;
+      labelSair = "sair da faixa crítica";
+      break;
+    case "alta":
+      alvoSairFaixa = 55;
+      labelSair = "sair da faixa alta";
+      break;
+    case "moderada":
+      alvoSairFaixa = 30;
+      labelSair = "atingir a meta de baixa exposição";
+      break;
+    default:
+      alvoSairFaixa = META_EXPOSICAO;
+      labelSair = "manter faixa";
+  }
+  const distancia = atual - alvoSairFaixa;
+  return {
+    atual,
+    meta: META_EXPOSICAO,
+    distancia,
+    distanciaLabel: labelSair,
+  };
+}
+
 // ─── Textos canônicos do indicador (fonte única) ────────────────────────────
 
 export const EXPOSICAO_TEXTOS = {

--- a/client/src/lib/exposicao-risco-thresholds.ts
+++ b/client/src/lib/exposicao-risco-thresholds.ts
@@ -1,0 +1,124 @@
+/**
+ * exposicao-risco-thresholds.ts — issue #802
+ *
+ * Classificação de UX do indicador "Exposição ao Risco de Compliance".
+ *
+ * ARQUITETURA:
+ *   - Backend calcula apenas o número (score 0-100) via calculateComplianceScore.
+ *   - Este módulo (frontend) aplica os thresholds e mapeia para label + cor.
+ *   - Nunca misturar: threshold é decisão de UX · fórmula é decisão de negócio.
+ *
+ * Consumidores: ExposicaoRiscoBadge, ConsolidacaoV4, generateDiagnosticoPDF.
+ *
+ * ⚠️ Semântica crítica:
+ *   - Quanto MENOR o score, MELHOR a situação.
+ *   - "Baixa exposição" é META (pós-tratamento), não ponto de partida.
+ *   - Projetos com riscos aprovados tipicamente começam em 56-75.
+ */
+
+export type ExposicaoLevel = "baixa" | "moderada" | "alta" | "critica";
+
+export interface ExposicaoConfig {
+  /** Label curto (PT-BR) exibido no badge/card */
+  label: string;
+  /** Emoji indicador */
+  emoji: string;
+  /** Interpretação da faixa (1 linha) */
+  interpretation: string;
+  /** Ação recomendada */
+  action: string;
+  /** Classes Tailwind (texto · fundo · borda) — unificado para dark mode */
+  className: string;
+  /** Cor da barra de progresso */
+  barClass: string;
+  /** Faixa numérica inclusive-inclusive */
+  range: { min: number; max: number };
+}
+
+/**
+ * Configuração determinística das 4 bandas.
+ * Alterações aqui AFETAM todas as UIs que consomem este módulo — único ponto de verdade.
+ */
+export const EXPOSICAO_CONFIG: Record<ExposicaoLevel, ExposicaoConfig> = {
+  baixa: {
+    label: "Baixa exposição",
+    emoji: "🟢",
+    interpretation: "Situação controlada",
+    action: "Manter monitoramento",
+    className:
+      "text-emerald-700 bg-emerald-50 border-emerald-200 dark:bg-emerald-900/20 dark:text-emerald-400",
+    barClass: "bg-emerald-500",
+    range: { min: 0, max: 30 },
+  },
+  moderada: {
+    label: "Exposição moderada",
+    emoji: "🟡",
+    interpretation: "Riscos relevantes identificados",
+    action: "Revisar aprovações",
+    className:
+      "text-amber-700 bg-amber-50 border-amber-200 dark:bg-amber-900/20 dark:text-amber-400",
+    barClass: "bg-amber-500",
+    range: { min: 31, max: 55 },
+  },
+  alta: {
+    label: "Alta exposição",
+    emoji: "🟠",
+    interpretation: "Exposição significativa",
+    action: "Priorizar mitigação",
+    className:
+      "text-orange-700 bg-orange-50 border-orange-200 dark:bg-orange-900/20 dark:text-orange-400",
+    barClass: "bg-orange-500",
+    range: { min: 56, max: 75 },
+  },
+  critica: {
+    label: "Exposição crítica",
+    emoji: "🔴",
+    interpretation: "Alto risco de não conformidade",
+    action: "Ação imediata",
+    className:
+      "text-red-700 bg-red-50 border-red-200 dark:bg-red-900/20 dark:text-red-400",
+    barClass: "bg-red-500",
+    range: { min: 76, max: 100 },
+  },
+};
+
+/**
+ * Classifica um score numérico (0-100) em uma das 4 faixas de exposição.
+ * Determinística. Mesmo input → mesmo output.
+ *
+ * Thresholds:
+ *   0–30  → baixa
+ *   31–55 → moderada
+ *   56–75 → alta
+ *   76+   → crítica
+ */
+export function classifyExposicao(score: number): ExposicaoLevel {
+  if (!Number.isFinite(score)) return "baixa";
+  const s = Math.max(0, Math.min(100, Math.round(score)));
+  if (s >= 76) return "critica";
+  if (s >= 56) return "alta";
+  if (s >= 31) return "moderada";
+  return "baixa";
+}
+
+/**
+ * Retorna o config completo para um score.
+ */
+export function getExposicaoConfig(score: number | null | undefined): ExposicaoConfig | null {
+  if (typeof score !== "number" || !Number.isFinite(score)) return null;
+  return EXPOSICAO_CONFIG[classifyExposicao(score)];
+}
+
+// ─── Textos canônicos do indicador (fonte única) ────────────────────────────
+
+export const EXPOSICAO_TEXTOS = {
+  titulo: "Exposição ao Risco de Compliance",
+  subtitulo:
+    "O objetivo não é aumentar o indicador.\nÉ reduzir a exposição ao risco.",
+  alerta:
+    "Este indicador mede EXPOSIÇÃO ao risco — não o nível de compliance.\nQuanto MENOR o valor, MELHOR a situação.",
+  nota_pedagogica:
+    "Projetos com riscos aprovados normalmente começam com exposição entre 56 e 75.\nA redução ocorre conforme os riscos são tratados ou removidos.",
+  frase_final:
+    "O verde não é o ponto de partida. É o resultado do trabalho.",
+} as const;

--- a/client/src/lib/generateDiagnosticoPDF.ts
+++ b/client/src/lib/generateDiagnosticoPDF.ts
@@ -7,6 +7,10 @@
 
 import jsPDF from "jspdf";
 import autoTable from "jspdf-autotable";
+import {
+  classifyExposicao,
+  EXPOSICAO_CONFIG,
+} from "./exposicao-risco-thresholds";
 
 export interface DiagnosticoPDFData {
   cnpj?: string;
@@ -88,19 +92,48 @@ export function generateDiagnosticoPDF(data: DiagnosticoPDFData): void {
   doc.text(disclaimerLines, margin, y);
   y += disclaimerLines.length * 3 + 6;
 
-  // ─── Score ──────────────────────────────────────────────────────────
+  // ─── Score / Exposição ao Risco (issue #802) ────────────────────────
   doc.setTextColor(30, 30, 30);
   doc.setFontSize(12);
   doc.setFont("helvetica", "bold");
   doc.text("Exposição ao Risco de Compliance", margin, y);
+  y += 5;
+
+  // Subtítulo
+  doc.setFontSize(9);
+  doc.setFont("helvetica", "italic");
+  doc.setTextColor(100, 100, 100);
+  doc.text(
+    "O objetivo não é aumentar o indicador. É reduzir a exposição ao risco.",
+    margin,
+    y
+  );
   y += 6;
+
+  // Alerta anti-erro
+  doc.setFontSize(8);
+  doc.setFont("helvetica", "normal");
+  doc.setTextColor(146, 64, 14); // amber-800
+  const alertaLines = doc.splitTextToSize(
+    "ATENÇÃO: Este indicador mede EXPOSIÇÃO ao risco — não o nível de compliance. Quanto MENOR o valor, MELHOR a situação.",
+    pageW - margin * 2
+  );
+  doc.text(alertaLines, margin, y);
+  y += alertaLines.length * 3.5 + 2;
+
+  // Classificação UX (fonte única de verdade — #802)
+  const level = classifyExposicao(data.score);
+  const cfg = EXPOSICAO_CONFIG[level];
+  doc.setTextColor(30, 30, 30);
 
   autoTable(doc, {
     startY: y,
     head: [["Indicador", "Valor"]],
     body: [
-      ["Score Global", `${data.score}%`],
-      ["Nível", data.nivel.toUpperCase()],
+      ["Score (0-100)", `${data.score}`],
+      ["Nível", `${cfg.emoji} ${cfg.label}`],
+      ["Interpretação", cfg.interpretation],
+      ["Ação recomendada", cfg.action],
       ["Riscos Alta Severidade", String(data.totalAlta)],
       ["Riscos Média Severidade", String(data.totalMedia)],
       ["Total Oportunidades", String(data.opportunities.length)],
@@ -110,7 +143,50 @@ export function generateDiagnosticoPDF(data: DiagnosticoPDFData): void {
     headStyles: { fillColor: [15, 68, 124] },
     margin: { left: margin, right: margin },
   });
-  y = (doc as any).lastAutoTable.finalY + 8;
+  y = (doc as any).lastAutoTable.finalY + 4;
+
+  // Tabela Limites Ideais (thresholds)
+  doc.setFontSize(9);
+  doc.setFont("helvetica", "bold");
+  doc.setTextColor(30, 30, 30);
+  doc.text("Limites Ideais (thresholds)", margin, y);
+  y += 4;
+
+  autoTable(doc, {
+    startY: y,
+    head: [["Faixa", "Nível", "Interpretação", "Ação"]],
+    body: [
+      ["0–30", "🟢 Baixa exposição", "Situação controlada", "Manter monitoramento"],
+      ["31–55", "🟡 Exposição moderada", "Riscos relevantes", "Revisar aprovações"],
+      ["56–75", "🟠 Alta exposição", "Exposição significativa", "Priorizar mitigação"],
+      ["76–100", "🔴 Exposição crítica", "Alto risco de não conformidade", "Ação imediata"],
+    ],
+    styles: { fontSize: 8 },
+    headStyles: { fillColor: [100, 100, 100] },
+    margin: { left: margin, right: margin },
+  });
+  y = (doc as any).lastAutoTable.finalY + 4;
+
+  // Nota pedagógica
+  doc.setFontSize(8);
+  doc.setFont("helvetica", "italic");
+  doc.setTextColor(30, 64, 175); // blue-800
+  const notaLines = doc.splitTextToSize(
+    "Projetos com riscos aprovados normalmente começam com exposição entre 56 e 75. A redução ocorre conforme os riscos são tratados ou removidos.",
+    pageW - margin * 2
+  );
+  doc.text(notaLines, margin, y);
+  y += notaLines.length * 3.5 + 2;
+
+  // Frase final
+  doc.setFont("helvetica", "bold");
+  doc.setTextColor(30, 30, 30);
+  doc.text(
+    "O verde não é o ponto de partida. É o resultado do trabalho.",
+    margin,
+    y
+  );
+  y += 8;
 
   // ─── Riscos Aprovados ───────────────────────────────────────────────
   if (data.risks.length > 0) {

--- a/client/src/lib/generateDiagnosticoPDF.ts
+++ b/client/src/lib/generateDiagnosticoPDF.ts
@@ -10,6 +10,8 @@ import autoTable from "jspdf-autotable";
 import {
   classifyExposicao,
   EXPOSICAO_CONFIG,
+  getMetaInfo,
+  META_EXPOSICAO,
 } from "./exposicao-risco-thresholds";
 
 export interface DiagnosticoPDFData {
@@ -124,16 +126,24 @@ export function generateDiagnosticoPDF(data: DiagnosticoPDFData): void {
   // Classificação UX (fonte única de verdade — #802)
   const level = classifyExposicao(data.score);
   const cfg = EXPOSICAO_CONFIG[level];
+  const meta = getMetaInfo(data.score);
   doc.setTextColor(30, 30, 30);
+
+  const distanciaRow =
+    meta.distancia === 0
+      ? "0 pontos · meta atingida"
+      : `${meta.distancia} pontos para ${meta.distanciaLabel}`;
 
   autoTable(doc, {
     startY: y,
     head: [["Indicador", "Valor"]],
     body: [
-      ["Score (0-100)", `${data.score}`],
+      ["Exposição atual", `${data.score} / 100 pontos  ↓`],
       ["Nível", `${cfg.emoji} ${cfg.label}`],
       ["Interpretação", cfg.interpretation],
       ["Ação recomendada", cfg.action],
+      ["Meta", `≤ ${META_EXPOSICAO} pontos`],
+      ["Distância até a meta", distanciaRow],
       ["Riscos Alta Severidade", String(data.totalAlta)],
       ["Riscos Média Severidade", String(data.totalMedia)],
       ["Total Oportunidades", String(data.opportunities.length)],

--- a/client/src/pages/ConsolidacaoV4.tsx
+++ b/client/src/pages/ConsolidacaoV4.tsx
@@ -32,6 +32,8 @@ import { toast } from "sonner";
 import {
   classifyExposicao,
   getExposicaoConfig,
+  getMetaInfo,
+  META_EXPOSICAO,
   EXPOSICAO_CONFIG,
   EXPOSICAO_TEXTOS,
 } from "@/lib/exposicao-risco-thresholds";
@@ -149,6 +151,7 @@ export default function ConsolidacaoV4() {
   const rawScore = typeof score?.score === "number" ? score.score : 0;
   const exposicaoLevel = classifyExposicao(rawScore);
   const exposicaoCfg = EXPOSICAO_CONFIG[exposicaoLevel];
+  const metaInfo = getMetaInfo(rawScore);
   // Mantido para compat com NIVEL_COLORS downstream (KpiCard Score)
   const nivel = score?.nivel ?? "baixo";
   const nivelColors = NIVEL_COLORS[nivel] ?? NIVEL_COLORS.baixo;
@@ -249,14 +252,22 @@ export default function ConsolidacaoV4() {
               </AlertDescription>
             </Alert>
 
-            {/* Score + Label */}
-            <div className="flex items-baseline gap-4">
+            {/* Score + Label + seta ↓ (anti-reflexo: indica "queremos diminuir") */}
+            <div className="flex items-baseline gap-3 flex-wrap">
               <span
                 data-testid="exposicao-score"
-                className={`text-5xl font-bold ${exposicaoCfg.className.split(" ").find((c) => c.startsWith("text-"))}`}
+                className={`text-5xl font-bold leading-none ${exposicaoCfg.className.split(" ").find((c) => c.startsWith("text-"))}`}
               >
                 {rawScore}
-                <span className="text-2xl">/100</span>
+              </span>
+              <span className="text-lg text-muted-foreground">/ 100 pontos</span>
+              <span
+                data-testid="exposicao-seta-reduzir"
+                className={`text-xl ${exposicaoCfg.className.split(" ").find((c) => c.startsWith("text-"))}`}
+                title="Queremos reduzir este número"
+                aria-label="Quanto menor, melhor"
+              >
+                ↓
               </span>
               <Badge
                 data-testid="exposicao-nivel-badge"
@@ -264,6 +275,40 @@ export default function ConsolidacaoV4() {
               >
                 {exposicaoCfg.emoji} {exposicaoCfg.label.toUpperCase()}
               </Badge>
+            </div>
+
+            {/* Meta + Distância (anti-reflexo: transforma o número numa distância a percorrer) */}
+            <div
+              data-testid="exposicao-meta-distancia"
+              className="rounded-lg border bg-card/70 px-3 py-2 space-y-1 text-sm"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <span className="flex items-center gap-2 text-muted-foreground">
+                  <span aria-hidden>🎯</span>
+                  Meta
+                </span>
+                <span className="font-mono tabular-nums font-semibold">
+                  ≤ {META_EXPOSICAO} pontos
+                </span>
+              </div>
+              <div className="flex items-center justify-between gap-3">
+                <span className="flex items-center gap-2 text-muted-foreground">
+                  <span aria-hidden>📉</span>
+                  Distância
+                </span>
+                <span
+                  data-testid="exposicao-distancia-valor"
+                  className={`font-mono tabular-nums font-semibold ${
+                    metaInfo.distancia === 0
+                      ? "text-emerald-700 dark:text-emerald-400"
+                      : exposicaoCfg.className.split(" ").find((c) => c.startsWith("text-"))
+                  }`}
+                >
+                  {metaInfo.distancia === 0
+                    ? "0 pontos · meta atingida"
+                    : `${metaInfo.distancia} pontos para ${metaInfo.distanciaLabel}`}
+                </span>
+              </div>
             </div>
 
             {/* Barra visual com marcadores de threshold */}

--- a/client/src/pages/ConsolidacaoV4.tsx
+++ b/client/src/pages/ConsolidacaoV4.tsx
@@ -29,6 +29,12 @@ import {
   TrendingUp,
 } from "lucide-react";
 import { toast } from "sonner";
+import {
+  classifyExposicao,
+  getExposicaoConfig,
+  EXPOSICAO_CONFIG,
+  EXPOSICAO_TEXTOS,
+} from "@/lib/exposicao-risco-thresholds";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -138,6 +144,12 @@ export default function ConsolidacaoV4() {
     }
   }, [projectId]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // issue #802: UX-side classification (frontend é fonte única de interpretação).
+  // Backend retorna apenas o número; thresholds aplicados aqui.
+  const rawScore = typeof score?.score === "number" ? score.score : 0;
+  const exposicaoLevel = classifyExposicao(rawScore);
+  const exposicaoCfg = EXPOSICAO_CONFIG[exposicaoLevel];
+  // Mantido para compat com NIVEL_COLORS downstream (KpiCard Score)
   const nivel = score?.nivel ?? "baixo";
   const nivelColors = NIVEL_COLORS[nivel] ?? NIVEL_COLORS.baixo;
 
@@ -208,54 +220,158 @@ export default function ConsolidacaoV4() {
           <KpiCard testId="kpi-tarefas" label="Tarefas" value={allTasks.length} color="text-purple-600" />
         </div>
 
-        {/* Exposicao ao Risco de Compliance Card (RN-CV4-01..07) */}
-        <Card data-testid="compliance-score-card" className={nivelColors.bg}>
+        {/* Exposicao ao Risco de Compliance Card — issue #802
+            Arquitetura: backend calcula score (número), frontend interpreta.
+            Fonte única dos thresholds: client/src/lib/exposicao-risco-thresholds.ts */}
+        <Card data-testid="compliance-score-card" className={exposicaoCfg.className.replace(/text-\S+/g, "").trim()}>
           <CardHeader className="pb-3">
             <CardTitle className="text-base flex items-center gap-2">
               <TrendingUp className="h-4 w-4" />
-              Exposição ao Risco de Compliance
+              {EXPOSICAO_TEXTOS.titulo}
             </CardTitle>
+            {/* Subtítulo educativo — fonte única de copy, não escondido em tooltip */}
+            <p
+              data-testid="exposicao-subtitulo"
+              className="text-sm text-muted-foreground whitespace-pre-line mt-1"
+            >
+              {EXPOSICAO_TEXTOS.subtitulo}
+            </p>
           </CardHeader>
-          <CardContent className="space-y-3">
-            <div className="flex items-center gap-4">
-              <span className={`text-4xl font-bold ${nivelColors.text}`}>
-                {score?.score ?? 0}%
+          <CardContent className="space-y-4">
+            {/* Alerta anti-erro de interpretação — banner permanente (não tooltip) */}
+            <Alert
+              data-testid="exposicao-alerta-anti-erro"
+              className="border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/30"
+            >
+              <AlertTriangle className="h-4 w-4 text-amber-700 dark:text-amber-400" />
+              <AlertDescription className="text-xs text-amber-800 dark:text-amber-200 whitespace-pre-line leading-relaxed">
+                {EXPOSICAO_TEXTOS.alerta}
+              </AlertDescription>
+            </Alert>
+
+            {/* Score + Label */}
+            <div className="flex items-baseline gap-4">
+              <span
+                data-testid="exposicao-score"
+                className={`text-5xl font-bold ${exposicaoCfg.className.split(" ").find((c) => c.startsWith("text-"))}`}
+              >
+                {rawScore}
+                <span className="text-2xl">/100</span>
               </span>
-              <Badge className={`${nivelColors.bar} text-white`}>
-                {nivel.toUpperCase()}
+              <Badge
+                data-testid="exposicao-nivel-badge"
+                className={`${exposicaoCfg.barClass} text-white`}
+              >
+                {exposicaoCfg.emoji} {exposicaoCfg.label.toUpperCase()}
               </Badge>
             </div>
-            <div className="w-full bg-muted rounded-full h-2.5">
-              <div
-                className={`h-2.5 rounded-full ${nivelColors.bar}`}
-                style={{ width: `${Math.min(score?.score ?? 0, 100)}%` }}
-              />
+
+            {/* Barra visual com marcadores de threshold */}
+            <div className="space-y-1" data-testid="exposicao-barra">
+              <div className="relative w-full bg-muted rounded-full h-3 overflow-hidden">
+                <div
+                  className={`h-full rounded-full transition-all ${exposicaoCfg.barClass}`}
+                  style={{ width: `${Math.min(Math.max(rawScore, 0), 100)}%` }}
+                />
+                {/* Marcadores de threshold nas posições 30, 55, 75 */}
+                {[30, 55, 75].map((t) => (
+                  <div
+                    key={t}
+                    className="absolute top-0 h-full w-px bg-background/60"
+                    style={{ left: `${t}%` }}
+                  />
+                ))}
+              </div>
+              <div className="grid grid-cols-4 text-[10px] text-muted-foreground tabular-nums">
+                <span>🟢 0</span>
+                <span className="text-center">🟡 31</span>
+                <span className="text-center">🟠 56</span>
+                <span className="text-right">🔴 76-100</span>
+              </div>
             </div>
-            <p data-testid="score-transparencia" className="text-xs text-muted-foreground">
-              Este indicador mostra o nível de exposição ao risco de compliance com base nos riscos aprovados.
-              Ele aumenta quando a quantidade de riscos, a gravidade deles e/ou a falta de qualidade das respostas
-              (força das evidências) aumenta.
+
+            {/* Limites Ideais (thresholds) — tabela explicativa */}
+            <div
+              data-testid="exposicao-limites-ideais"
+              className="rounded-lg border bg-card/50 p-3 space-y-2"
+            >
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Limites Ideais (thresholds)
+              </p>
+              <div className="grid grid-cols-1 gap-1 text-xs">
+                {(Object.keys(EXPOSICAO_CONFIG) as Array<keyof typeof EXPOSICAO_CONFIG>).map((lvl) => {
+                  const c = EXPOSICAO_CONFIG[lvl];
+                  const isCurrent = lvl === exposicaoLevel;
+                  return (
+                    <div
+                      key={lvl}
+                      data-testid={`exposicao-faixa-${lvl}`}
+                      className={`flex items-center gap-2 rounded px-2 py-1 ${
+                        isCurrent ? "font-semibold ring-1 ring-border bg-background" : ""
+                      }`}
+                    >
+                      <span>{c.emoji}</span>
+                      <span className="font-mono tabular-nums w-14 text-muted-foreground">
+                        {c.range.min}–{c.range.max}
+                      </span>
+                      <span className="flex-1">{c.label}</span>
+                      <span className="text-muted-foreground text-[11px] hidden sm:inline">
+                        {c.interpretation}
+                      </span>
+                      <span className="text-muted-foreground text-[11px] italic">
+                        {c.action}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Nota pedagógica — contexto do ponto de partida */}
+            <Alert
+              data-testid="exposicao-nota-pedagogica"
+              className="border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/30"
+            >
+              <AlertDescription className="text-xs text-blue-800 dark:text-blue-200 whitespace-pre-line leading-relaxed">
+                💡 {EXPOSICAO_TEXTOS.nota_pedagogica}
+              </AlertDescription>
+            </Alert>
+
+            {/* Metadados técnicos (menos importantes — apenas para auditoria) */}
+            <p
+              data-testid="score-transparencia"
+              className="text-[11px] text-muted-foreground"
+            >
               {(score as any)?.calculated_at && (
                 <>
-                  {" "}Calculado em{" "}
+                  Calculado em{" "}
                   {new Date((score as any).calculated_at).toLocaleString("pt-BR")}.
+                  {" "}
                 </>
               )}
-              {" "}
               <span className="font-mono text-[10px]">
-                (Fórmula v4.0 · peso × max(confiança, 0,5) / n × 9 × 100)
+                Fórmula v4.0 · peso × max(confiança, 0,5) / n × 9 × 100
               </span>
             </p>
-            {/* fix UAT 2026-04-20: botão "Analisar o Indicador" abre o dashboard de Exposição ao Risco (on-demand). */}
+
+            {/* Frase final — consolidação pedagógica */}
+            <p
+              data-testid="exposicao-frase-final"
+              className="text-sm font-medium text-center italic text-muted-foreground border-t pt-3"
+            >
+              {EXPOSICAO_TEXTOS.frase_final}
+            </p>
+
+            {/* Botão analisar — mantido */}
             <Link href={`/projetos/${projectId}/compliance-dashboard`}>
               <Button
                 variant="outline"
                 size="sm"
-                className="mt-2 gap-2"
+                className="mt-1 gap-2 w-full sm:w-auto"
                 data-testid="btn-analisar-indicador-exposicao"
               >
                 <BarChart3 className="h-4 w-4" />
-                Analisar o Indicador de Exposição ao Riscos
+                Analisar o Indicador de Exposição ao Risco
                 <ChevronRight className="h-4 w-4" />
               </Button>
             </Link>


### PR DESCRIPTION
## Summary

Implementa **Limites Ideais (thresholds)** do indicador de Exposição ao Risco, validado pelo P.O. e pelo consultor externo.

**Regra arquitetural crítica (consultor):**
> Nunca colocar interpretação no backend. Backend calcula · Frontend interpreta.

Então: thresholds vivem em **`client/src/lib/exposicao-risco-thresholds.ts`** como fonte única. Backend `calculateComplianceScore` retorna apenas o número `score`.

## 4 faixas canônicas

| Faixa | Nível | Ação recomendada |
|---|---|---|
| 🟢 0–30 | Baixa exposição | Manter monitoramento |
| 🟡 31–55 | Exposição moderada | Revisar aprovações |
| 🟠 56–75 | Alta exposição | Priorizar mitigação |
| 🔴 76–100 | Exposição crítica | Ação imediata |

## UX card ConsolidacaoV4

1. Título + subtítulo (`O objetivo não é aumentar o indicador. É reduzir a exposição`)
2. **Alerta anti-erro** (banner amarelo permanente): _Quanto MENOR o valor, MELHOR a situação_
3. Score + badge colorido com emoji
4. Barra de progresso com **marcadores nas posições 30, 55, 75**
5. Tabela **Limites Ideais (thresholds)** — faixa atual destacada
6. **Nota pedagógica** (banner azul): _Projetos com riscos aprovados normalmente começam entre 56 e 75_
7. Metadados técnicos (fórmula v4.0 + timestamp)
8. **Frase final** centralizada: _O verde não é o ponto de partida. É o resultado do trabalho._
9. Botão "Analisar o Indicador" (inalterado)

## Arquivos

- `client/src/lib/exposicao-risco-thresholds.ts` — **novo** (lib + copy canônico + config)
- `client/src/lib/exposicao-risco-thresholds.test.ts` — **18 unit tests**
- `client/src/components/ExposicaoRiscoBadge.tsx` — refatorado para usar lib
- `client/src/lib/generateDiagnosticoPDF.ts` — PDF alinhado com UI (mesmas strings)
- `client/src/pages/ConsolidacaoV4.tsx` — card rico com 9 seções

## Ajustes do consultor aplicados

1. ✅ **Thresholds NUNCA no backend** — backend mantém `score` apenas
2. ✅ **Subtítulo usa "indicador"** (não "score") — evita ambiguidade
3. ✅ **Nota pedagógica mais técnica** — "com riscos aprovados"

## ORQ-20 — Avaliação de Risco

- **Tier:** 2 médio (UX-heavy, frontend-only)
- **Schema:** nenhum
- **Engine:** não tocada (fórmula v4.0 intacta)
- **Reversibilidade:** alta (`git revert`)
- **Rollback:** Nível 1 — revert do PR

## Test plan

- [x] `pnpm check` — zero erros
- [x] `pnpm vitest run client/src/lib/exposicao-risco-thresholds.test.ts` — **18/18 PASS**
- [ ] UAT visual: card em ConsolidacaoV4 com 9 seções · todos os textos
- [ ] UAT visual: badge no header do projeto mostra label + % no tooltip
- [ ] UAT PDF: export com 2 tabelas (score + thresholds) + textos canônicos

🤖 Generated with [Claude Code](https://claude.com/claude-code)