### PR TITLE
fix(briefing): sanitizer anti-alucinação de NCM/NBS — Closes #808

### DIFF
--- a/server/lib/briefing-sanitizer.test.ts
+++ b/server/lib/briefing-sanitizer.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { sanitizeBriefingMarkdown } from "./briefing-sanitizer";
+
+describe("briefing-sanitizer", () => {
+  const originalFlag = process.env.BRIEFING_SANITIZER_ENABLED;
+
+  beforeEach(() => {
+    delete process.env.BRIEFING_SANITIZER_ENABLED;
+  });
+
+  afterEach(() => {
+    if (originalFlag === undefined) delete process.env.BRIEFING_SANITIZER_ENABLED;
+    else process.env.BRIEFING_SANITIZER_ENABLED = originalFlag;
+  });
+
+  describe("cenário real do incidente UAT 2026-04-21", () => {
+    it("bloqueia NCMs citados quando usuário não cadastrou nenhum", () => {
+      const markdown =
+        "Enquadramento em alíquota zero para arroz (NCM 1006), feijão (NCM 0713), açúcar (NCM 1701) e óleo (NCM 1507).";
+      const result = sanitizeBriefingMarkdown(markdown, { ncms: [] });
+
+      expect(result.sanitized).toContain("NCM 1006 (sugerido pela lei");
+      expect(result.sanitized).toContain("NCM 0713 (sugerido pela lei");
+      expect(result.sanitized).toContain("NCM 1701 (sugerido pela lei");
+      expect(result.sanitized).toContain("NCM 1507 (sugerido pela lei");
+      expect(result.blockedCodes).toHaveLength(4);
+      expect(result.enabled).toBe(true);
+    });
+  });
+
+  describe("códigos autorizados (cadastrados em meta.ncms)", () => {
+    it("permite NCM cadastrado sem disclaimer", () => {
+      const markdown = "O produto da empresa é NCM 1006.";
+      const result = sanitizeBriefingMarkdown(markdown, { ncms: ["1006"] });
+
+      expect(result.sanitized).toBe(markdown);
+      expect(result.blockedCodes).toHaveLength(0);
+    });
+
+    it("normaliza NCM com ponto (1006.10) vs sem ponto (1006)", () => {
+      const markdown = "Produto NCM 1006.10 da cesta básica.";
+      const result = sanitizeBriefingMarkdown(markdown, { ncms: ["1006"] });
+
+      expect(result.sanitized).toBe(markdown);
+      expect(result.blockedCodes).toHaveLength(0);
+    });
+
+    it("caso misto — 1006 autorizado mas 0713 não", () => {
+      const markdown = "Arroz NCM 1006 e feijão NCM 0713 são cesta básica.";
+      const result = sanitizeBriefingMarkdown(markdown, { ncms: ["1006"] });
+
+      expect(result.sanitized).toContain("NCM 1006 e");
+      expect(result.sanitized).not.toContain("NCM 1006 (sugerido");
+      expect(result.sanitized).toContain("NCM 0713 (sugerido pela lei");
+      expect(result.blockedCodes).toHaveLength(1);
+      expect(result.blockedCodes[0].code).toBe("0713");
+    });
+  });
+
+  describe("repetições do mesmo código", () => {
+    it("disclaimer completo só na primeira ocorrência", () => {
+      const markdown = "NCM 1006 aparece. De novo NCM 1006. E mais NCM 1006.";
+      const result = sanitizeBriefingMarkdown(markdown, { ncms: [] });
+
+      const fullCount = (result.sanitized.match(/sugerido pela lei/g) ?? []).length;
+      const shortCount = (result.sanitized.match(/\(sugerido\)/g) ?? []).length;
+
+      expect(fullCount).toBe(1);
+      expect(shortCount).toBe(2);
+      expect(result.blockedCodes).toHaveLength(1);
+      expect(result.blockedCodes[0].occurrences).toBe(3);
+    });
+  });
+
+  describe("NBS (serviços)", () => {
+    it("bloqueia NBS não cadastrado", () => {
+      const markdown = "O serviço NBS 10250 requer atenção.";
+      const result = sanitizeBriefingMarkdown(markdown, { nbs: [] });
+
+      expect(result.sanitized).toContain("NBS 10250 (sugerido");
+      expect(result.blockedCodes).toHaveLength(1);
+      expect(result.blockedCodes[0].type).toBe("nbs");
+    });
+
+    it("permite NBS cadastrado", () => {
+      const markdown = "Serviço NBS 10250.";
+      const result = sanitizeBriefingMarkdown(markdown, { nbs: ["10250"] });
+
+      expect(result.sanitized).toBe(markdown);
+      expect(result.blockedCodes).toHaveLength(0);
+    });
+  });
+
+  describe("feature flag", () => {
+    it("BRIEFING_SANITIZER_ENABLED=false → no-op", () => {
+      process.env.BRIEFING_SANITIZER_ENABLED = "false";
+      const markdown = "NCM 9999 inventado.";
+      const result = sanitizeBriefingMarkdown(markdown, { ncms: [] });
+
+      expect(result.sanitized).toBe(markdown);
+      expect(result.enabled).toBe(false);
+      expect(result.blockedCodes).toHaveLength(0);
+    });
+
+    it("default (sem env var) → sanitizer ativo", () => {
+      const markdown = "NCM 9999 inventado.";
+      const result = sanitizeBriefingMarkdown(markdown, { ncms: [] });
+
+      expect(result.enabled).toBe(true);
+      expect(result.sanitized).not.toBe(markdown);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("markdown sem NCM/NBS → sem mudanças", () => {
+      const markdown = "Texto normal sem códigos fiscais.";
+      const result = sanitizeBriefingMarkdown(markdown, {});
+
+      expect(result.sanitized).toBe(markdown);
+      expect(result.blockedCodes).toHaveLength(0);
+    });
+
+    it("meta undefined → comporta como vazio", () => {
+      const markdown = "NCM 1006 citado.";
+      const result = sanitizeBriefingMarkdown(markdown, {});
+
+      expect(result.blockedCodes).toHaveLength(1);
+    });
+
+    it("caixa variada (ncm, Ncm, NCM) → todos capturados", () => {
+      const markdown = "ncm 1006, Ncm 0713, NCM 1701.";
+      const result = sanitizeBriefingMarkdown(markdown, { ncms: [] });
+
+      expect(result.blockedCodes).toHaveLength(3);
+    });
+
+    it("é determinístico — mesma entrada → mesma saída", () => {
+      const markdown = "NCM 1006, NCM 0713, NCM 1701.";
+      const a = sanitizeBriefingMarkdown(markdown, { ncms: ["1006"] });
+      const b = sanitizeBriefingMarkdown(markdown, { ncms: ["1006"] });
+      expect(a.sanitized).toBe(b.sanitized);
+      expect(a.blockedCodes).toEqual(b.blockedCodes);
+    });
+  });
+});

--- a/server/lib/briefing-sanitizer.ts
+++ b/server/lib/briefing-sanitizer.ts
@@ -1,0 +1,127 @@
+/**
+ * briefing-sanitizer.ts — issue #808
+ *
+ * Bloqueia alucinação de NCM/NBS pelo LLM no briefing.
+ *
+ * Contexto:
+ *   O prompt de generateBriefing cita lista autoritativa de NCMs da cesta básica
+ *   (Art. 9 LC 214/2025). O LLM, ao ver "arroz" na descrição, associa NCM 1006
+ *   aos PRODUTOS DA EMPRESA — mas o usuário pode não ter cadastrado esse NCM.
+ *   Citar código específico sem confirmação é alucinação + risco tributário.
+ *
+ * Abordagem:
+ *   1. Varrer o markdown com regex NCM \d{4} / NBS \d{3,}
+ *   2. Se o código está em meta.ncms/meta.nbs (confirmado pelo usuário) → OK
+ *   3. Se não está → envolver em disclaimer "(sugerido pela lei — confirmar
+ *      classificação fiscal)" na primeira ocorrência. Subsequentes ficam com
+ *      marcador curto "(sugerido)".
+ *   4. Retornar lista de códigos bloqueados para audit_log.
+ *
+ * Feature flag:
+ *   BRIEFING_SANITIZER_ENABLED=false → no-op (rollback instantâneo).
+ *
+ * Determinístico. Mesmo input → mesmo output.
+ */
+
+export interface SanitizerMeta {
+  ncms?: string[];
+  nbs?: string[];
+}
+
+export interface BlockedCode {
+  type: "ncm" | "nbs";
+  code: string;
+  occurrences: number;
+}
+
+export interface SanitizeResult {
+  sanitized: string;
+  blockedCodes: BlockedCode[];
+  enabled: boolean;
+}
+
+const NCM_REGEX = /\bNCM\s*(\d{4}(?:\.\d{2,4})?)/gi;
+const NBS_REGEX = /\bNBS\s*(\d{3,8}(?:\.\d{2,4})?)/gi;
+
+const DISCLAIMER_FULL_NCM = "(sugerido pela lei — confirmar classificação fiscal do produto específico com contador)";
+const DISCLAIMER_SHORT_NCM = "(sugerido)";
+const DISCLAIMER_FULL_NBS = "(sugerido — confirmar classificação do serviço específico)";
+const DISCLAIMER_SHORT_NBS = "(sugerido)";
+
+function isEnabled(): boolean {
+  return (process.env.BRIEFING_SANITIZER_ENABLED ?? "true").toLowerCase() !== "false";
+}
+
+/**
+ * Normaliza NCM para 4 dígitos (sem ponto).
+ * "1006.10" → "1006" · "1006" → "1006" · "01006" → "0100"
+ */
+function normalizeNcm(code: string): string {
+  return code.replace(/\D/g, "").slice(0, 4);
+}
+
+/**
+ * Normaliza NBS removendo apenas pontos.
+ */
+function normalizeNbs(code: string): string {
+  return code.replace(/\D/g, "");
+}
+
+/**
+ * Sanitiza o markdown do briefing contra alucinações de NCM/NBS.
+ */
+export function sanitizeBriefingMarkdown(
+  markdown: string,
+  meta: SanitizerMeta
+): SanitizeResult {
+  if (!isEnabled()) {
+    return { sanitized: markdown, blockedCodes: [], enabled: false };
+  }
+
+  const allowedNcms = new Set((meta.ncms ?? []).map(normalizeNcm).filter(Boolean));
+  const allowedNbs = new Set((meta.nbs ?? []).map(normalizeNbs).filter(Boolean));
+
+  const blocked = new Map<string, BlockedCode>();
+  const seenNcm = new Set<string>();
+  const seenNbs = new Set<string>();
+
+  let sanitized = markdown.replace(NCM_REGEX, (match, rawCode: string) => {
+    const normalized = normalizeNcm(rawCode);
+    if (!normalized || allowedNcms.has(normalized)) return match;
+
+    const key = `ncm:${normalized}`;
+    const prev = blocked.get(key);
+    blocked.set(key, {
+      type: "ncm",
+      code: normalized,
+      occurrences: (prev?.occurrences ?? 0) + 1,
+    });
+
+    const disclaimer = seenNcm.has(normalized) ? DISCLAIMER_SHORT_NCM : DISCLAIMER_FULL_NCM;
+    seenNcm.add(normalized);
+    return `${match} ${disclaimer}`;
+  });
+
+  sanitized = sanitized.replace(NBS_REGEX, (match, rawCode: string) => {
+    const normalized = normalizeNbs(rawCode);
+    if (!normalized || allowedNbs.has(normalized)) return match;
+
+    const key = `nbs:${normalized}`;
+    const prev = blocked.get(key);
+    blocked.set(key, {
+      type: "nbs",
+      code: normalized,
+      occurrences: (prev?.occurrences ?? 0) + 1,
+    });
+
+    const disclaimer = seenNbs.has(normalized) ? DISCLAIMER_SHORT_NBS : DISCLAIMER_FULL_NBS;
+    seenNbs.add(normalized);
+    return `${match} ${disclaimer}`;
+  });
+
+  return {
+    sanitized,
+    blockedCodes: Array.from(blocked.values()),
+    enabled: true,
+  };
+}

--- a/server/routers-fluxo-v3.ts
+++ b/server/routers-fluxo-v3.ts
@@ -1273,6 +1273,15 @@ Quando qualquer um dos sinais abaixo aparecer no perfil, FATOS ADICIONAIS, CORRE
 
 IMPORTANTE: Essas regras operam EM ADIÇÃO ao regulatoryContext. Se o RAG já trouxe o artigo, aprofunde com o texto. Se não trouxe, cite o artigo com a descrição curta acima e sinalize na limitação que a análise deve ser validada por advogado tributarista. NUNCA invente texto de artigo que não esteja no regulatoryContext — apenas cite o número e a regra curta.
 
+REGRA ANTI-ALUCINAÇÃO — NCM/NBS DE PRODUTOS (issue #808, fix UAT 2026-04-21):
+- NUNCA atribua NCM específico (ex: "arroz NCM 1006") a um produto DA EMPRESA se esse código não estiver cadastrado em "PRINCIPAIS PRODUTOS" do perfil corporativo.
+- A lista de NCMs citada nas regras acima (cesta básica, Imposto Seletivo) é REFERÊNCIA REGULATÓRIA (a LC cita esses códigos), NÃO confirmação de que a empresa comercializa exatamente esses NCMs.
+- Quando a descrição mencionar "arroz" mas o NCM 1006 NÃO estiver nos produtos cadastrados:
+  - ERRADO: "arroz (NCM 1006) tem alíquota zero"
+  - CERTO: "o arroz comercializado pela empresa PODE se enquadrar em alíquota zero se classificado no NCM 1006 da cesta básica — validar classificação fiscal com contador"
+- Quando o usuário NÃO cadastrou nenhum NCM (lista vazia): use linguagem genérica ("produtos alimentícios", "itens da cesta básica") SEM citar códigos específicos como se fossem da empresa.
+- Um sanitizer pós-LLM adiciona disclaimer automático em códigos não cadastrados, mas sua responsabilidade é gerar texto correto desde o início.
+
 ${regulatoryContext}
 
 ${OUTPUT_CONTRACT}`,
@@ -1408,7 +1417,15 @@ Gere o Briefing estruturado em JSON:
         ncms: (opProfile.principaisProdutos ?? []).map((p) => p?.ncm_code).filter((c): c is string => !!c),
         nbs: (opProfile.principaisServicos ?? []).map((s) => s?.nbs_code).filter((c): c is string => !!c),
       };
-      const briefingMarkdown = buildBriefingMarkdown(structured, briefingMeta);
+      // fix #808: sanitiza markdown contra alucinação de NCM/NBS (códigos citados que
+      // não estão em principaisProdutos/principaisServicos recebem disclaimer "(sugerido)").
+      const rawMarkdown = buildBriefingMarkdown(structured, briefingMeta);
+      const { sanitizeBriefingMarkdown } = await import("./lib/briefing-sanitizer");
+      const sanitizeResult = sanitizeBriefingMarkdown(rawMarkdown, {
+        ncms: briefingMeta.ncms,
+        nbs: briefingMeta.nbs,
+      });
+      const briefingMarkdown = sanitizeResult.sanitized;
 
       // Salvar briefing no banco (markdown + estruturado)
       const database = await db.getDb();
@@ -1459,6 +1476,13 @@ Gere o Briefing estruturado em JSON:
               gaps_count: Array.isArray(structured.principais_gaps) ? structured.principais_gaps.length : 0,
               confidence: structured.confidence_score?.nivel_confianca ?? null,
               llm_retries: llmRetries,
+            },
+            // fix #808: registra NCMs/NBS que o LLM citou sem estarem cadastrados
+            // (alucinação) — sanitizer adicionou disclaimer mas a tentativa é auditada.
+            sanitizer: {
+              enabled: sanitizeResult.enabled,
+              blocked_codes: sanitizeResult.blockedCodes,
+              blocked_total: sanitizeResult.blockedCodes.reduce((sum, b) => sum + b.occurrences, 0),
             },
           },
         });
@@ -3010,6 +3034,12 @@ Quando qualquer um dos sinais abaixo aparecer no perfil, FATOS ADICIONAIS, CORRE
 
 IMPORTANTE: Essas regras operam EM ADIÇÃO ao regulatoryContext. Se RAG trouxe o artigo, aprofunde com o texto. Se não, cite número e regra curta e sinalize em limitações que validação por advogado é recomendada. NUNCA invente texto de artigo que não esteja no regulatoryContext.
 
+REGRA ANTI-ALUCINAÇÃO — NCM/NBS DE PRODUTOS (issue #808, fix UAT 2026-04-21):
+- NUNCA atribua NCM específico (ex: "arroz NCM 1006") a um produto DA EMPRESA se esse código não estiver cadastrado em "PRINCIPAIS PRODUTOS" do perfil.
+- A lista de NCMs citada nas regras acima (cesta básica, IS) é REFERÊNCIA REGULATÓRIA (a LC cita esses códigos), NÃO confirmação de que a empresa comercializa exatamente esses NCMs.
+- ERRADO: "arroz (NCM 1006) tem alíquota zero" — CERTO: "o arroz comercializado pela empresa PODE se enquadrar em alíquota zero se classificado no NCM 1006 da cesta básica — validar classificação com contador".
+- Quando nenhum NCM foi cadastrado: use linguagem genérica sem códigos específicos como se fossem da empresa. Um sanitizer pós-LLM adiciona disclaimer em códigos não cadastrados — gere texto correto desde o início.
+
 ${regulatoryContext}
 
 ${OC}`,
@@ -3131,6 +3161,14 @@ Gere o Briefing estruturado em JSON:
         briefingMarkdown = `# Briefing de Compliance\n\n**Nível de Risco:** ${structured.nivel_risco_geral}\n\n## Resumo Executivo\n${structured.resumo_executivo}`;
       }
 
+      // fix #808: sanitiza alucinação de NCM/NBS antes de persistir.
+      const { sanitizeBriefingMarkdown: sanitizeFD } = await import("./lib/briefing-sanitizer");
+      const sanitizeResultFD = sanitizeFD(briefingMarkdown, {
+        ncms: briefingMetaFD.ncms,
+        nbs: briefingMetaFD.nbs,
+      });
+      briefingMarkdown = sanitizeResultFD.sanitized;
+
       if (!database) throw new TRPCError({ code: "INTERNAL_SERVER_ERROR", message: "Database not available" });
       await database
         .update(projects)
@@ -3173,6 +3211,11 @@ Gere o Briefing estruturado em JSON:
               nivel_risco: structured.nivel_risco_geral,
               gaps_count: Array.isArray(structured.principais_gaps) ? structured.principais_gaps.length : 0,
               confidence: structured.confidence_score?.nivel_confianca ?? null,
+            },
+            sanitizer: {
+              enabled: sanitizeResultFD.enabled,
+              blocked_codes: sanitizeResultFD.blockedCodes,
+              blocked_total: sanitizeResultFD.blockedCodes.reduce((sum, b) => sum + b.occurrences, 0),
             },
           },
         });


