### PR TITLE
docs(rag): atualiza RAG Cockpit + MDs labels RAG para Sprint Z-22 UAT

### DIFF
--- a/client/src/pages/RagCockpit.tsx
+++ b/client/src/pages/RagCockpit.tsx
@@ -150,6 +150,15 @@ const SPRINTS = [
       "CORPUS-BASELINE.md v5.0 · 2.515 chunks · 13 leis · 100% anchor_id",
       "ESTADO-ATUAL.md v5.6 · Gate 7 PASS",
     ], status: "done" },
+  { id: "Sprint Z-22 — UAT ENCERRADA", date: "2026-04-21", pr: "#755–#806", commit: "839e860",
+    changes: [
+      "Auditoria 🟢 APROVADA (2026-04-20) · docs/governance/audits/v7.42-2026-04-20.md",
+      "REGRA-ORQ-19 (auditoria fim de sessão) + REGRA-ORQ-20 (risk assessment estrutural)",
+      "Hotfix P0 #792: useMemo BriefingV3 — crash /briefing-v3 corrigido",
+      "Bundle briefing feat/811 (#808–#811): source_type por gap + Top 3 Ações + sanitizer NCM/NBS",
+      "Corpus estável: 2.515 chunks · 13 leis · 100% anchor_id (sem alterações desde Z-13)",
+      "Compliance score: 66% (confidence=0.97 — issue #796 aguarda decisão P.O.)",
+    ], status: "done" },
 ];
 
 const SOURCE_FILES = [
@@ -868,8 +877,8 @@ export default function RAGCockpit() {
             background: "#1a2744", border: "1px solid #3b82f6",
             borderRadius: 8, padding: "6px 14px", textAlign: "center"
           }}>
-            <div style={{ color: "#22c55e", fontWeight: 700, fontSize: 12, letterSpacing: "0.05em" }}>✅ SPRINT Z-13 — Gate 7 PASS · 2.515 chunks · 13 leis</div>
-            <div style={{ color: "#334155", fontSize: 10, marginTop: 2 }}>Decision Kernel · 37 casos NCM/NBS + 1 pending · 48 testes · 2d53596</div>
+            <div style={{ color: "#22c55e", fontWeight: 700, fontSize: 12, letterSpacing: "0.05em" }}>✅ SPRINT Z-22 — UAT ENCERRADA · 2.515 chunks · 13 leis</div>
+            <div style={{ color: "#334155", fontSize: 10, marginTop: 2 }}>Auditoria 🟢 APROVADA · PRs #755–#806 · HEAD 839e860 · 2026-04-21</div>
           </div>
           <div style={{ textAlign: "center" }}>
             <div style={{ color: corpusConfidence >= 98 ? "#22c55e" : "#f59e0b", fontFamily: "monospace", fontWeight: 700, fontSize: 20 }}>{corpusConfidence}%</div>

