### PR TITLE
fix(pdf): remover Unicode extendido do diagnóstico PDF (emojis, ≤, ↓ → lixo)

### DIFF
--- a/client/src/lib/generateDiagnosticoPDF.ts
+++ b/client/src/lib/generateDiagnosticoPDF.ts
@@ -3,6 +3,22 @@
  * PDF client-side via jsPDF + autoTable
  * RN-CV4-11 (disclaimer) + RN-CV4-12 (jsPDF)
  * Leitura defensiva: data_fim ?? '—'
+ *
+ * ⚠️ CODIFICAÇÃO (hotfix 2026-04-21):
+ * jsPDF com fonte Helvetica padrão usa WinAnsi (Windows-1252).
+ * NÃO suporta: emojis (🟢🟡🟠🔴), setas Unicode (↑↓), ≤ ≥, e vários símbolos extendidos.
+ * Estes caracteres renderizam como lixo: "Ø=ßà" ao invés de "🟠", "d" ao invés de "≤".
+ *
+ * Regra: no PDF usar SOMENTE caracteres Latin-1 / Windows-1252:
+ *   - acentos latinos (á é í ó ú ã õ â ê ô ç ñ) ✓
+ *   - hífen regular (-) e travessão (– em Windows-1252) ✓
+ *   - aspas curvas " " ‘ ’ ✓
+ *   - NÃO USAR: emojis · ≤ ≥ · ↑ ↓ → ← · ≈ ≠ ± · ★ ● ■
+ *
+ * Substituir por: "<=" ao invés de "≤", "(reduzir)" ao invés de "↓",
+ * "[ALTA]" ao invés de "🟠 Alta", etc.
+ *
+ * HTML/web mantém emojis/Unicode extendido — apenas PDF é restrito.
  */
 
 import jsPDF from "jspdf";
@@ -138,11 +154,11 @@ export function generateDiagnosticoPDF(data: DiagnosticoPDFData): void {
     startY: y,
     head: [["Indicador", "Valor"]],
     body: [
-      ["Exposição atual", `${data.score} / 100 pontos  ↓`],
-      ["Nível", `${cfg.emoji} ${cfg.label}`],
+      ["Exposição atual", `${data.score} / 100 pontos  (reduzir)`],
+      ["Nível", `[${cfg.label.toUpperCase()}]`],
       ["Interpretação", cfg.interpretation],
       ["Ação recomendada", cfg.action],
-      ["Meta", `≤ ${META_EXPOSICAO} pontos`],
+      ["Meta", `ate ${META_EXPOSICAO} pontos`],
       ["Distância até a meta", distanciaRow],
       ["Riscos Alta Severidade", String(data.totalAlta)],
       ["Riscos Média Severidade", String(data.totalMedia)],
@@ -166,10 +182,10 @@ export function generateDiagnosticoPDF(data: DiagnosticoPDFData): void {
     startY: y,
     head: [["Faixa", "Nível", "Interpretação", "Ação"]],
     body: [
-      ["0–30", "🟢 Baixa exposição", "Situação controlada", "Manter monitoramento"],
-      ["31–55", "🟡 Exposição moderada", "Riscos relevantes", "Revisar aprovações"],
-      ["56–75", "🟠 Alta exposição", "Exposição significativa", "Priorizar mitigação"],
-      ["76–100", "🔴 Exposição crítica", "Alto risco de não conformidade", "Ação imediata"],
+      ["0-30", "[BAIXA]", "Situação controlada", "Manter monitoramento"],
+      ["31-55", "[MODERADA]", "Riscos relevantes", "Revisar aprovações"],
+      ["56-75", "[ALTA]", "Exposição significativa", "Priorizar mitigação"],
+      ["76-100", "[CRÍTICA]", "Alto risco de não conformidade", "Ação imediata"],
     ],
     styles: { fontSize: 8 },
     headStyles: { fillColor: [100, 100, 100] },


### PR DESCRIPTION
## Sintoma UAT 2026-04-21

P.O. exportou PDF do card Exposição ao Risco e viu caracteres corrompidos:

```
Nível              : Ø=ßà Alta exposição    ← deveria: [ALTA]
Meta               : "d 30 pontos           ← deveria: ate 30 pontos
Exposição atual    : 66 / 100 pontos  !"    ← deveria: 66 / 100 pontos (reduzir)
Tabela de faixas   : Ø=ßâ, Ø=ßá, Ø=ßà, Ø=Ý4 ← deveria: [BAIXA], [MODERADA], [ALTA], [CRÍTICA]
```

## Root cause

jsPDF com fonte Helvetica (default) usa **WinAnsi (Windows-1252)** encoding. Caracteres UTF-8 multi-byte fora dessa tabela viram lixo byte-a-byte:

| Caractere | Código | Problema |
|---|---|---|
| 🟢🟡🟠🔴 | U+1F7E2 etc | Emoji 4-byte UTF-8 → colide byte-a-byte |
| ↓ | U+2193 | Seta fora de Windows-1252 |
| ≤ | U+2264 | "≤" fora de Windows-1252 |

## Fix

Substituições **apenas no PDF** (UI/web mantém emojis):

| Antes | Depois |
|---|---|
| `🟠 Alta exposição` | `[ALTA]` |
| `↓` | `(reduzir)` |
| `≤ 30 pontos` | `ate 30 pontos` |

**Acentos latinos preservados** (á, é, ç, ã, õ) — estão em Windows-1252.

## Prevenção de regressão

Banner no topo do arquivo documenta a restrição permanentemente:

```
⚠️ CODIFICAÇÃO: jsPDF Helvetica só suporta WinAnsi.
NÃO USAR em PDF: emojis · ≤ ≥ · ↑ ↓ → ← · ≈ ≠ ± · ★ ● ■
Usar: "<=", "(reduzir)", "[ALTA]", etc.
```

## Arquivos

- `client/src/lib/generateDiagnosticoPDF.ts` — 23 insertions / 7 deletions

## Test plan

- [x] `pnpm check` zero erros
- [ ] UAT: exportar PDF novamente → texto legível
- [ ] UAT: acentos latinos permanecem intactos

🤖 Generated with [Claude Code](https://claude.com/claude-code)