### PR DESCRIPTION
## Summary

Implementa [Issue #808](https://github.com/Solaris-Empresa/compliance-tributaria-v2/issues/808) — primeira das 4 issues do bundle (D, A, B, C). **Draft** até UAT das 4 passar.

Closes #808

## Root cause

Projeto "Distribuidora Alimentos Teste" (UAT 2026-04-21) com descrição contendo "arroz, feijão, açúcar, óleo" e **zero NCMs cadastrados** gerou briefing afirmando:

> *"arroz (NCM 1006), feijão (NCM 0713), açúcar (NCM 1701), óleo (NCM 1507)"*

Códigos inferidos pelo LLM, **não vieram do input estruturado**. Viola Regra #4 do Content Engine (Anti-hallucination).

## Solução em 2 camadas (defense in depth)

### Layer 1 — Prompt (ambos generateBriefing e generateBriefingFromDiagnostic)

Nova `REGRA ANTI-ALUCINAÇÃO` instruindo o LLM a:
- NUNCA atribuir NCM específico a produto da empresa sem cadastro
- Frasear citações da cesta básica como referência regulatória genérica
- Usar linguagem condicional ("pode se enquadrar... se classificado em...")

### Layer 2 — Sanitizer pós-LLM (`server/lib/briefing-sanitizer.ts`)

- Regex scan `NCM \d{4}` / `NBS \d{3,}`
- Códigos fora de `meta.ncms`/`meta.nbs` → disclaimer automático
- Primeira ocorrência: *"NCM 1006 (sugerido pela lei — confirmar classificação fiscal do produto específico com contador)"*
- Subsequentes: *"NCM 1006 (sugerido)"*
- Feature flag `BRIEFING_SANITIZER_ENABLED=false` → rollback instantâneo
- **Determinístico** — mesma entrada → mesma saída

## Observabilidade

`audit_log` grava por briefing:
```json
{
  "sanitizer": {
    "enabled": true,
    "blocked_codes": [{"type": "ncm", "code": "1006", "occurrences": 2}],
    "blocked_total": 5
  }
}
```

## Testes

- ✅ 13 unit tests em `briefing-sanitizer.test.ts` — PASS (cenário UAT real, códigos autorizados, mistos, repetições, NBS, feature flag, edge cases, determinismo)
- ✅ `pnpm check` zero errors

## Test plan (UAT — antes de sair do draft)

- [ ] Regenerar briefing do projeto "Distribuidora Alimentos Teste" → confirmar disclaimers nos NCMs
- [ ] Cadastrar NCM 1006 em principaisProdutos → regenerar → confirmar 1006 sem disclaimer, outros com
- [ ] Verificar audit_log na aba Histórico → entry `sanitizer` presente com `blocked_codes`
- [ ] Rollback drill: `BRIEFING_SANITIZER_ENABLED=false` → disclaimer desaparece

## Rollback

1. Feature flag: `BRIEFING_SANITIZER_ENABLED=false` no `.env`
2. Revert completo: `git revert bff380a`

## Evaluação de risco (ORQ-20)

- **Tier:** 2 (engine determinística adicionada)
- **Touches LLM:** sim (prompt + pós-processamento)
- **Risk level:** high (jurídico se falhar silently)
- **Abort criteria:** sanitizer substituir >30% dos NCMs em produção → investigar falso-positivo

## Evidence

```json
{
  "scope": "fix",
  "touches_db": false,
  "touches_llm": true,
  "touches_ui": false,
  "risk_level": "high",
  "e2e_included": false,
  "rollback_plan": "BRIEFING_SANITIZER_ENABLED=false OR git revert bff380a"
}
```

## Bundle sequência

| # | Issue | Status |
|---|---|---|
| 1 | [#808](https://github.com/Solaris-Empresa/compliance-tributaria-v2/issues/808) — anti-alucinação NCM | **este PR (draft)** |
| 2 | [#809](https://github.com/Solaris-Empresa/compliance-tributaria-v2/issues/809) — linguagem condicional + banner | próximo |
| 3 | [#810](https://github.com/Solaris-Empresa/compliance-tributaria-v2/issues/810) — Top 3 + Qualidade + Badge | após |
| 4 | [#811](https://github.com/Solaris-Empresa/compliance-tributaria-v2/issues/811) — source_type por gap | após |

Bundle merge após UAT passar nas 4 issues.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>