--- a/docs/painel-po/RASTREABILIDADE-RAG-PO.md
+++ b/docs/painel-po/RASTREABILIDADE-RAG-PO.md
@@ -251,7 +251,9 @@ Evento RAG (nova funcionalidade / alteração / RFC / incidente)
 | 2026-04-05 | Sprint V Lote 2 (PR #330): +8 casos NCM/NBS → 24 confirmados | NCM:12 · NBS:12 · Testes:34/34 · Correção S-07 (Arts.234-235) |
 | 2026-04-05 | Sprint V Lote 3 (PR #333): +13 casos + 1 pending → 37 confirmados | NCM:19 · NBS:19 · Testes:48/48 · Sprint V encerrada |
 | 2026-04-13 | Sprint Z-13 ENCERRADA · Gate 7 PASS (PRs #485–#497): fix B-Z13-004 risk_category_code, backfill project_gaps_v3, CGIBS +6 chunks | HEAD 1ea5c64 · 2.515 chunks · 13 leis · ESTADO-ATUAL v5.6 |
+| 2026-04-20 | Sprint Z-22 UAT Wave ENCERRADA (PRs #755–#797): auditoria 🟢 APROVADO · REGRA-ORQ-19 + REGRA-ORQ-20 | HEAD eee5462 · corpus estável · sem alterações de corpus |
+| 2026-04-21 | Bundle briefing feat/811 (#808–#811) + hotfix #792 (useMemo) + PRs #800–#806 | HEAD 839e860 · checkpoint v7.50 (2e9d1a3c) · corpus inalterado |
 
 ---
 
-*Documento gerado em 2026-03-30. Atualizado em 2026-04-13 (Sprint Z-13 ENCERRADA · Gate 7 PASS · HEAD 1ea5c64 · PRs #485–#497 · 2.515 chunks · 13 leis). Pelo implementador técnico Manus. Aprovado pelo P.O. Uires Tapajós. Fonte de verdade: [ESTADO-ATUAL.md](https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/docs/ESTADO-ATUAL.md) e [BASELINE-PRODUTO.md](https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/docs/BASELINE-PRODUTO.md).*
+*Documento gerado em 2026-03-30. Atualizado em 2026-04-21 (Sprint Z-22 UAT ENCERRADA · HEAD 839e860 · PRs #755–#806 · feat/811 em UAT · 2.515 chunks · 13 leis · corpus estável). Pelo implementador técnico Manus. Aprovado pelo P.O. Uires Tapajós. Fonte de verdade: [ESTADO-ATUAL.md](https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/docs/ESTADO-ATUAL.md) e [BASELINE-PRODUTO.md](https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/docs/BASELINE-PRODUTO.md).*

--- a/docs/painel-po/index.html
+++ b/docs/painel-po/index.html
@@ -489,7 +489,7 @@ mark.search-hl{
 <body>
 <header>
   <div><h1>&#127963; Cockpit P.O. &mdash; Compliance Tributaria v2.0</h1></div>
-  <div class="meta">Uires Tapajos &middot; P.O. &middot; <span id="headerDate">2026-04-13</span></div>
+  <div class="meta">Uires Tapajos &middot; P.O. &middot; <span id="headerDate">2026-04-21</span></div>
   <div class="search-wrap">
     <div class="search-input-wrap">
       <span class="search-icon">&#128269;</span>
@@ -585,7 +585,7 @@ mark.search-hl{
         <li><a href="https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/docs/governance/ESTADO-ATUAL.md" target="_blank">ESTADO-ATUAL.md</a><span class="doc-desc">Leia primeiro &mdash; estado real do repositorio</span></li>
         <li><a href="https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/docs/governance/CONTEXTO-ORQUESTRADOR.md" target="_blank">CONTEXTO-ORQUESTRADOR.md</a><span class="doc-desc">ADRs, backlog, invariants, template de prompt</span></li>
         <li><a href="https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/docs/governance/RASTREABILIDADE-COMPLETA.md" target="_blank">RASTREABILIDADE-COMPLETA.md</a><span class="doc-desc">PR x Sprint x RF x arquivo x status</span></li>
-        <li><a href="https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/docs/BASELINE-PRODUTO.md" target="_blank">BASELINE-PRODUTO.md v5.6</a><span class="doc-desc">Baseline oficial — Sprint Z-13 Gate 7 PASS ✅</span></li>
+        <li><a href="https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/docs/BASELINE-PRODUTO.md" target="_blank">BASELINE-PRODUTO.md v5.6</a><span class="doc-desc">Baseline oficial — Sprint Z-22 UAT ENCERRADA ✅ (PRs #755–#806)</span></li>
       </ul>
     </div>
     <div class="agent-card chatgpt">
@@ -627,7 +627,7 @@ mark.search-hl{
     </div>
     <div class="status-card green">
       <div class="label">Estado do produto</div>
-      <div class="value">v5.6 &mdash; Sprint Z-13 Gate 7 PASS ✅ (FIX_01+FIX_02+FIX_03 mergeados)</div>
+      <div class="value">v5.6 &mdash; Sprint Z-22 UAT ENCERRADA ✅ (PRs #755–#806 · Auditoria 🟢 APROVADA)</div>
       <div class="sub" id="statusTestes">Carregando dados do GitHub...</div>
       <a class="link" href="https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/docs/BASELINE-PRODUTO.md" target="_blank">&#8594; BASELINE-PRODUTO.md</a>
     </div>
@@ -709,7 +709,7 @@ mark.search-hl{
 
 <!-- SECAO 4 - RELATORIO DE DOCUMENTACAO -->
 <div class="section">
-  <div class="section-title">Seção 4 &mdash; Relatório de Documentação <span style="font-weight:400;font-size:11px;text-transform:none;letter-spaci<span id="docReportDate">(gerado em 2026-04-13)</span></div>
+  <div class="section-title">Seção 4 &mdash; Relatório de Documentação <span style="font-weight:400;font-size:11px;text-transform:none;letter-spaci<span id="docReportDate">(gerado em 2026-04-21)</span></div>
 
   <!-- Resumo executivo -->
   <div class="doc-report-summary">
@@ -735,21 +735,21 @@ mark.search-hl{
       <tbody>
         <tr>
           <td><a class="doc-link" href="https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/docs/BASELINE-PRODUTO.md" target="_blank">BASELINE-PRODUTO.md</a></td>
-          <td><span id="doc-date-baseline">2026-04-13</span></td>
+          <td><span id="doc-date-baseline">2026-04-21</span></td>
           <td><span class="doc-commit" id="doc-sha-baseline">47b2d5a</span></td>
           <td>393</td>
           <td><span class="doc-status-ok">&#10003; Atualizado</span><div class="doc-comment">v5.6 — Sprint Z-13 Gate 7 PASS ✅</div></td>
         </tr>
         <tr>
           <td><a class="doc-link" href="https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/docs/governance/ESTADO-ATUAL.md" target="_blank">ESTADO-ATUAL.md</a></td>
-          <td><span id="doc-date-estado-atual-4a">2026-04-13</span></td>
+          <td><span id="doc-date-estado-atual-4a">2026-04-21</span></td>
           <td><span class="doc-commit" id="doc-sha-estado-atual-4a">0b5f266</span></td>
           <td>146</td>
           <td><span class="doc-status-ok">&#10003; Atualizado</span><div class="doc-comment"><strong>P0</strong> &mdash; porta de entrada obrigatória para todos os agentes</div></td>
         </tr>
         <tr>
           <td><a class="doc-link" href="https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/docs/HANDOFF-MANUS.md" target="_blank">HANDOFF-MANUS.md</a></td>
-          <td><span id="doc-date-handoff-manus-4a">2026-04-13</span></td>
+          <td><span id="doc-date-handoff-manus-4a">2026-04-21</span></td>
           <td><span class="doc-commit" id="doc-sha-handoff-manus-4a">0b5f266</span></td>
           <td>197</td>
           <td><span class="doc-status-ok">&#10003; Atualizado</span><div class="doc-comment"><strong>P1</strong> &mdash; regras operacionais e estado atual para o Manus</div></td>
@@ -874,7 +874,7 @@ mark.search-hl{
       <tbody>
         <tr>
           <td><a class="doc-link" href="https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/docs/HANDOFF-MANUS.md" target="_blank">HANDOFF-MANUS.md</a></td>
-          <td><span id="doc-date-handoff-manus">2026-04-13</span></td>
+          <td><span id="doc-date-handoff-manus">2026-04-21</span></td>
           <td><span class="doc-commit" id="doc-sha-handoff-manus">47b2d5a</span></td>
           <td>171</td>
           <td><span class="doc-status-ok">&#10003; Atualizado</span><div class="doc-comment">v5.6 — Sprint Z-13 Gate 7 PASS ✅</div></td>
@@ -912,14 +912,14 @@ mark.search-hl{
           <td><span id="doc-date-skill-orquestracao">2026-03-29 18:42</span></td>
           <td><span class="doc-commit" id="doc-sha-skill-orquestracao">16f7ca2</span></td>
           <td>115</td>
-          <td><span class="doc-status-ok">&#10003; Atualizado</span><div class="doc-comment">Skill operacional do Manus — v5.6 + Gate 7</div></td>
+          <td><span class="doc-status-ok">&#10003; Atualizado</span><div class="doc-comment">Skill operacional do Manus — v5.6 + Z-22 UAT</div></td>
         </tr>
         <tr>
           <td><a class="doc-link" href="https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/skills/solaris-contexto/SKILL.md" target="_blank">SKILL — solaris-contexto (Claude)</a></td>
           <td><span id="doc-date-skill-contexto">2026-03-29 18:42</span></td>
           <td><span class="doc-commit" id="doc-sha-skill-contexto">16f7ca2</span></td>
           <td>148</td>
-          <td><span class="doc-status-ok">&#10003; Atualizado</span><div class="doc-comment">Skill de contexto do Claude — v5.6 + Gate 7</div></td>
+          <td><span class="doc-status-ok">&#10003; Atualizado</span><div class="doc-comment">Skill de contexto do Claude — v5.6 + Z-22 UAT (2.515 chunks)</div></td>
         </tr>
       </tbody>
     </table>
@@ -932,7 +932,7 @@ mark.search-hl{
       <tbody>
         <tr>
           <td><a class="doc-link" href="https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/docs/governance/ESTADO-ATUAL.md" target="_blank">ESTADO-ATUAL.md</a></td>
-          <td><span id="doc-date-estado-atual">2026-04-13</span></td>
+          <td><span id="doc-date-estado-atual">2026-04-21</span></td>
           <td><span class="doc-commit" id="doc-sha-estado-atual">90fe7b3</span></td>
           <td>131</td>
           <td><span class="doc-status-ok">&#10003; Porta de entrada</span><div class="doc-comment">Criado hoje (DEC-007) — leia antes de qualquer sessão</div></td>
@@ -946,21 +946,21 @@ mark.search-hl{
         </tr>
         <tr>
           <td><a class="doc-link" href="https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/docs/governance/HANDOFF-IMPLEMENTADOR.md" target="_blank">HANDOFF-IMPLEMENTADOR.md</a></td>
-          <td><span id="doc-date-handoff-impl">2026-04-13</span></td>
+          <td><span id="doc-date-handoff-impl">2026-04-21</span></td>
           <td><span class="doc-commit" id="doc-sha-handoff-impl">47b2d5a</span></td>
           <td>203</td>
           <td><span class="doc-status-ok">&#10003; Atualizado</span><div class="doc-comment">Guia operacional completo para o Manus</div></td>
         </tr>
         <tr>
           <td><a class="doc-link" href="https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/docs/governance/CONTEXTO-ORQUESTRADOR.md" target="_blank">CONTEXTO-ORQUESTRADOR.md</a></td>
-          <td><span id="doc-date-ctx-orch">2026-04-13</span></td>
+          <td><span id="doc-date-ctx-orch">2026-04-21</span></td>
           <td><span class="doc-commit" id="doc-sha-ctx-orch">47b2d5a</span></td>
           <td>195</td>
           <td><span class="doc-status-ok">&#10003; Atualizado</span><div class="doc-comment">Estado do produto e governança para o Claude</div></td>
         </tr>
         <tr>
           <td><a class="doc-link" href="https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/docs/governance/RASTREABILIDADE-COMPLETA.md" target="_blank">RASTREABILIDADE-COMPLETA.md</a></td>
-          <td><span id="doc-date-rastr-comp">2026-04-13</span></td>
+          <td><span id="doc-date-rastr-comp">2026-04-21</span></td>
           <td><span class="doc-commit" id="doc-sha-rastr-comp">47b2d5a</span></td>
           <td>183</td>
           <td><span class="doc-status-ok">&#10003; Atualizado</span><div class="doc-comment">PR × Sprint × RF × arquivo × status</div></td>
@@ -1006,7 +1006,7 @@ mark.search-hl{
     </table>
   </div>
 
-  <div class="doc-report-refresh" id="docReportRefresh">Fonte: git log no repositório Solaris-Empresa/compliance-tributaria-v2 &middot; Gerado em 2026-04-13</div>
+  <div class="doc-report-refresh" id="docReportRefresh">Fonte: git log no repositório Solaris-Empresa/compliance-tributaria-v2 &middot; Gerado em 2026-04-21</div>
 </div>
 
 <!-- SECAO 5 - LOG DE DECISOES (C5: links decisao -> PR/Issue) -->
@@ -1042,7 +1042,7 @@ mark.search-hl{
       <a href="https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/docs/BASELINE-PRODUTO.md" target="_blank">BASELINE-PRODUTO.md</a>
     </div>
     <div class="gov-legend">
-      <span class="gov-badge static">⚙ estático</span> = baseline v5.0 (atualizado Sprint Z-13 Gate 7 2026-04-13)
+      <span class="gov-badge static">⚙ estático</span> = baseline v5.0 (corpus estável · Sprint Z-22 UAT · 2026-04-21)
       &nbsp;&middot;&nbsp;
       <span class="gov-badge live">⟳ vivo</span> = fetch API GitHub (cache 5 min)
     </div>
@@ -1080,13 +1080,13 @@ mark.search-hl{
       <div class="milestone-bar">
         <span class="milestone-bar-label">🟢 Sprint S &mdash; Encerrada ✅</span>
         <span class="milestone-bar-label">🟢 Sprint T / Milestone 1 &mdash; Encerrado ✅ (Decision Kernel)</span>
-        <span class="milestone-bar-label">🟢 Sprint Z-13 &mdash; Gate 7 PASS ✅</span>
-        <span class="milestone-bar-label">🟢 Sprint Z-13 &mdash; Gate 7 PASS ✅</span>
+        <span class="milestone-bar-label">🟢 Sprint Z-22 &mdash; UAT ENCERRADA ✅</span>
+        <span class="milestone-bar-label">🟢 Sprint Z-22 &mdash; UAT ENCERRADA ✅</span>
         <div class="milestone-bar-track"><div class="milestone-bar-fill" id="milestoneFillK" style="width:0%"></div></div>
         <span class="milestone-bar-pct" id="milestonePctK">⟳ buscando...</span>
       </div>
       <div class="milestone-bar">
-        <span class="milestone-bar-label">🟢 Sprint Z-13 &mdash; Gate 7 PASS ✅</span>
+        <span class="milestone-bar-label">🟢 Sprint Z-22 &mdash; UAT ENCERRADA ✅</span>
         <div class="milestone-bar-track"><div class="milestone-bar-fill" id="milestoneFillL" style="width:0%"></div></div>
         <span class="milestone-bar-pct" id="milestonePctL">⟳ buscando...</span>
       </div>
@@ -1094,7 +1094,7 @@ mark.search-hl{
     <div class="rastreabilidade-header">
       <div class="rastreabilidade-tabs">
         <button class="rastreabilidade-tab active" onclick="setRastrTab('sprint-k',this)">Sprint K &mdash; M2</button>
-        <button class="rastreabilidade-tab" onclick="setRastrTab('sprint-l',this)">Sprint Z-13 &mdash; Gate 7 PASS ✅</button>
+        <button class="rastreabilidade-tab" onclick="setRastrTab('sprint-l',this)">Sprint Z-22 &mdash; UAT ENCERRADA ✅</button>
         <button class="rastreabilidade-tab" onclick="setRastrTab('prs',this)">PRs Mergeados</button>
         <button class="rastreabilidade-tab" onclick="setRastrTab('issues',this)">Issues Abertas</button>
       </div>
@@ -1125,7 +1125,7 @@ mark.search-hl{
         </div>
         <div class="onda-sprints">
           <span class="onda-sprint done">Sprint K ✅</span>
-          <span class="onda-sprint done">Sprint Z-13 ✅ (Gate 7 PASS)</span>
+          <span class="onda-sprint done">Sprint Z-22 ✅ (UAT ENCERRADA · PRs #755–#806)</span>
         </div>
         <div class="onda-prs">
           <a href="https://github.com/Solaris-Empresa/compliance-tributaria-v2/pull/159" target="_blank">#159</a>
@@ -1222,7 +1222,7 @@ mark.search-hl{
       <a href="https://github.com/Solaris-Empresa/compliance-tributaria-v2/blob/main/docs/rag/RAG-PROCESSO.md" target="_blank">RAG-PROCESSO.md</a>
     </div>
     <div class="rag-gov-legend">
-      <span class="gov-badge static">&#9881; estático</span> = baseline v5.0 (atualizado Sprint Z-13 Gate 7 2026-04-13) &middot;
+      <span class="gov-badge static">&#9881; estático</span> = baseline v5.0 (corpus estável · Sprint Z-22 UAT · 2026-04-21) &middot;
       <span class="gov-badge live">&#8635; vivo</span> = fetch API GitHub (cache 5 min)
     </div>
   </div>
@@ -1348,7 +1348,7 @@ mark.search-hl{
           <span>&#10003; 2.515 chunks &middot; 13 leis &middot; 0 duplicatas críticas</span>
           <span id="rag7eTelemetriaStatus">&#9888; Telemetria de uso: aguardando primeiros logs...</span>
           <span>&#9888; Gold set: evidência manual (script pendente)</span>
-          <span style="font-size:9px;color:var(--text-muted);margin-top:2px">Baseline v5.0 &middot; 2026-04-13 &middot; L-RAG-01 implementado</span>
+          <span style="font-size:9px;color:var(--text-muted);margin-top:2px">Baseline v5.0 &middot; 2026-04-21 &middot; corpus estável · Z-22 UAT</span>
         </div>
       </div>
       <div class="rag7e-score-card">

--- a/docs/rag/HANDOFF-RAG.md
+++ b/docs/rag/HANDOFF-RAG.md
@@ -35,7 +35,7 @@ Regras invioláveis:
 
 | Indicador | Valor | Última atualização |
 |---|---|---|
-| Versão do baseline | **v5.0** | 2026-04-13 (Sprint Z-13 ENCERRADA · Gate 7 PASS · PRs #485–#497) |
+| Versão do baseline | **v5.0** | 2026-04-13 (Sprint Z-13 ENCERRADA · Gate 7 PASS · PRs #485–#497) — **sem alterações de corpus desde Z-13** |
 | Total de chunks | **2.515** | Sprint Z-12 Lote D (CGIBS +6 chunks) |
 | Leis ativas | **13** | lc214 · lc227 · lc224 · ec132 · lc123 · lc87 · lc116 · cg_ibs · rfb_cbs · conv_icms · resolucao_cgibs_1 · resolucao_cgibs_2 · resolucao_cgibs_3 |
 | Confiabilidade gold set | 100% (8/8) | Sprint G |

--- a/docs/skills/SKILL-CONTEXTO.md
+++ b/docs/skills/SKILL-CONTEXTO.md
@@ -25,13 +25,15 @@ Antes de qualquer trabalho, verificar via project_knowledge_search:
 
 ## Estado atual do produto
 
-- Baseline: v1.5 | Testes: 489 | Migrations: 56
-- Corpus RAG: 2.078 chunks — 100% anchor_id
+- Baseline: v5.6 | HEAD: 839e860 (PR #806) | Sprint Z-22 UAT ENCERRADA
+- Corpus RAG: **2.515 chunks · 13 leis · 100% anchor_id** (Sprint Z-13 ENCERRADA · Gate 7 PASS)
 - DIAGNOSTIC_READ_MODE: shadow (NUNCA alterar)
-- Sprint 98% Confidence: B0 ✅ B1 ✅ B2 em andamento (PR #113)
+- PRs mergeados: #755–#806 (52 PRs pós-Z-13) | feat/811 bundle em UAT
+- Checkpoint Manus: v7.50-bundle-briefing-uat-fix-bug1 (2e9d1a3c)
+- Auditoria Z-22: 🟢 APROVADO (2026-04-20 · docs/governance/audits/v7.42-2026-04-20.md)
 - Engines: server/routers/ (7 engines, 259/259 testes)
-- G10/G11 implementados em routers-fluxo-v3.ts
-- G12 (fonte_acao) implementado no PR #113
+- Compliance score: 66% (confidence=0.97 — issue #796 aguarda decisão P.O.)
+- BUG-3: badge inconsistências persiste após aprovação briefing (aberto)
 
 ## Gaps resolvidos
 


### PR DESCRIPTION
## Resumo

Atualiza todos os artefatos com labels RAG para refletir o estado real da Sprint Z-22 UAT ENCERRADA.

## Arquivos alterados

- `docs/skills/SKILL-CONTEXTO.md` — corpus 2.078→2.515 chunks, estado Z-22 UAT ENCERRADA
- `docs/rag/HANDOFF-RAG.md` — nota: sem alterações de corpus desde Z-13
- `docs/painel-po/RASTREABILIDADE-RAG-PO.md` — histórico Z-22 + bundle feat/811 + rodapé 2026-04-21
- `docs/painel-po/index.html` — datas 2026-04-13→2026-04-21, Sprint Z-13→Z-22, DEC-019
- `client/src/pages/RagCockpit.tsx` — banner Z-22 UAT ENCERRADA + Sprint Z-22 no histórico

## Labels RAG aplicadas
`rag:corpus` `rag:governanca`

## Evidência
```json
{"head": "839e860", "chunks": 2515, "leis": 13, "anchor_id": "100%", "corpus_status": "estavel", "sprint": "Z-22-UAT-ENCERRADA"}
```